### PR TITLE
perf: implement lazy loading for riscv_extensions.json

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -10,7 +10,6 @@ import {
   ChevronLeft,
   ChevronRight,
 } from 'lucide-react';
-import extensions from './riscv_extensions.json';
 
 const BIT_WIDTH = 32n;
 const BIT_MASK_32 = (1n << BIT_WIDTH) - 1n;
@@ -564,6 +563,7 @@ const EncodingDiagram = ({ encoding }) => {
 };
 
 const RISCVExplorer = () => {
+  const [extensions, setExtensions] = useState(null);
   const [activeProfile, setActiveProfile] = useState(null);
   const [activeVolume, setActiveVolume] = useState(null);
   const [selectedExt, setSelectedExt] = useState(null);
@@ -581,6 +581,23 @@ const RISCVExplorer = () => {
   const [encoderValidatorResult, setEncoderValidatorResult] = useState(null);
   const [encoderValidatorCopyStatus, setEncoderValidatorCopyStatus] = useState(null);
   const lastScrolledKeyRef = React.useRef(null);
+
+  React.useEffect(() => {
+    import('./riscv_extensions.json').then((mod) => {
+      setExtensions(mod.default);
+    });
+  }, []);
+
+  if (!extensions) {
+    return (
+      <div className="min-h-screen bg-slate-950 text-slate-300 flex items-center justify-center font-sans">
+        <div className="flex flex-col items-center gap-4">
+          <div className="w-8 h-8 border-4 border-purple-500 border-t-transparent rounded-full animate-spin"></div>
+          <div className="text-slate-400 font-medium">Loading RISC-V Extensions...</div>
+        </div>
+      </div>
+    );
+  }
 
   // ---------------------------------------------------------------------------
   // Extension Catalog – loaded from `src/riscv_extensions.json`

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
   entry: './src/main.jsx',
   output: {
     filename: 'bundle.js',
+    chunkFilename: '[name].[contenthash].js',
     path: path.resolve(__dirname, 'dist'),
   },
   module: {


### PR DESCRIPTION
This PR addresses the performance bottleneck caused by synchronously parsing the large `riscv_extensions.json` file (~528KB) on initial load. 

Previously, the massive extension catalog was statically imported and bundled directly into the main JavaScript chunk, blocking the initial render even if the user only needed to view a few extensions. This PR implements dynamic lazy loading to resolve the issue.

### Changes Made
- **Removed Static Import**: Removed the static `import extensions from './riscv_extensions.json'` inside `src/risc_v_visualizer.jsx`.
- **Dynamic Import with `useEffect`**: Added React state and a `useEffect` hook to dynamically fetch the JSON file (`import()`) only after the application mounts.
- **Loading State UI**: Added a sleek loading spinner and fallback text that is displayed to the user while the JSON payload is being fetched over the network.
- **Webpack Chunking**: Added `chunkFilename: '[name].[contenthash].js'` to `webpack.config.js` to explicitly separate dynamic imports into clear, cacheable chunks.

### Impact
- **Significant Bundle Size Reduction:** The 500KB+ JSON file is no longer baked into `bundle.js`, drastically reducing the initial JavaScript payload size.
- **Improved Time-To-Interactive (TTI):** Faster parsing and execution of the core app bundle on slower devices and low-bandwidth connections.

### Verification
- Tested locally by building the app with Webpack and verifying that the `riscv_extensions.json` data is correctly emitted as a separate chunk.
- Verified that the fallback loading spinner renders properly and seamlessly transitions once the data is resolved.


Fixes: #35 