### PR TITLE
Fix: Remove duplicate Zclsd extension and add data catalog validation

### DIFF
--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -82,6 +82,7 @@ function extractExtensionInstructions(jsxText) {
 
 function buildExtensionIndex(extensionsCatalog) {
   const index = new Map();
+  const duplicates = new Set();
 
   for (const [category, entries] of Object.entries(extensionsCatalog)) {
     if (!Array.isArray(entries)) continue;
@@ -92,7 +93,15 @@ function buildExtensionIndex(extensionsCatalog) {
       const list = index.get(id) ?? [];
       list.push({ category, entry });
       index.set(id, list);
+      
+      if (list.length > 1) {
+        duplicates.add(id);
+      }
     }
+  }
+
+  if (duplicates.size > 0) {
+    die(`ERROR: Duplicate extension IDs found across groups: ${Array.from(duplicates).join(', ')}`);
   }
 
   return index;

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -773,7 +773,7 @@ const RISCVExplorer = () => {
       { id: 'Zilsm*', name: 'Zilsm*', desc: 'Streaming Mem (pattern)', use: 'Wildcard for Zilsm<x>b family' },
       { id: 'Zilsm<x>b', name: 'Zilsm<x>b', desc: 'Streaming Mem (x-byte)', use: 'Line-size specific streaming ops' },
 
-      { id: 'Zclsd', name: 'Zclsd', desc: 'Compressed LS Pair', use: 'Compressed LS pairs (RV32)' },
+
 
       // PMA / cache-block / reservation set / misc
       { id: 'Za64rs', name: 'Za64rs', desc: '64B Reservation Set', use: 'Reservation set granularity (64-byte)' },


### PR DESCRIPTION

### Description
This PR resolves Issue #22 by removing the duplicate `Zclsd` extension from the application's catalog and adding validation to prevent similar issues from being introduced in the future.
Having duplicate IDs caused several problems:
1. React `key` warnings due to duplicate list items.
2. The `Zclsd` extension tile rendering twice in the UI.
3. Unpredictable first-match behavior when checking Profile/Volume memberships.
### Changes Made
- **Removed Duplicate Data**: Cleaned up `src/risc_v_visualizer.jsx` by removing the incorrect `Zclsd` entry from the `z_system` fallback data (its canonical location is `z_compress`). Verified that `src/riscv_extensions.json` is already correct.
- **Added Sync Validation**: Updated `scripts/sync_instructions.mjs` to validate the `extensionsCatalog` when building the index. The script now keeps track of extension IDs and throws an explicit `ERROR` if any duplicate ID is found across groups, failing the build process gracefully.
### Closes
Closes #22
### Verification
- [x] Verified `Zclsd` no longer appears twice in the UI.
- [x] Ran `node scripts/sync_instructions.mjs` successfully and it no longer threw any errors.
- [x] Verified successful production build via `npm run build`.