### PR TITLE
feat(data): map instruction sets for vector crypto bundle extensions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -802,7 +801,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -829,7 +827,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1053,7 +1050,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3002,7 +2998,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3306,7 +3301,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3929,7 +3923,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4059,7 +4052,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -4109,7 +4101,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -102,6 +102,72 @@ function mnemonicToInstrDictKey(mnemonic) {
   return String(mnemonic).trim().toLowerCase().replaceAll('.', '_');
 }
 
+// Prints a full coverage breakdown: overall %, per-category progress bars,
+// and a list of every extension still missing instruction data with a
+// diagnosis of why (no JSX list vs. instrs absent from instr_dict.json).
+// Triggered by passing --report on the command line.
+function printCoverageReport(extensionsCatalog, extensionInstructions) {
+  const totalPerCat = {};
+  const filledPerCat = {};
+  let grandTotal = 0;
+  let grandFilled = 0;
+
+  for (const [category, entries] of Object.entries(extensionsCatalog)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      grandTotal += 1;
+      totalPerCat[category] = (totalPerCat[category] ?? 0) + 1;
+      const count = Object.keys(entry.instructions ?? {}).length;
+      if (count > 0) {
+        grandFilled += 1;
+        filledPerCat[category] = (filledPerCat[category] ?? 0) + 1;
+      }
+    }
+  }
+
+  const pct = grandTotal > 0 ? ((grandFilled / grandTotal) * 100).toFixed(1) : '0.0';
+  console.log('');
+  console.log('=== RISC-V Extensions Landscape — Coverage Report ===');
+  console.log('');
+  console.log(`  Overall: ${grandFilled}/${grandTotal} extensions with instruction data (${pct}%)`);
+  console.log('');
+  console.log('  Category breakdown:');
+
+  const BAR_WIDTH = 20;
+  for (const category of Object.keys(totalPerCat)) {
+    const total = totalPerCat[category] ?? 0;
+    const filled = filledPerCat[category] ?? 0;
+    const catPct = total > 0 ? filled / total : 0;
+    const bar = '#'.repeat(Math.round(catPct * BAR_WIDTH)).padEnd(BAR_WIDTH, '.');
+    const catPctStr = (catPct * 100).toFixed(0).padStart(3);
+    console.log(`    ${category.padEnd(22)} [${bar}] ${String(filled).padStart(3)}/${total} (${catPctStr}%)`);
+  }
+
+  console.log('');
+  console.log('  Extensions without instruction data:');
+
+  const jsxIds = new Set(Object.keys(extensionInstructions));
+  for (const [category, entries] of Object.entries(extensionsCatalog)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      const count = Object.keys(entry.instructions ?? {}).length;
+      if (count === 0) {
+        const diagnosis = jsxIds.has(entry.id)
+          ? '(has JSX list, instrs missing from instr_dict)'
+          : '(no JSX list)';
+        console.log(`    - ${entry.id.padEnd(25)} [${category}]  ${diagnosis}`);
+      }
+    }
+  }
+  console.log('');
+}
+
+// ---- main ------------------------------------------------------------------
+
+const showReport = process.argv.includes('--report');
+
 const workspaceRoot = process.cwd();
 const instrDictPath = path.join(workspaceRoot, 'src', 'instr_dict.json');
 const catalogPath = path.join(workspaceRoot, 'src', 'riscv_extensions.json');
@@ -146,12 +212,16 @@ fs.writeFileSync(catalogPath, `${JSON.stringify(extensionsCatalog, null, 2)}\n`)
 
 console.log(`Updated ${path.relative(workspaceRoot, catalogPath)} with ${addedCount} instruction entries.`);
 if (missingExtensions.size) {
-  console.warn(`Extensions referenced in JSX but not found in YAML: ${Array.from(missingExtensions).sort().join(', ')}`);
+  console.warn(`Extensions referenced in JSX but not found in catalog: ${Array.from(missingExtensions).sort().join(', ')}`);
 }
 if (missingInstructions.size) {
   const sorted = Array.from(missingInstructions.entries()).sort(([a], [b]) => a.localeCompare(b));
-  console.warn('Instructions missing from instr_dict.json (by extension):');
+  console.warn('Instructions listed in JSX but missing from instr_dict.json (by extension):');
   for (const [extId, list] of sorted) {
-    console.warn(`- ${extId}: ${list.length}`);
+    console.warn(`  - ${extId}: ${list.length} missing`);
   }
+}
+
+if (showReport) {
+  printCoverageReport(extensionsCatalog, extensionInstructions);
 }

--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -2,6 +2,59 @@ import fs from 'node:fs';
 import path from 'node:path';
 import vm from 'node:vm';
 
+// ---------------------------------------------------------------------------
+// TAG_ALIASES: maps riscv-opcodes extension tags (used in instr_dict.json)
+// to their canonical catalog IDs (used in riscv_extensions.json).
+//
+// The upstream riscv-opcodes project names extension tags with prefixes like
+// rv_, rv32_, rv64_, and sometimes combines two extension names with an
+// underscore (e.g. rv_f_zfa = "Zfa instructions that also require F").
+// These do not match the catalog's CamelCase IDs, so the sync script cannot
+// link them automatically. This table bridges that gap.
+//
+// How to add an entry:
+//   "<instr_dict tag>": "<catalog extension ID>",
+//
+// Guidelines:
+//   - Use the catalog ID exactly as it appears in riscv_extensions.json.
+//   - For cross-extension tags (e.g. rv_f_zfa = Zfa instructions that also
+//     need F), map to the extension that *defines* those instructions.
+//   - Leave a comment explaining the mapping when it is non-obvious.
+// ---------------------------------------------------------------------------
+const TAG_ALIASES = {
+  // Base integer: rv_i / rv64_i cover the core RV64I instruction set
+  rv_i:              'RV64I',
+  rv64_i:            'RV64I',
+
+  // Supervisor / machine system instructions
+  rv_system:         'S',        // MRET, WFI live under the S (supervisor) group
+
+  // Compressed floating-point subsets
+  rv_c_d:            'Zcd',      // C+D double-precision loads/stores (RV64)
+  rv32_c_f:          'Zcf',      // C+F single-precision loads/stores (RV32 only)
+
+  // Svinval H-mode variant — HINVAL.GVMA / HINVAL.VVMA belong with Svinval
+  rv_svinval_h:      'Svinval',
+
+  // Zicbom: the upstream tag is rv_zicbo (no trailing 'm')
+  rv_zicbo:          'Zicbom',
+
+  // Zfa: additional floating-point instructions spread across F/D/H/Q tags
+  rv_f_zfa:          'Zfa',
+  rv_d_zfa:          'Zfa',
+  rv32_d_zfa:        'Zfa',
+  rv_q_zfa:          'Zfa',
+  rv64_q_zfa:        'Zfa',
+  rv_zfh_zfa:        'Zfa',      // Zfa instructions that also need Zfh
+
+  // Zfhmin: half-precision min subset — conversions between H and D/Q
+  rv_d_zfhmin:       'Zfhmin',
+  rv_q_zfhmin:       'Zfhmin',
+
+  // Zabha: byte/halfword atomics that require Zacas
+  rv_zabha_zacas:    'Zabha',
+};
+
 function die(message) {
   console.error(message);
   process.exit(1);
@@ -102,6 +155,25 @@ function mnemonicToInstrDictKey(mnemonic) {
   return String(mnemonic).trim().toLowerCase().replaceAll('.', '_');
 }
 
+// Reads instr_dict.json and groups instructions by catalog ID using TAG_ALIASES.
+// Returns Map<catalogId, Map<mnemonic, details>>.
+function buildAliasInstructions(instrDict) {
+  const result = new Map();
+
+  for (const [tag, catalogId] of Object.entries(TAG_ALIASES)) {
+    for (const [key, details] of Object.entries(instrDict)) {
+      if (!details.extension || !details.extension.includes(tag)) continue;
+      // Best-effort mnemonic: uppercase the key and replace _ with .
+      const mnemonic = key.toUpperCase().replaceAll('_', '.');
+      const bucket = result.get(catalogId) ?? new Map();
+      bucket.set(mnemonic, details);
+      result.set(catalogId, bucket);
+    }
+  }
+
+  return result;
+}
+
 // Prints a full coverage breakdown: overall %, per-category progress bars,
 // and a list of every extension still missing instruction data with a
 // diagnosis of why (no JSX list vs. instrs absent from instr_dict.json).
@@ -180,10 +252,14 @@ const visualizerSource = fs.readFileSync(visualizerPath, 'utf8');
 const extensionInstructions = extractExtensionInstructions(visualizerSource);
 const extIndex = buildExtensionIndex(extensionsCatalog);
 
+// Build alias-derived instructions from TAG_ALIASES
+const aliasInstructions = buildAliasInstructions(instrDict);
+
 const missingExtensions = new Set();
 const missingInstructions = new Map();
 let addedCount = 0;
 
+// --- Pass 1: JSX mnemonic lists (original behaviour) -----------------------
 for (const [extId, mnemonics] of Object.entries(extensionInstructions)) {
   const locations = extIndex.get(extId);
   if (!locations || locations.length === 0) {
@@ -208,9 +284,30 @@ for (const [extId, mnemonics] of Object.entries(extensionInstructions)) {
   }
 }
 
+// --- Pass 2: TAG_ALIASES — auto-populate from instr_dict tags --------------
+// Runs after Pass 1 so JSX-listed mnemonics always take priority.
+let aliasAddedCount = 0;
+for (const [catalogId, mnemonicMap] of aliasInstructions) {
+  const locations = extIndex.get(catalogId);
+  if (!locations || locations.length === 0) continue;
+
+  for (const { entry } of locations) {
+    if (!entry.instructions || typeof entry.instructions !== 'object') entry.instructions = {};
+    for (const [mnemonic, details] of mnemonicMap) {
+      if (entry.instructions[mnemonic]) continue; // already set by Pass 1
+      entry.instructions[mnemonic] = details;
+      aliasAddedCount += 1;
+      addedCount += 1;
+    }
+  }
+}
+
 fs.writeFileSync(catalogPath, `${JSON.stringify(extensionsCatalog, null, 2)}\n`);
 
 console.log(`Updated ${path.relative(workspaceRoot, catalogPath)} with ${addedCount} instruction entries.`);
+if (aliasAddedCount > 0) {
+  console.log(`  (${aliasAddedCount} of those came from TAG_ALIASES in sync_instructions.mjs)`);
+}
 if (missingExtensions.size) {
   console.warn(`Extensions referenced in JSX but not found in catalog: ${Array.from(missingExtensions).sort().join(', ')}`);
 }

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1762,6 +1762,51 @@ const RISCVExplorer = () => {
       // Vector SM3
       'VSM3C.VI', 'VSM3ME.VV',
     ],
+    // Vector crypto bundles (union of sub-extensions)
+    Zvkb: [
+      // Zvbb subset
+      'VANDN.VV', 'VANDN.VX', 'VBREV8.V', 'VREV8.V',
+      'VROL.VV', 'VROL.VX', 'VROR.VI', 'VROR.VV', 'VROR.VX',
+      'VBREV.V', 'VCLZ.V', 'VCTZ.V', 'VCPOP.V',
+      'VWSLL.VI', 'VWSLL.VV', 'VWSLL.VX',
+      // Zvbc subset
+      'VCLMUL.VV', 'VCLMUL.VX', 'VCLMULH.VV', 'VCLMULH.VX',
+    ],
+    Zvkng: [
+      // Zvkn subset
+      'VAESDF.VS', 'VAESDF.VV', 'VAESDM.VS', 'VAESDM.VV',
+      'VAESEF.VS', 'VAESEF.VV', 'VAESEM.VS', 'VAESEM.VV',
+      'VAESKF1.VI', 'VAESKF2.VI', 'VAESZ.VS',
+      'VSHA2CH.VV', 'VSHA2CL.VV', 'VSHA2MS.VV',
+      'VANDN.VV', 'VANDN.VX', 'VBREV8.V', 'VREV8.V',
+      'VROL.VV', 'VROL.VX', 'VROR.VI', 'VROR.VV', 'VROR.VX',
+      // Zvkg subset
+      'VGHSH.VV', 'VGMUL.VV',
+    ],
+    Zvknc: [
+      // Zvkn + Zvbc
+      'VAESDF.VS', 'VAESDF.VV', 'VAESDM.VS', 'VAESDM.VV',
+      'VAESEF.VS', 'VAESEF.VV', 'VAESEM.VS', 'VAESEM.VV',
+      'VAESKF1.VI', 'VAESKF2.VI', 'VAESZ.VS',
+      'VSHA2CH.VV', 'VSHA2CL.VV', 'VSHA2MS.VV',
+      'VANDN.VV', 'VANDN.VX', 'VBREV8.V', 'VREV8.V',
+      'VROL.VV', 'VROL.VX', 'VROR.VI', 'VROR.VV', 'VROR.VX',
+      'VCLMUL.VV', 'VCLMUL.VX', 'VCLMULH.VV', 'VCLMULH.VX',
+    ],
+    Zvksg: [
+      // Zvks + Zvkg
+      'VSM3C.VI', 'VSM3ME.VV', 'VSM4K.VI', 'VSM4R.VS', 'VSM4R.VV',
+      'VANDN.VV', 'VANDN.VX', 'VBREV8.V', 'VREV8.V',
+      'VROL.VV', 'VROL.VX', 'VROR.VI', 'VROR.VV', 'VROR.VX',
+      'VGHSH.VV', 'VGMUL.VV',
+    ],
+    Zvksc: [
+      // Zvks + Zvbc
+      'VSM3C.VI', 'VSM3ME.VV', 'VSM4K.VI', 'VSM4R.VS', 'VSM4R.VV',
+      'VANDN.VV', 'VANDN.VX', 'VBREV8.V', 'VREV8.V',
+      'VROL.VV', 'VROL.VX', 'VROR.VI', 'VROR.VV', 'VROR.VX',
+      'VCLMUL.VV', 'VCLMUL.VX', 'VCLMULH.VV', 'VCLMULH.VX',
+    ],
 
     // Scalar Cryptography Extensions
     Zbkb: [

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -19451,7 +19451,302 @@
       "name": "Zvkb",
       "desc": "Vector Crypto Bitmanip",
       "use": "Vector crypto bit ops",
-      "url": "https://github.com/riscv/riscv-isa-manual"
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {
+        "VANDN.VV": {
+          "encoding": "000001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4000057",
+          "mask": "0xfc00707f"
+        },
+        "VANDN.VX": {
+          "encoding": "000001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4004057",
+          "mask": "0xfc00707f"
+        },
+        "VBREV8.V": {
+          "encoding": "010010------01000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x48042057",
+          "mask": "0xfc0ff07f"
+        },
+        "VREV8.V": {
+          "encoding": "010010------01001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4804a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VROL.VV": {
+          "encoding": "010101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54000057",
+          "mask": "0xfc00707f"
+        },
+        "VROL.VX": {
+          "encoding": "010101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54004057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VI": {
+          "encoding": "01010------------011-----1010111",
+          "variable_fields": [
+            "zimm6hi",
+            "vm",
+            "vs2",
+            "zimm6lo",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50003057",
+          "mask": "0xf800707f"
+        },
+        "VROR.VV": {
+          "encoding": "010100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50000057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VX": {
+          "encoding": "010100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50004057",
+          "mask": "0xfc00707f"
+        },
+        "VBREV.V": {
+          "encoding": "010010------01010010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb"
+          ],
+          "match": "0x48052057",
+          "mask": "0xfc0ff07f"
+        },
+        "VCLZ.V": {
+          "encoding": "010010------01100010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb"
+          ],
+          "match": "0x48062057",
+          "mask": "0xfc0ff07f"
+        },
+        "VCTZ.V": {
+          "encoding": "010010------01101010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb"
+          ],
+          "match": "0x4806a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VCPOP.V": {
+          "encoding": "010010------01110010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb"
+          ],
+          "match": "0x48072057",
+          "mask": "0xfc0ff07f"
+        },
+        "VWSLL.VI": {
+          "encoding": "110101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb"
+          ],
+          "match": "0xd4003057",
+          "mask": "0xfc00707f"
+        },
+        "VWSLL.VV": {
+          "encoding": "110101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb"
+          ],
+          "match": "0xd4000057",
+          "mask": "0xfc00707f"
+        },
+        "VWSLL.VX": {
+          "encoding": "110101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb"
+          ],
+          "match": "0xd4004057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMUL.VV": {
+          "encoding": "001100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x30002057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMUL.VX": {
+          "encoding": "001100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x30006057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMULH.VV": {
+          "encoding": "001101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x34002057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMULH.VX": {
+          "encoding": "001101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x34006057",
+          "mask": "0xfc00707f"
+        }
+      }
     },
     {
       "id": "Zvkg",
@@ -19506,7 +19801,398 @@
       "name": "Zvknc",
       "desc": "Vector NIST + CLMUL",
       "use": "NIST crypto with carryless multiply",
-      "url": "https://github.com/riscv/riscv-isa-manual"
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {
+        "VAESDF.VS": {
+          "encoding": "1010011-----00001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa600a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDF.VV": {
+          "encoding": "1010001-----00001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa200a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDM.VS": {
+          "encoding": "1010011-----00000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa6002077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDM.VV": {
+          "encoding": "1010001-----00000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa2002077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEF.VS": {
+          "encoding": "1010011-----00011010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa601a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEF.VV": {
+          "encoding": "1010001-----00011010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa201a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEM.VS": {
+          "encoding": "1010011-----00010010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa6012077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEM.VV": {
+          "encoding": "1010001-----00010010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa2012077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESKF1.VI": {
+          "encoding": "1000101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0x8a002077",
+          "mask": "0xfe00707f"
+        },
+        "VAESKF2.VI": {
+          "encoding": "1010101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xaa002077",
+          "mask": "0xfe00707f"
+        },
+        "VAESZ.VS": {
+          "encoding": "1010011-----00111010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa603a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VSHA2CH.VV": {
+          "encoding": "1011101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xba002077",
+          "mask": "0xfe00707f"
+        },
+        "VSHA2CL.VV": {
+          "encoding": "1011111----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xbe002077",
+          "mask": "0xfe00707f"
+        },
+        "VSHA2MS.VV": {
+          "encoding": "1011011----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xb6002077",
+          "mask": "0xfe00707f"
+        },
+        "VANDN.VV": {
+          "encoding": "000001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4000057",
+          "mask": "0xfc00707f"
+        },
+        "VANDN.VX": {
+          "encoding": "000001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4004057",
+          "mask": "0xfc00707f"
+        },
+        "VBREV8.V": {
+          "encoding": "010010------01000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x48042057",
+          "mask": "0xfc0ff07f"
+        },
+        "VREV8.V": {
+          "encoding": "010010------01001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4804a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VROL.VV": {
+          "encoding": "010101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54000057",
+          "mask": "0xfc00707f"
+        },
+        "VROL.VX": {
+          "encoding": "010101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54004057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VI": {
+          "encoding": "01010------------011-----1010111",
+          "variable_fields": [
+            "zimm6hi",
+            "vm",
+            "vs2",
+            "zimm6lo",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50003057",
+          "mask": "0xf800707f"
+        },
+        "VROR.VV": {
+          "encoding": "010100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50000057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VX": {
+          "encoding": "010100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50004057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMUL.VV": {
+          "encoding": "001100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x30002057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMUL.VX": {
+          "encoding": "001100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x30006057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMULH.VV": {
+          "encoding": "001101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x34002057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMULH.VX": {
+          "encoding": "001101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x34006057",
+          "mask": "0xfc00707f"
+        }
+      }
     },
     {
       "id": "Zvkned",
@@ -19674,7 +20360,367 @@
       "name": "Zvkng",
       "desc": "Vector NIST + GCM",
       "use": "NIST suite + GCM vector bundle",
-      "url": "https://github.com/riscv/riscv-isa-manual"
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {
+        "VAESDF.VS": {
+          "encoding": "1010011-----00001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa600a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDF.VV": {
+          "encoding": "1010001-----00001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa200a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDM.VS": {
+          "encoding": "1010011-----00000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa6002077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDM.VV": {
+          "encoding": "1010001-----00000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa2002077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEF.VS": {
+          "encoding": "1010011-----00011010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa601a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEF.VV": {
+          "encoding": "1010001-----00011010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa201a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEM.VS": {
+          "encoding": "1010011-----00010010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa6012077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEM.VV": {
+          "encoding": "1010001-----00010010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa2012077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESKF1.VI": {
+          "encoding": "1000101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0x8a002077",
+          "mask": "0xfe00707f"
+        },
+        "VAESKF2.VI": {
+          "encoding": "1010101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xaa002077",
+          "mask": "0xfe00707f"
+        },
+        "VAESZ.VS": {
+          "encoding": "1010011-----00111010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa603a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VSHA2CH.VV": {
+          "encoding": "1011101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xba002077",
+          "mask": "0xfe00707f"
+        },
+        "VSHA2CL.VV": {
+          "encoding": "1011111----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xbe002077",
+          "mask": "0xfe00707f"
+        },
+        "VSHA2MS.VV": {
+          "encoding": "1011011----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xb6002077",
+          "mask": "0xfe00707f"
+        },
+        "VANDN.VV": {
+          "encoding": "000001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4000057",
+          "mask": "0xfc00707f"
+        },
+        "VANDN.VX": {
+          "encoding": "000001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4004057",
+          "mask": "0xfc00707f"
+        },
+        "VBREV8.V": {
+          "encoding": "010010------01000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x48042057",
+          "mask": "0xfc0ff07f"
+        },
+        "VREV8.V": {
+          "encoding": "010010------01001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4804a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VROL.VV": {
+          "encoding": "010101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54000057",
+          "mask": "0xfc00707f"
+        },
+        "VROL.VX": {
+          "encoding": "010101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54004057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VI": {
+          "encoding": "01010------------011-----1010111",
+          "variable_fields": [
+            "zimm6hi",
+            "vm",
+            "vs2",
+            "zimm6lo",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50003057",
+          "mask": "0xf800707f"
+        },
+        "VROR.VV": {
+          "encoding": "010100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50000057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VX": {
+          "encoding": "010100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50004057",
+          "mask": "0xfc00707f"
+        },
+        "VGHSH.VV": {
+          "encoding": "1011001----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkg"
+          ],
+          "match": "0xb2002077",
+          "mask": "0xfe00707f"
+        },
+        "VGMUL.VV": {
+          "encoding": "1010001-----10001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkg"
+          ],
+          "match": "0xa208a077",
+          "mask": "0xfe0ff07f"
+        }
+      }
     },
     {
       "id": "Zvknha",
@@ -19796,7 +20842,276 @@
       "name": "Zvksc",
       "desc": "Vector ShangMi + CLMUL",
       "use": "SMx with carryless multiply",
-      "url": "https://github.com/riscv/riscv-isa-manual"
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {
+        "VSM3C.VI": {
+          "encoding": "1010111----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksh",
+            "rv_zvks"
+          ],
+          "match": "0xae002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM3ME.VV": {
+          "encoding": "1000001----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksh",
+            "rv_zvks"
+          ],
+          "match": "0x82002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM4K.VI": {
+          "encoding": "1000011----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0x86002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM4R.VS": {
+          "encoding": "1010011-----10000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0xa6082077",
+          "mask": "0xfe0ff07f"
+        },
+        "VSM4R.VV": {
+          "encoding": "1010001-----10000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0xa2082077",
+          "mask": "0xfe0ff07f"
+        },
+        "VANDN.VV": {
+          "encoding": "000001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4000057",
+          "mask": "0xfc00707f"
+        },
+        "VANDN.VX": {
+          "encoding": "000001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4004057",
+          "mask": "0xfc00707f"
+        },
+        "VBREV8.V": {
+          "encoding": "010010------01000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x48042057",
+          "mask": "0xfc0ff07f"
+        },
+        "VREV8.V": {
+          "encoding": "010010------01001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4804a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VROL.VV": {
+          "encoding": "010101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54000057",
+          "mask": "0xfc00707f"
+        },
+        "VROL.VX": {
+          "encoding": "010101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54004057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VI": {
+          "encoding": "01010------------011-----1010111",
+          "variable_fields": [
+            "zimm6hi",
+            "vm",
+            "vs2",
+            "zimm6lo",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50003057",
+          "mask": "0xf800707f"
+        },
+        "VROR.VV": {
+          "encoding": "010100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50000057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VX": {
+          "encoding": "010100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50004057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMUL.VV": {
+          "encoding": "001100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x30002057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMUL.VX": {
+          "encoding": "001100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x30006057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMULH.VV": {
+          "encoding": "001101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x34002057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMULH.VX": {
+          "encoding": "001101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x34006057",
+          "mask": "0xfc00707f"
+        }
+      }
     },
     {
       "id": "Zvksed",
@@ -19852,7 +21167,245 @@
       "name": "Zvksg",
       "desc": "Vector ShangMi + GCM",
       "use": "ShangMi + GCM vectors",
-      "url": "https://github.com/riscv/riscv-isa-manual"
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {
+        "VSM3C.VI": {
+          "encoding": "1010111----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksh",
+            "rv_zvks"
+          ],
+          "match": "0xae002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM3ME.VV": {
+          "encoding": "1000001----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksh",
+            "rv_zvks"
+          ],
+          "match": "0x82002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM4K.VI": {
+          "encoding": "1000011----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0x86002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM4R.VS": {
+          "encoding": "1010011-----10000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0xa6082077",
+          "mask": "0xfe0ff07f"
+        },
+        "VSM4R.VV": {
+          "encoding": "1010001-----10000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0xa2082077",
+          "mask": "0xfe0ff07f"
+        },
+        "VANDN.VV": {
+          "encoding": "000001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4000057",
+          "mask": "0xfc00707f"
+        },
+        "VANDN.VX": {
+          "encoding": "000001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4004057",
+          "mask": "0xfc00707f"
+        },
+        "VBREV8.V": {
+          "encoding": "010010------01000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x48042057",
+          "mask": "0xfc0ff07f"
+        },
+        "VREV8.V": {
+          "encoding": "010010------01001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4804a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VROL.VV": {
+          "encoding": "010101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54000057",
+          "mask": "0xfc00707f"
+        },
+        "VROL.VX": {
+          "encoding": "010101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54004057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VI": {
+          "encoding": "01010------------011-----1010111",
+          "variable_fields": [
+            "zimm6hi",
+            "vm",
+            "vs2",
+            "zimm6lo",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50003057",
+          "mask": "0xf800707f"
+        },
+        "VROR.VV": {
+          "encoding": "010100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50000057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VX": {
+          "encoding": "010100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50004057",
+          "mask": "0xfc00707f"
+        },
+        "VGHSH.VV": {
+          "encoding": "1011001----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkg"
+          ],
+          "match": "0xb2002077",
+          "mask": "0xfe00707f"
+        },
+        "VGMUL.VV": {
+          "encoding": "1010001-----10001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkg"
+          ],
+          "match": "0xa208a077",
+          "mask": "0xfe0ff07f"
+        }
+      }
     },
     {
       "id": "Zvksh",


### PR DESCRIPTION
Description

This PR adds instruction mappings for vector crypto bundle extensions in the z_vector_crypto category.

These extensions are not standalone instruction sets; they are defined in the RISC-V Vector Crypto specification as compositions of existing sub-extensions. Their instruction sets are therefore implemented as the union of their respective components.

The following bundle extensions are added:

Zvkb = Zvbb + Zvbc
Zvkng = Zvkn + Zvkg
Zvknc = Zvkn + Zvbc
Zvksg = Zvks + Zvkg
Zvksc = Zvks + Zvbc

Each extension has been mapped by aggregating instructions from its already-supported base extensions, ensuring consistency with the spec and avoiding duplication of logic.

Changes Made
Updated src/risc_v_visualizer.jsx to include:
Zvkb
Zvkng
Zvknc
Zvksg
Zvksc
Populated instruction sets as unions of corresponding sub-extensions
Ran node scripts/sync_instructions.mjs to sync generated data