### PR TITLE
chore: optimize webpack build to resolve bundlesize warnings and improve caching

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = {
   mode: 'production',
   entry: './src/main.jsx',
   output: {
-    filename: 'bundle.js',
+    filename: '[name].bundle.js',
     path: path.resolve(__dirname, 'dist'),
   },
   module: {
@@ -28,6 +28,11 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.jsx']
+  },
+  optimization: {
+    splitChunks: {
+      chunks: 'all',
+    },
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
## Description
This Pull Request optimizes the Webpack build configuration by enabling chunk splitting. 

Previously, `npm run build` was throwing `asset size limit` and `entrypoint size limit` warnings because the entire application (including heavy dependencies like `react`, `react-dom`, and `lucide-react`) was being bundled into a single, monolithic `bundle.js` file (~500+ KiB).

By cleanly separating third-party `node_modules` into their own chunk, we resolve these build warnings and significantly improve the application's performance and caching behavior for end users.

## Changes Made
* Added the `optimization.splitChunks` block to `webpack.config.js` to automatically split vendor data.
* Updated `output.filename` to dynamically handle `[name].bundle.js`, preventing the `Conflict: Multiple chunks emit assets to the same filename bundle.js` error.

## Validation
* Ran `npm run install` and `npm run build` locally.
* Verified that Webpack now outputs a smaller `main.bundle.js` along with separated vendor chunks.
* Confirmed that all bundle size and asset limit warnings have disappeared.
