### PR TITLE
feat: add instruction lists for 9 RISC-V extensions

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1924,10 +1924,63 @@ const RISCVExplorer = () => {
     ],
     U: [
       // User-level environment instructions (Volume II)
-      // Note: U-mode mostly reuses unprivileged ISA, so only traps/syscalls are distinct
+      // Note: U-mode mostly reuses unprivileged ISA, so only traps/yscalls are distinct
       'URET',
       'ECALL',
       'EBREAK',
+    ],
+
+    // Supervisor-level extensions
+    Svinval: [
+      // Fine-grained address-translation cache invalidation
+      'SINVAL.VMA',
+      'SFENCE.W.INVAL',
+      'SFENCE.INVAL.IR',
+    ],
+    Sdext: [
+      // Debug mode return
+      'DRET',
+    ],
+    Smrnmi: [
+      // Resumable non-maskable interrupts
+      'MNRET',
+    ],
+    Ssctr: [
+      // Control-transfer records supervisor clear
+      'SCTRCLR',
+    ],
+
+    // Integer extensions
+    Zibi: [
+      // Immediate branch instructions
+      'BEQI',
+      'BNEI',
+    ],
+
+    // Vector extensions
+    Zvabd: [
+      // Vector absolute difference
+      'VABD.VV', 'VABDU.VV', 'VABS.V',
+      'VWABDA.VV', 'VWABDAU.VV',
+    ],
+    Zvfofp8min: [
+      // Vector FP8 narrowing conversions
+      'VFNCVT.F.F.Q', 'VFNCVT.SAT.F.F.Q', 'VFNCVTBF16.SAT.F.F.W',
+    ],
+    Zvkn: [
+      // Vector cryptography: NIST suite (AES + SHA-2 + Zvbb)
+      'VAESDF.VS', 'VAESDF.VV', 'VAESDM.VS', 'VAESDM.VV',
+      'VAESEF.VS', 'VAESEF.VV', 'VAESEM.VS', 'VAESEM.VV',
+      'VAESKF1.VI', 'VAESKF2.VI', 'VAESZ.VS',
+      'VSHA2CH.VV', 'VSHA2CL.VV', 'VSHA2MS.VV',
+      'VANDN.VV', 'VANDN.VX', 'VBREV8.V', 'VREV8.V',
+      'VROL.VV', 'VROL.VX', 'VROR.VI', 'VROR.VV', 'VROR.VX',
+    ],
+    Zvks: [
+      // Vector cryptography: ShangMi suite (SM3 + SM4 + Zvbb)
+      'VSM3C.VI', 'VSM3ME.VV', 'VSM4K.VI', 'VSM4R.VS', 'VSM4R.VV',
+      'VANDN.VV', 'VANDN.VX', 'VBREV8.V', 'VREV8.V',
+      'VROL.VV', 'VROL.VX', 'VROR.VI', 'VROR.VV', 'VROR.VX',
     ],
   };
 


### PR DESCRIPTION
hi @rpsene 
### Summary

This PR adds instruction membership (mnemonic lists) for 9 RISC-V extensions that previously had encoding data available but were not connected in the UI.

### Extensions Covered

* Svinval
* Sdext
* Smrnmi
* Ssctr
* Zibi
* Zvabd
* Zvfofp8min
* Zvkn
* Zvks

### Changes

* Updated `extensionInstructions` in `src/risc_v_visualizer.jsx`
* Mapped missing instruction mnemonics to their respective extensions
* Ensured compatibility with existing instruction catalog generation

### Details

These extensions already had encoding definitions in `instr_dict.json`, but were not wired into the visualization layer. This caused them to be absent from the UI despite having valid data.

Running `sync_instructions.mjs` after these changes:

* Increases coverage from **71/220 (32.3%) → 80/220 (36.4%)**
* Adds **53 instruction entries** to the catalog

### Example Additions

* **Svinval:** SINVAL.VMA, SFENCE.W.INVAL, SFENCE.INVAL.IR
* **Sdext:** DRET
* **Smrnmi:** MNRET
* **Zibi:** BEQI, BNEI
* **Zvabd:** Vector absolute difference instructions
* **Zvkn / Zvks:** AES, SHA-2, SM3, SM4 instruction groups

### Impact

* Improves completeness of extension coverage in the visualization tool
* Enables accurate display of instruction-level data for the added extensions
* Aligns UI with existing backend instruction definitions

### Testing

* Verified successful build
* Confirmed new extensions and instructions appear correctly in the UI
