### PR TITLE
feat(sync): add TAG_ALIASES to resolve riscv-opcodes naming mismatches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -802,7 +801,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -829,7 +827,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1053,7 +1050,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3002,7 +2998,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3306,7 +3301,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3929,7 +3923,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4059,7 +4052,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -4109,7 +4101,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -102,6 +102,72 @@ function mnemonicToInstrDictKey(mnemonic) {
   return String(mnemonic).trim().toLowerCase().replaceAll('.', '_');
 }
 
+// Prints a full coverage breakdown: overall %, per-category progress bars,
+// and a list of every extension still missing instruction data with a
+// diagnosis of why (no JSX list vs. instrs absent from instr_dict.json).
+// Triggered by passing --report on the command line.
+function printCoverageReport(extensionsCatalog, extensionInstructions) {
+  const totalPerCat = {};
+  const filledPerCat = {};
+  let grandTotal = 0;
+  let grandFilled = 0;
+
+  for (const [category, entries] of Object.entries(extensionsCatalog)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      grandTotal += 1;
+      totalPerCat[category] = (totalPerCat[category] ?? 0) + 1;
+      const count = Object.keys(entry.instructions ?? {}).length;
+      if (count > 0) {
+        grandFilled += 1;
+        filledPerCat[category] = (filledPerCat[category] ?? 0) + 1;
+      }
+    }
+  }
+
+  const pct = grandTotal > 0 ? ((grandFilled / grandTotal) * 100).toFixed(1) : '0.0';
+  console.log('');
+  console.log('=== RISC-V Extensions Landscape — Coverage Report ===');
+  console.log('');
+  console.log(`  Overall: ${grandFilled}/${grandTotal} extensions with instruction data (${pct}%)`);
+  console.log('');
+  console.log('  Category breakdown:');
+
+  const BAR_WIDTH = 20;
+  for (const category of Object.keys(totalPerCat)) {
+    const total = totalPerCat[category] ?? 0;
+    const filled = filledPerCat[category] ?? 0;
+    const catPct = total > 0 ? filled / total : 0;
+    const bar = '#'.repeat(Math.round(catPct * BAR_WIDTH)).padEnd(BAR_WIDTH, '.');
+    const catPctStr = (catPct * 100).toFixed(0).padStart(3);
+    console.log(`    ${category.padEnd(22)} [${bar}] ${String(filled).padStart(3)}/${total} (${catPctStr}%)`);
+  }
+
+  console.log('');
+  console.log('  Extensions without instruction data:');
+
+  const jsxIds = new Set(Object.keys(extensionInstructions));
+  for (const [category, entries] of Object.entries(extensionsCatalog)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      const count = Object.keys(entry.instructions ?? {}).length;
+      if (count === 0) {
+        const diagnosis = jsxIds.has(entry.id)
+          ? '(has JSX list, instrs missing from instr_dict)'
+          : '(no JSX list)';
+        console.log(`    - ${entry.id.padEnd(25)} [${category}]  ${diagnosis}`);
+      }
+    }
+  }
+  console.log('');
+}
+
+// ---- main ------------------------------------------------------------------
+
+const showReport = process.argv.includes('--report');
+
 const workspaceRoot = process.cwd();
 const instrDictPath = path.join(workspaceRoot, 'src', 'instr_dict.json');
 const catalogPath = path.join(workspaceRoot, 'src', 'riscv_extensions.json');
@@ -146,12 +212,16 @@ fs.writeFileSync(catalogPath, `${JSON.stringify(extensionsCatalog, null, 2)}\n`)
 
 console.log(`Updated ${path.relative(workspaceRoot, catalogPath)} with ${addedCount} instruction entries.`);
 if (missingExtensions.size) {
-  console.warn(`Extensions referenced in JSX but not found in YAML: ${Array.from(missingExtensions).sort().join(', ')}`);
+  console.warn(`Extensions referenced in JSX but not found in catalog: ${Array.from(missingExtensions).sort().join(', ')}`);
 }
 if (missingInstructions.size) {
   const sorted = Array.from(missingInstructions.entries()).sort(([a], [b]) => a.localeCompare(b));
-  console.warn('Instructions missing from instr_dict.json (by extension):');
+  console.warn('Instructions listed in JSX but missing from instr_dict.json (by extension):');
   for (const [extId, list] of sorted) {
-    console.warn(`- ${extId}: ${list.length}`);
+    console.warn(`  - ${extId}: ${list.length} missing`);
   }
+}
+
+if (showReport) {
+  printCoverageReport(extensionsCatalog, extensionInstructions);
 }

--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -2,6 +2,59 @@ import fs from 'node:fs';
 import path from 'node:path';
 import vm from 'node:vm';
 
+// ---------------------------------------------------------------------------
+// TAG_ALIASES: maps riscv-opcodes extension tags (used in instr_dict.json)
+// to their canonical catalog IDs (used in riscv_extensions.json).
+//
+// The upstream riscv-opcodes project names extension tags with prefixes like
+// rv_, rv32_, rv64_, and sometimes combines two extension names with an
+// underscore (e.g. rv_f_zfa = "Zfa instructions that also require F").
+// These do not match the catalog's CamelCase IDs, so the sync script cannot
+// link them automatically. This table bridges that gap.
+//
+// How to add an entry:
+//   "<instr_dict tag>": "<catalog extension ID>",
+//
+// Guidelines:
+//   - Use the catalog ID exactly as it appears in riscv_extensions.json.
+//   - For cross-extension tags (e.g. rv_f_zfa = Zfa instructions that also
+//     need F), map to the extension that *defines* those instructions.
+//   - Leave a comment explaining the mapping when it is non-obvious.
+// ---------------------------------------------------------------------------
+const TAG_ALIASES = {
+  // Base integer: rv_i / rv64_i cover the core RV64I instruction set
+  rv_i:              'RV64I',
+  rv64_i:            'RV64I',
+
+  // Supervisor / machine system instructions
+  rv_system:         'S',        // MRET, WFI live under the S (supervisor) group
+
+  // Compressed floating-point subsets
+  rv_c_d:            'Zcd',      // C+D double-precision loads/stores (RV64)
+  rv32_c_f:          'Zcf',      // C+F single-precision loads/stores (RV32 only)
+
+  // Svinval H-mode variant — HINVAL.GVMA / HINVAL.VVMA belong with Svinval
+  rv_svinval_h:      'Svinval',
+
+  // Zicbom: the upstream tag is rv_zicbo (no trailing 'm')
+  rv_zicbo:          'Zicbom',
+
+  // Zfa: additional floating-point instructions spread across F/D/H/Q tags
+  rv_f_zfa:          'Zfa',
+  rv_d_zfa:          'Zfa',
+  rv32_d_zfa:        'Zfa',
+  rv_q_zfa:          'Zfa',
+  rv64_q_zfa:        'Zfa',
+  rv_zfh_zfa:        'Zfa',      // Zfa instructions that also need Zfh
+
+  // Zfhmin: half-precision min subset — conversions between H and D/Q
+  rv_d_zfhmin:       'Zfhmin',
+  rv_q_zfhmin:       'Zfhmin',
+
+  // Zabha: byte/halfword atomics that require Zacas
+  rv_zabha_zacas:    'Zabha',
+};
+
 function die(message) {
   console.error(message);
   process.exit(1);
@@ -102,6 +155,25 @@ function mnemonicToInstrDictKey(mnemonic) {
   return String(mnemonic).trim().toLowerCase().replaceAll('.', '_');
 }
 
+// Reads instr_dict.json and groups instructions by catalog ID using TAG_ALIASES.
+// Returns Map<catalogId, Map<mnemonic, details>>.
+function buildAliasInstructions(instrDict) {
+  const result = new Map();
+
+  for (const [tag, catalogId] of Object.entries(TAG_ALIASES)) {
+    for (const [key, details] of Object.entries(instrDict)) {
+      if (!details.extension || !details.extension.includes(tag)) continue;
+      // Best-effort mnemonic: uppercase the key and replace _ with .
+      const mnemonic = key.toUpperCase().replaceAll('_', '.');
+      const bucket = result.get(catalogId) ?? new Map();
+      bucket.set(mnemonic, details);
+      result.set(catalogId, bucket);
+    }
+  }
+
+  return result;
+}
+
 // Prints a full coverage breakdown: overall %, per-category progress bars,
 // and a list of every extension still missing instruction data with a
 // diagnosis of why (no JSX list vs. instrs absent from instr_dict.json).
@@ -180,10 +252,14 @@ const visualizerSource = fs.readFileSync(visualizerPath, 'utf8');
 const extensionInstructions = extractExtensionInstructions(visualizerSource);
 const extIndex = buildExtensionIndex(extensionsCatalog);
 
+// Build alias-derived instructions from TAG_ALIASES
+const aliasInstructions = buildAliasInstructions(instrDict);
+
 const missingExtensions = new Set();
 const missingInstructions = new Map();
 let addedCount = 0;
 
+// --- Pass 1: JSX mnemonic lists (original behaviour) -----------------------
 for (const [extId, mnemonics] of Object.entries(extensionInstructions)) {
   const locations = extIndex.get(extId);
   if (!locations || locations.length === 0) {
@@ -208,9 +284,30 @@ for (const [extId, mnemonics] of Object.entries(extensionInstructions)) {
   }
 }
 
+// --- Pass 2: TAG_ALIASES — auto-populate from instr_dict tags --------------
+// Runs after Pass 1 so JSX-listed mnemonics always take priority.
+let aliasAddedCount = 0;
+for (const [catalogId, mnemonicMap] of aliasInstructions) {
+  const locations = extIndex.get(catalogId);
+  if (!locations || locations.length === 0) continue;
+
+  for (const { entry } of locations) {
+    if (!entry.instructions || typeof entry.instructions !== 'object') entry.instructions = {};
+    for (const [mnemonic, details] of mnemonicMap) {
+      if (entry.instructions[mnemonic]) continue; // already set by Pass 1
+      entry.instructions[mnemonic] = details;
+      aliasAddedCount += 1;
+      addedCount += 1;
+    }
+  }
+}
+
 fs.writeFileSync(catalogPath, `${JSON.stringify(extensionsCatalog, null, 2)}\n`);
 
 console.log(`Updated ${path.relative(workspaceRoot, catalogPath)} with ${addedCount} instruction entries.`);
+if (aliasAddedCount > 0) {
+  console.log(`  (${aliasAddedCount} of those came from TAG_ALIASES in sync_instructions.mjs)`);
+}
 if (missingExtensions.size) {
   console.warn(`Extensions referenced in JSX but not found in catalog: ${Array.from(missingExtensions).sort().join(', ')}`);
 }


### PR DESCRIPTION
### Summary

This PR introduces a `TAG_ALIASES` mapping in `sync_instructions.mjs` to resolve naming mismatches between `instr_dict.json` tags and the catalog’s extension IDs.

### Problem

The upstream instruction source uses tags like:

* `rv_f_zfa`
* `rv_zicbo`
* `rv_svinval_h`

These do not match the catalog’s CamelCase IDs (e.g., `Zfa`, `Zicbom`, `Svinval`), causing multiple extensions to remain unpopulated despite having valid instruction data.

### Solution

* Added a `TAG_ALIASES` table to map mismatched tags → correct catalog IDs
* Implemented a **second sync pass** that:

  * Reads instruction data using aliases
  * Fills missing extensions without overriding existing JSX mappings

### Key Behavior

* **Pass 1:** Uses JSX `extensionInstructions` (existing behavior)
* **Pass 2:** Uses `TAG_ALIASES` to fill remaining gaps
* Ensures no duplication or overwrite of existing mappings

### Coverage Impact

* Resolves **16 previously unmapped tags**
* Populates **9 catalog extensions**
* Adds additional instruction entries automatically from `instr_dict.json`

### Aliases Added

* `rv_i`, `rv64_i` → `RV64I` (base integer instructions)
* `rv_system` → `S` (e.g., MRET, WFI)
* `rv_c_d` → `Zcd`
* `rv32_c_f` → `Zcf`
* `rv_svinval_h` → `Svinval`
* `rv_zicbo` → `Zicbom`
* `rv_f/d/q/zfh_zfa` → `Zfa`
* `rv_d/q_zfhmin` → `Zfhmin`
* `rv_zabha_zacas` → `Zabha`

### Impact

* Fixes missing instruction mappings caused by naming inconsistencies
* Improves completeness of the extension catalog
* Reduces need for manual JSX updates

### Testing

* Ran `node scripts/sync_instructions.mjs` successfully
* Verified instruction entries are populated for aliased extensions
* Confirmed no regressions in existing mappings
