### PR TITLE
fix: clear stale search-driven selection when query has no match

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -2514,6 +2514,11 @@ const RISCVExplorer = () => {
         }
 	        lastScrolledKeyRef.current = key;
 	      }
+	    } else {
+	      setSelectedExt(null);
+	      setSelectedInstruction(null);
+	      setSearchMatches(null);
+	      lastScrolledKeyRef.current = null;
 	    }
 	  }, [searchQuery, extensionSearchIndexById]);
 


### PR DESCRIPTION
## Proposed changes

The search `useEffect` in `src/risc_v_visualizer.jsx` previously cleared the search-driven selection only when the query was empty. If the query was non-empty but matched nothing (e.g. typing past a match like `ADD` → `ADDqqq`), the prior `selectedExt`, `selectedInstruction`, and `searchMatches` stayed in place, making the panel look like the new query had matched. This PR adds the missing else branch so a non-matching, non-empty query clears the same state and resets the scroll-tracking ref.

## Issue(s)

Closes #39

## How to test or reproduce

1. `npm install && npm run build && python3 -m http.server 8080 -d dist`
2. Open `http://localhost:8080`.
3. Type `ADD` in the search box — the page scrolls to the RV32I tile and the Selected Details panel opens with `ADD`.
4. Extend the query to `ADDqqq`.
5. Before this PR: the RV32I tile remains selected and `ADD` still shows in the Selected Details panel.
6. After this PR: the selection clears as soon as the query no longer matches anything.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] Lint and unit tests pass locally with my changes