### PR TITLE
fix: fail sync on missing mappings

### DIFF
--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -315,7 +315,11 @@ to the clipboard.
    ```
 
    The script reports statistics: how many instructions were added, and any
-   missing extensions or instructions that could not be resolved.
+   missing extensions or instructions that could not be resolved. **Important:**
+   The script will fail (non-zero exit code) if any extension or instruction
+   mapping is incomplete, preventing partial catalog commits. Resolve any missing
+   mnemonics in `src/instr_dict.json` or the extension lists in the visualizer,
+   then re-run.
 
 4. **Build and verify:**
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ node scripts/sync_instructions.mjs
 
 This updates `src/riscv_extensions.json` by populating `instructions` maps under each extension (keyed by mnemonic, e.g. `"SC.W": { ... }`).
 
+**Note:** The sync script will fail with a non-zero exit code if any extension references or instruction mnemonics cannot be fully resolved. This prevents incomplete catalog data from being committed. Fix any missing mappings in `src/instr_dict.json` or the extension instruction lists in `src/risc_v_visualizer.jsx`, then re-run the sync.
+
 ### 4) Verify
 
 ```bash

--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -144,13 +144,14 @@ for (const [extId, mnemonics] of Object.entries(extensionInstructions)) {
 
 if (missingExtensions.size || missingInstructions.size) {
   if (missingExtensions.size) {
-    console.error(`Extensions referenced in JSX but not found in YAML: ${Array.from(missingExtensions).sort().join(', ')}`);
+    console.error(`Extensions referenced in JSX but not found in src/riscv_extensions.json: ${Array.from(missingExtensions).sort().join(', ')}`);
   }
   if (missingInstructions.size) {
     const sorted = Array.from(missingInstructions.entries()).sort(([a], [b]) => a.localeCompare(b));
     console.error('Instructions missing from instr_dict.json (by extension):');
     for (const [extId, list] of sorted) {
-      console.error(`- ${extId}: ${list.length}`);
+      const missingMnemonics = Array.from(new Set(list)).sort((a, b) => a.localeCompare(b));
+      console.error(`- ${extId}: ${missingMnemonics.join(', ')}`);
     }
   }
   die('Sync aborted: missing extension or instruction mappings would produce a partial catalog.');

--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -142,16 +142,20 @@ for (const [extId, mnemonics] of Object.entries(extensionInstructions)) {
   }
 }
 
+if (missingExtensions.size || missingInstructions.size) {
+  if (missingExtensions.size) {
+    console.error(`Extensions referenced in JSX but not found in YAML: ${Array.from(missingExtensions).sort().join(', ')}`);
+  }
+  if (missingInstructions.size) {
+    const sorted = Array.from(missingInstructions.entries()).sort(([a], [b]) => a.localeCompare(b));
+    console.error('Instructions missing from instr_dict.json (by extension):');
+    for (const [extId, list] of sorted) {
+      console.error(`- ${extId}: ${list.length}`);
+    }
+  }
+  die('Sync aborted: missing extension or instruction mappings would produce a partial catalog.');
+}
+
 fs.writeFileSync(catalogPath, `${JSON.stringify(extensionsCatalog, null, 2)}\n`);
 
 console.log(`Updated ${path.relative(workspaceRoot, catalogPath)} with ${addedCount} instruction entries.`);
-if (missingExtensions.size) {
-  console.warn(`Extensions referenced in JSX but not found in YAML: ${Array.from(missingExtensions).sort().join(', ')}`);
-}
-if (missingInstructions.size) {
-  const sorted = Array.from(missingInstructions.entries()).sort(([a], [b]) => a.localeCompare(b));
-  console.warn('Instructions missing from instr_dict.json (by extension):');
-  for (const [extId, list] of sorted) {
-    console.warn(`- ${extId}: ${list.length}`);
-  }
-}


### PR DESCRIPTION
## **Summary**
This PR makes `scripts/sync_instructions.mjs` fail fast when the sync would produce a partial catalog.

## **What Changed**
The script now treats missing mappings as fatal instead of warning-only:

- missing extension references in `src/risc_v_visualizer.jsx` are reported as errors
- missing instruction entries in `src/instr_dict.json` are reported as errors
- the sync aborts before writing `src/riscv_extensions.json` if any required mappings are missing

## **Why**
Previously, the sync script could write a partially updated catalog while only printing warnings. That made it too easy to commit incomplete data and hide mapping gaps.

## **Scope**
- Sync integrity behavior only
- No catalog schema changes
- No UI changes

## **Validation**
- `node --check scripts/sync_instructions.mjs` ✅

## **Risk**
Low to medium:
- It is intentionally stricter
- Existing incomplete mapping states will now fail instead of silently writing partial output

## **Related Issue**
Closes #54 