### PR TITLE
fix: replace mop_r_N and mop_rr_N placeholders with 40 individual encodings

### DIFF
--- a/src/instr_dict.json
+++ b/src/instr_dict.json
@@ -5003,35 +5003,285 @@
     "match": "0x70200073",
     "mask": "0xffffffff"
   },
-  "mop_r_N": {
-    "encoding": "1-00--0111-------100-----1110011",
-    "variable_fields": [
-      "mop_r_t_30",
-      "mop_r_t_27_26",
-      "mop_r_t_21_20",
-      "rd",
-      "rs1"
-    ],
-    "extension": [
-      "rv_zimop"
-    ],
+  "mop_r_0": {
+    "encoding": "100000011100-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
     "match": "0x81c04073",
-    "mask": "0xb3c0707f"
+    "mask": "0xfff0707f"
   },
-  "mop_rr_N": {
-    "encoding": "1-00--1----------100-----1110011",
-    "variable_fields": [
-      "mop_rr_t_30",
-      "mop_rr_t_27_26",
-      "rd",
-      "rs1",
-      "rs2"
-    ],
-    "extension": [
-      "rv_zimop"
-    ],
+  "mop_r_1": {
+    "encoding": "100000011101-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x81d04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_2": {
+    "encoding": "100000011110-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x81e04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_3": {
+    "encoding": "100000011111-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x81f04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_4": {
+    "encoding": "100001011100-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x85c04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_5": {
+    "encoding": "100001011101-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x85d04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_6": {
+    "encoding": "100001011110-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x85e04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_7": {
+    "encoding": "100001011111-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x85f04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_8": {
+    "encoding": "100010011100-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x89c04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_9": {
+    "encoding": "100010011101-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x89d04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_10": {
+    "encoding": "100010011110-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x89e04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_11": {
+    "encoding": "100010011111-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x89f04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_12": {
+    "encoding": "100011011100-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x8dc04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_13": {
+    "encoding": "100011011101-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x8dd04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_14": {
+    "encoding": "100011011110-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x8de04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_15": {
+    "encoding": "100011011111-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0x8df04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_16": {
+    "encoding": "110000011100-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xc1c04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_17": {
+    "encoding": "110000011101-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xc1d04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_18": {
+    "encoding": "110000011110-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xc1e04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_19": {
+    "encoding": "110000011111-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xc1f04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_20": {
+    "encoding": "110001011100-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xc5c04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_21": {
+    "encoding": "110001011101-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xc5d04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_22": {
+    "encoding": "110001011110-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xc5e04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_23": {
+    "encoding": "110001011111-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xc5f04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_24": {
+    "encoding": "110010011100-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xc9c04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_25": {
+    "encoding": "110010011101-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xc9d04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_26": {
+    "encoding": "110010011110-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xc9e04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_27": {
+    "encoding": "110010011111-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xc9f04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_28": {
+    "encoding": "110011011100-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xcdc04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_29": {
+    "encoding": "110011011101-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xcdd04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_30": {
+    "encoding": "110011011110-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xcde04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_31": {
+    "encoding": "110011011111-----100-----1110011",
+    "variable_fields": ["rd", "rs1"],
+    "extension": ["rv_zimop"],
+    "match": "0xcdf04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_rr_0": {
+    "encoding": "1000001----------100-----1110011",
+    "variable_fields": ["rd", "rs1", "rs2"],
+    "extension": ["rv_zimop"],
     "match": "0x82004073",
-    "mask": "0xb200707f"
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_1": {
+    "encoding": "1000011----------100-----1110011",
+    "variable_fields": ["rd", "rs1", "rs2"],
+    "extension": ["rv_zimop"],
+    "match": "0x86004073",
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_2": {
+    "encoding": "1000101----------100-----1110011",
+    "variable_fields": ["rd", "rs1", "rs2"],
+    "extension": ["rv_zimop"],
+    "match": "0x8a004073",
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_3": {
+    "encoding": "1000111----------100-----1110011",
+    "variable_fields": ["rd", "rs1", "rs2"],
+    "extension": ["rv_zimop"],
+    "match": "0x8e004073",
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_4": {
+    "encoding": "1100001----------100-----1110011",
+    "variable_fields": ["rd", "rs1", "rs2"],
+    "extension": ["rv_zimop"],
+    "match": "0xc2004073",
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_5": {
+    "encoding": "1100011----------100-----1110011",
+    "variable_fields": ["rd", "rs1", "rs2"],
+    "extension": ["rv_zimop"],
+    "match": "0xc6004073",
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_6": {
+    "encoding": "1100101----------100-----1110011",
+    "variable_fields": ["rd", "rs1", "rs2"],
+    "extension": ["rv_zimop"],
+    "match": "0xca004073",
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_7": {
+    "encoding": "1100111----------100-----1110011",
+    "variable_fields": ["rd", "rs1", "rs2"],
+    "extension": ["rv_zimop"],
+    "match": "0xce004073",
+    "mask": "0xfe00707f"
   },
   "mret": {
     "encoding": "00110000001000000000000001110011",

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1261,7 +1261,15 @@ const RISCVExplorer = () => {
     ],
     Zimop: [
       // May-be operations (reserved NOPs)
-      // Note: MOP.R.N, MOP.RR.N have encoding but naming mismatch in dictionary
+      'MOP.R.0', 'MOP.R.1', 'MOP.R.2', 'MOP.R.3', 'MOP.R.4',
+      'MOP.R.5', 'MOP.R.6', 'MOP.R.7', 'MOP.R.8', 'MOP.R.9',
+      'MOP.R.10', 'MOP.R.11', 'MOP.R.12', 'MOP.R.13', 'MOP.R.14',
+      'MOP.R.15', 'MOP.R.16', 'MOP.R.17', 'MOP.R.18', 'MOP.R.19',
+      'MOP.R.20', 'MOP.R.21', 'MOP.R.22', 'MOP.R.23', 'MOP.R.24',
+      'MOP.R.25', 'MOP.R.26', 'MOP.R.27', 'MOP.R.28', 'MOP.R.29',
+      'MOP.R.30', 'MOP.R.31',
+      'MOP.RR.0', 'MOP.RR.1', 'MOP.RR.2', 'MOP.RR.3',
+      'MOP.RR.4', 'MOP.RR.5', 'MOP.RR.6', 'MOP.RR.7',
     ],
     F: [
       // Load/Store

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -16991,7 +16991,496 @@
       "desc": "May-Be-Ops (NOP family)",
       "use": "Reserved NOP encodings for future",
       "url": "https://github.com/riscv/riscv-isa-manual",
-      "instructions": {}
+      "instructions": {
+        "MOP.R.0": {
+          "encoding": "100000011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x81c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.1": {
+          "encoding": "100000011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x81d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.2": {
+          "encoding": "100000011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x81e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.3": {
+          "encoding": "100000011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x81f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.4": {
+          "encoding": "100001011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x85c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.5": {
+          "encoding": "100001011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x85d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.6": {
+          "encoding": "100001011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x85e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.7": {
+          "encoding": "100001011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x85f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.8": {
+          "encoding": "100010011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x89c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.9": {
+          "encoding": "100010011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x89d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.10": {
+          "encoding": "100010011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x89e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.11": {
+          "encoding": "100010011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x89f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.12": {
+          "encoding": "100011011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8dc04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.13": {
+          "encoding": "100011011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8dd04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.14": {
+          "encoding": "100011011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8de04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.15": {
+          "encoding": "100011011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8df04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.16": {
+          "encoding": "110000011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc1c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.17": {
+          "encoding": "110000011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc1d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.18": {
+          "encoding": "110000011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc1e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.19": {
+          "encoding": "110000011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc1f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.20": {
+          "encoding": "110001011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc5c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.21": {
+          "encoding": "110001011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc5d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.22": {
+          "encoding": "110001011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc5e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.23": {
+          "encoding": "110001011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc5f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.24": {
+          "encoding": "110010011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc9c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.25": {
+          "encoding": "110010011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc9d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.26": {
+          "encoding": "110010011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc9e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.27": {
+          "encoding": "110010011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc9f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.28": {
+          "encoding": "110011011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xcdc04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.29": {
+          "encoding": "110011011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xcdd04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.30": {
+          "encoding": "110011011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xcde04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.31": {
+          "encoding": "110011011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xcdf04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.RR.0": {
+          "encoding": "1000001----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x82004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.1": {
+          "encoding": "1000011----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x86004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.2": {
+          "encoding": "1000101----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8a004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.3": {
+          "encoding": "1000111----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8e004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.4": {
+          "encoding": "1100001----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc2004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.5": {
+          "encoding": "1100011----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc6004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.6": {
+          "encoding": "1100101----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xca004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.7": {
+          "encoding": "1100111----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xce004073",
+          "mask": "0xfe00707f"
+        }
+      }
     }
   ],
   "z_crypto": [


### PR DESCRIPTION
Fixes #23

## What this PR does
Replaces the `mop_r_N` and `mop_rr_N` placeholder entries in `instr_dict.json` with all 40 individual encodings:
- `mop_r_0` to `mop_r_31` (32 entries)
- `mop_rr_0` to `mop_rr_7` (8 entries)

## How encodings were derived
Individual bit values were taken from the upstream `riscv-opcodes` specification file `extensions/rv_zimop`.

## Testing part
Built and served locally - Now Zimop renders without crashing.