### PR TITLE
feat(sync): add --report flag for coverage gap detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -802,7 +801,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -829,7 +827,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1053,7 +1050,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3002,7 +2998,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3306,7 +3301,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3929,7 +3923,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4059,7 +4052,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -4109,7 +4101,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -102,6 +102,72 @@ function mnemonicToInstrDictKey(mnemonic) {
   return String(mnemonic).trim().toLowerCase().replaceAll('.', '_');
 }
 
+// Prints a full coverage breakdown: overall %, per-category progress bars,
+// and a list of every extension still missing instruction data with a
+// diagnosis of why (no JSX list vs. instrs absent from instr_dict.json).
+// Triggered by passing --report on the command line.
+function printCoverageReport(extensionsCatalog, extensionInstructions) {
+  const totalPerCat = {};
+  const filledPerCat = {};
+  let grandTotal = 0;
+  let grandFilled = 0;
+
+  for (const [category, entries] of Object.entries(extensionsCatalog)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      grandTotal += 1;
+      totalPerCat[category] = (totalPerCat[category] ?? 0) + 1;
+      const count = Object.keys(entry.instructions ?? {}).length;
+      if (count > 0) {
+        grandFilled += 1;
+        filledPerCat[category] = (filledPerCat[category] ?? 0) + 1;
+      }
+    }
+  }
+
+  const pct = grandTotal > 0 ? ((grandFilled / grandTotal) * 100).toFixed(1) : '0.0';
+  console.log('');
+  console.log('=== RISC-V Extensions Landscape — Coverage Report ===');
+  console.log('');
+  console.log(`  Overall: ${grandFilled}/${grandTotal} extensions with instruction data (${pct}%)`);
+  console.log('');
+  console.log('  Category breakdown:');
+
+  const BAR_WIDTH = 20;
+  for (const category of Object.keys(totalPerCat)) {
+    const total = totalPerCat[category] ?? 0;
+    const filled = filledPerCat[category] ?? 0;
+    const catPct = total > 0 ? filled / total : 0;
+    const bar = '#'.repeat(Math.round(catPct * BAR_WIDTH)).padEnd(BAR_WIDTH, '.');
+    const catPctStr = (catPct * 100).toFixed(0).padStart(3);
+    console.log(`    ${category.padEnd(22)} [${bar}] ${String(filled).padStart(3)}/${total} (${catPctStr}%)`);
+  }
+
+  console.log('');
+  console.log('  Extensions without instruction data:');
+
+  const jsxIds = new Set(Object.keys(extensionInstructions));
+  for (const [category, entries] of Object.entries(extensionsCatalog)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      const count = Object.keys(entry.instructions ?? {}).length;
+      if (count === 0) {
+        const diagnosis = jsxIds.has(entry.id)
+          ? '(has JSX list, instrs missing from instr_dict)'
+          : '(no JSX list)';
+        console.log(`    - ${entry.id.padEnd(25)} [${category}]  ${diagnosis}`);
+      }
+    }
+  }
+  console.log('');
+}
+
+// ---- main ------------------------------------------------------------------
+
+const showReport = process.argv.includes('--report');
+
 const workspaceRoot = process.cwd();
 const instrDictPath = path.join(workspaceRoot, 'src', 'instr_dict.json');
 const catalogPath = path.join(workspaceRoot, 'src', 'riscv_extensions.json');
@@ -146,12 +212,16 @@ fs.writeFileSync(catalogPath, `${JSON.stringify(extensionsCatalog, null, 2)}\n`)
 
 console.log(`Updated ${path.relative(workspaceRoot, catalogPath)} with ${addedCount} instruction entries.`);
 if (missingExtensions.size) {
-  console.warn(`Extensions referenced in JSX but not found in YAML: ${Array.from(missingExtensions).sort().join(', ')}`);
+  console.warn(`Extensions referenced in JSX but not found in catalog: ${Array.from(missingExtensions).sort().join(', ')}`);
 }
 if (missingInstructions.size) {
   const sorted = Array.from(missingInstructions.entries()).sort(([a], [b]) => a.localeCompare(b));
-  console.warn('Instructions missing from instr_dict.json (by extension):');
+  console.warn('Instructions listed in JSX but missing from instr_dict.json (by extension):');
   for (const [extId, list] of sorted) {
-    console.warn(`- ${extId}: ${list.length}`);
+    console.warn(`  - ${extId}: ${list.length} missing`);
   }
+}
+
+if (showReport) {
+  printCoverageReport(extensionsCatalog, extensionInstructions);
 }


### PR DESCRIPTION
### Summary

Adds a `--report` flag to `scripts/sync_instructions.mjs` to provide visibility into instruction coverage across RISC-V extensions.

### What’s Added

* New `--report` CLI flag:

  ```bash
  node scripts/sync_instructions.mjs --report
  ```
* `printCoverageReport()` utility that outputs:

  * Overall coverage percentage (filled vs total extensions)
  * Per-category coverage with ASCII progress bars
  * List of extensions with missing instruction mappings

### Why

Currently, there is no clear way to identify:

* Which extensions are missing instruction lists
* Whether gaps are due to missing JSX mappings or absent data in `instr_dict.json`

This makes it difficult to track progress and prioritize contributions.

### Impact

* Improves developer visibility into coverage gaps
* Helps contributors identify high-impact areas to work on
* Supports mentorship tasks focused on improving extension coverage 

### Behavior

* No changes to existing sync logic
* Default behavior remains unchanged
* Report is only generated when `--report` flag is explicitly used

### Testing

* Verified normal sync execution works as before
* Verified `--report` outputs correct coverage summary and extension diagnostics
