### PR TITLE
fix: replace c_mop_N placeholder with 8 individual Zcmop encodings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -802,7 +801,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -829,7 +827,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1053,7 +1050,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3002,7 +2998,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3306,7 +3301,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3929,7 +3923,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4059,7 +4052,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -4109,7 +4101,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/src/instr_dict.json
+++ b/src/instr_dict.json
@@ -1521,16 +1521,61 @@
     "match": "0x4002",
     "mask": "0xe003"
   },
-  "c_mop_N": {
-    "encoding": "----------------01100---10000001",
-    "variable_fields": [
-      "c_mop_t"
-    ],
-    "extension": [
-      "rv_zcmop"
-    ],
-    "match": "0x6081",
-    "mask": "0xf8ff"
+  "c_mop_1": {
+    "encoding": "----------------0110000110000001",
+    "variable_fields": [],
+    "extension": ["rv_zcmop"],
+    "match": "0x6181",
+    "mask": "0xffff"
+  },
+  "c_mop_3": {
+    "encoding": "----------------0110001110000001",
+    "variable_fields": [],
+    "extension": ["rv_zcmop"],
+    "match": "0x6381",
+    "mask": "0xffff"
+  },
+  "c_mop_5": {
+    "encoding": "----------------0110010110000001",
+    "variable_fields": [],
+    "extension": ["rv_zcmop"],
+    "match": "0x6581",
+    "mask": "0xffff"
+  },
+  "c_mop_7": {
+    "encoding": "----------------0110011110000001",
+    "variable_fields": [],
+    "extension": ["rv_zcmop"],
+    "match": "0x6781",
+    "mask": "0xffff"
+  },
+  "c_mop_9": {
+    "encoding": "----------------0110100110000001",
+    "variable_fields": [],
+    "extension": ["rv_zcmop"],
+    "match": "0x6981",
+    "mask": "0xffff"
+  },
+  "c_mop_11": {
+    "encoding": "----------------0110101110000001",
+    "variable_fields": [],
+    "extension": ["rv_zcmop"],
+    "match": "0x6b81",
+    "mask": "0xffff"
+  },
+  "c_mop_13": {
+    "encoding": "----------------0110110110000001",
+    "variable_fields": [],
+    "extension": ["rv_zcmop"],
+    "match": "0x6d81",
+    "mask": "0xffff"
+  },
+  "c_mop_15": {
+    "encoding": "----------------0110111110000001",
+    "variable_fields": [],
+    "extension": ["rv_zcmop"],
+    "match": "0x6f81",
+    "mask": "0xffff"
   },
   "c_mul": {
     "encoding": "----------------100111---10---01",

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1497,8 +1497,8 @@ const RISCVExplorer = () => {
       'CM.JALT',
     ],
     Zcmop: [
-      // May-be-operations (reserved NOPs)
-      // Note: C.MOP.N has encoding but naming mismatch in dictionary
+      'C.MOP.1', 'C.MOP.3', 'C.MOP.5', 'C.MOP.7',
+      'C.MOP.9', 'C.MOP.11', 'C.MOP.13', 'C.MOP.15',
     ],
     B: [
       // Aggregates Zba + Zbb + Zbc + Zbs

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -13895,7 +13895,80 @@
       "desc": "Compressed May-Be-Ops",
       "use": "Reserved 16-bit NOP/future ops",
       "url": "https://github.com/riscv/riscv-isa-manual",
-      "instructions": {}
+      "instructions": {
+        "C.MOP.1": {
+          "encoding": "----------------0110000110000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6181",
+          "mask": "0xffff"
+        },
+        "C.MOP.3": {
+          "encoding": "----------------0110001110000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6381",
+          "mask": "0xffff"
+        },
+        "C.MOP.5": {
+          "encoding": "----------------0110010110000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6581",
+          "mask": "0xffff"
+        },
+        "C.MOP.7": {
+          "encoding": "----------------0110011110000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6781",
+          "mask": "0xffff"
+        },
+        "C.MOP.9": {
+          "encoding": "----------------0110100110000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6981",
+          "mask": "0xffff"
+        },
+        "C.MOP.11": {
+          "encoding": "----------------0110101110000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6b81",
+          "mask": "0xffff"
+        },
+        "C.MOP.13": {
+          "encoding": "----------------0110110110000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6d81",
+          "mask": "0xffff"
+        },
+        "C.MOP.15": {
+          "encoding": "----------------0110111110000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6f81",
+          "mask": "0xffff"
+        }
+      }
     },
     {
       "id": "Zclsd",


### PR DESCRIPTION
## What this PR does
Replaces the `c_mop_N` placeholder entry in `instr_dict.json` 
with 8 individual encodings:
c_mop_1, c_mop_3, c_mop_5, c_mop_7, c_mop_9, c_mop_11, 
c_mop_13, c_mop_15

Also adds the 8 C.MOP.n mnemonics to `extensionInstructions` 
in `risc_v_visualizer.jsx` so Zcmop renders correctly in the UI.

## Why
Similar to #23 (Zimop fix), the `c_mop_N` placeholder key in 
`instr_dict.json` could not be matched by the sync script, 
leaving Zcmop with no instruction data. Fixes #30.

## Testing
Built and served locally — Zcmop now renders all 8 instructions 
without crashing.

## Notes
C.MOP.n is defined for odd integers only (1, 3, 5, 7, 9, 11, 
13, 15) as per the official RISC-V Zcmop specification.