### PR TITLE
Fix/show missing instruction fallback

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -3021,7 +3021,7 @@ const RISCVExplorer = () => {
 	                      </div>
 	                    )}
 
-	                  {extensionInstructions[selectedExt.id] && (
+	                  {extensionInstructions[selectedExt.id] ? (
 	                    <div className="bg-slate-900 p-3 rounded border border-slate-700">
 	                      <h4 className="text-[10px] uppercase tracking-wider text-emerald-400 font-bold mb-2">
 	                        Instruction Set Snapshot ({extensionInstructions[selectedExt.id].length})
@@ -3083,7 +3083,16 @@ const RISCVExplorer = () => {
 	                        })}
 	                      </div>
 	                    </div>
-	                  )}
+	                  ): (
+                      <div className="bg-slate-900 p-3 rounded border border-slate-700">
+                        <h4 className="text-[10px] uppercase tracking-wider text-emerald-400 font-bold mb-2">
+                          Instruction Set Snapshot
+                        </h4>
+                        <p className="text-[11px] text-slate-400 italic">
+                          No instruction data available for this extension yet.
+                        </p>
+                      </div>
+                    )}
 
                     {extensionCsrs[selectedExt.id] && (
                       <div className="bg-slate-900 p-3 rounded border border-slate-700">

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1247,6 +1247,9 @@ const RISCVExplorer = () => {
       // Instruction-fetch fence
       'FENCE.I',
     ],
+    Zihintpause: [    
+      'PAUSE',        
+    ],
     Zicbom: [
       // Cache-block management
       'CBO.CLEAN', 'CBO.FLUSH', 'CBO.INVAL',


### PR DESCRIPTION
### Problem
Some extensions exist in the catalog but do not have instruction mappings.
When such an extension is selected, the UI shows an empty section, which looks broken and provides no feedback.

### Example
Clicking on extensions like `Zinctr`, `Zicntrpmf`, `Zibi` results in no instruction data being displayed.

### Root Cause
The UI renders instructions only when `extensionInstructions[selectedExt.id]` exists.
If it is undefined, nothing is rendered.

### Fix
Added a fallback message when instruction data is missing:
> "No instruction data available for this extension"

### Result
- Prevents empty UI state
- Provides clear feedback to users
- Makes incomplete mappings visible

### Notes
Previously fixed a related issue where `Zihintpause` was missing its instruction mapping (`PAUSE`).
This PR improves the experience for other unmapped extensions.

Future improvement: visually highlight incomplete extensions in the UI.