### PR TITLE
fix: add a11y focus management to encoder modal

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -582,6 +582,70 @@ const RISCVExplorer = () => {
   const [encoderValidatorCopyStatus, setEncoderValidatorCopyStatus] = useState(null);
   const lastScrolledKeyRef = React.useRef(null);
 
+  const modalRef = React.useRef(null);
+  const previousFocusRef = React.useRef(null);
+
+  React.useEffect(() => {
+    if (encoderValidatorOpen) {
+      previousFocusRef.current = document.activeElement;
+      
+      const handleKeyDown = (e) => {
+        if (e.key === 'Escape') {
+          setEncoderValidatorOpen(false);
+          return;
+        }
+        
+        if (e.key === 'Tab') {
+          if (!modalRef.current) return;
+          
+          const focusableElements = modalRef.current.querySelectorAll(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          );
+          
+          if (focusableElements.length === 0) return;
+          
+          const firstElement = focusableElements[0];
+          const lastElement = focusableElements[focusableElements.length - 1];
+          
+          if (e.shiftKey) {
+            if (document.activeElement === firstElement) {
+              lastElement.focus();
+              e.preventDefault();
+            }
+          } else {
+            if (document.activeElement === lastElement) {
+              firstElement.focus();
+              e.preventDefault();
+            }
+          }
+        }
+      };
+      
+      document.addEventListener('keydown', handleKeyDown);
+      
+      setTimeout(() => {
+        if (modalRef.current) {
+          const focusableElements = modalRef.current.querySelectorAll(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+          );
+          const firstInput = modalRef.current.querySelector('input');
+          if (firstInput) {
+            firstInput.focus();
+          } else if (focusableElements.length > 0) {
+            focusableElements[0].focus();
+          }
+        }
+      }, 10);
+      
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown);
+        if (previousFocusRef.current) {
+          previousFocusRef.current.focus();
+        }
+      };
+    }
+  }, [encoderValidatorOpen]);
+
   // ---------------------------------------------------------------------------
   // Extension Catalog – loaded from `src/riscv_extensions.json`
   // ---------------------------------------------------------------------------
@@ -3359,13 +3423,20 @@ const RISCVExplorer = () => {
 	          />
 
 	          <div className="absolute inset-0 p-3 md:p-8 flex items-start justify-center overflow-y-auto">
-	            <div className="w-full max-w-3xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl overflow-hidden">
+	            <div
+	              ref={modalRef}
+	              role="dialog"
+	              aria-modal="true"
+	              aria-labelledby="encoder-modal-title"
+	              aria-describedby="encoder-modal-desc"
+	              className="w-full max-w-3xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl overflow-hidden"
+	            >
 	              <div className="p-4 border-b border-slate-700 flex items-start justify-between gap-3">
 	                <div className="min-w-0">
-	                  <h3 className="text-sm font-bold text-slate-200 uppercase tracking-wide flex items-center gap-2">
+	                  <h3 id="encoder-modal-title" className="text-sm font-bold text-slate-200 uppercase tracking-wide flex items-center gap-2">
 	                    <ScanSearch size={16} /> Encoder Validator
 	                  </h3>
-	                  <p className="text-xs text-slate-500 mt-1">
+	                  <p id="encoder-modal-desc" className="text-xs text-slate-500 mt-1">
 	                    Provide either a 32-bit Encoding pattern (0/1/-), or Match+Mask (hex). The validator lists any
 	                    existing instructions that overlap.
 	                  </p>


### PR DESCRIPTION
### Description
This PR resolves an accessibility and usability issue with the Encoder Validator modal where users relying on keyboard navigation were unable to interact with or exit the modal efficiently. 

**Resolves Issue:** #56 

### Changes Made
- **Escape Key Support:** Added an `onKeyDown` listener to allow closing the modal using the `Escape` key.
- **Focus Trapping:** Intercepted `Tab` and `Shift+Tab` keys to keep keyboard focus strictly within the dialog while it is open. 
- **Auto-Focus:** Focus is now programmatically shifted to the first input field as soon as the modal is opened.
- **Focus Restoration:** The modal now remembers the trigger element that opened it and restores focus to that element when closed.
- **ARIA Attributes:** Added `role="dialog"`, `aria-modal="true"`, `aria-labelledby`, and `aria-describedby` to the modal container for proper screen reader support.

### How to Test
1. Open the application and navigate to the Encoder Validator button.
2. Open the modal using the `Enter` or `Space` key.
3. Verify that focus jumps immediately to the first input field.
4. Press `Tab` repeatedly and verify that focus loops back to the top when reaching the end of the modal (focus does not escape to the background).
5. Press `Escape` and verify the modal closes.
6. After closing, verify that focus is automatically returned to the Encoder Validator trigger button.
