### PR TITLE
fix: add missing PAUSE instruction for Zihintpause extension

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1247,6 +1247,9 @@ const RISCVExplorer = () => {
       // Instruction-fetch fence
       'FENCE.I',
     ],
+    Zihintpause: [    
+      'PAUSE',        
+    ],
     Zicbom: [
       // Cache-block management
       'CBO.CLEAN', 'CBO.FLUSH', 'CBO.INVAL',


### PR DESCRIPTION
### Problem
Zihintpause extension exists in the catalog but has no instruction mapping.
As a result, no instruction data is shown in the UI.

### Fix
Added missing mapping in `extensionInstructions`:
Zihintpause → ['PAUSE']

### Result
Instruction now appears correctly when selecting Zihintpause in the UI.

This is one of several extensions missing mappings. Similar fixes can be applied for other extensions.