### PR TITLE
fix: reject Match/Mask hex inputs wider than 32 bits in Encoder Validator

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -2233,6 +2233,8 @@ const RISCVExplorer = () => {
       const maskParsed = parseHexToBigInt(proposedMaskInput);
       if (matchParsed == null) errors.push('Match must be a hex value like 0x1234.');
       if (maskParsed == null) errors.push('Mask must be a hex value like 0x707f.');
+      if (matchParsed != null && matchParsed > BIT_MASK_32) errors.push('Match exceeds 32 bits.');
+      if (maskParsed != null && maskParsed > BIT_MASK_32) errors.push('Mask exceeds 32 bits.');
 
       if (matchParsed != null && maskParsed != null) {
         const matchNorm = matchParsed & BIT_MASK_32;


### PR DESCRIPTION
## Proposed changes

The Encoder Validator was accepting hex Match/Mask values wider than 32 bits, AND-masking them with `BIT_MASK_32`, and reporting conflicts against the truncated value with no warning. This change adds two explicit width checks in the validator block so oversized input is rejected with `Match exceeds 32 bits.` / `Mask exceeds 32 bits.` instead of being silently coerced.

## Issue(s)

Closes #37

## How to test or reproduce

1. Open the Encoder Validator.
2. Enter `Match = 0x11800202f` and `Mask = 0xf800707f` (one extra hex digit on Match).
3. Click Validate.

Before this change: the validator returns a conflict against `SC.W` (whose real match is `0x1800202f`).
After this change: the validator returns the error `Match exceeds 32 bits.` and runs no conflict detection.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes (no eslint config / no test suite in repo; `npm run build` succeeds with only pre-existing bundle-size warnings)