### PR TITLE
fix(sync): clear stale instruction mappings during catalog sync

### DIFF
--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -126,7 +126,9 @@ for (const [extId, mnemonics] of Object.entries(extensionInstructions)) {
   }
 
   for (const { entry } of locations) {
-    if (!entry.instructions || typeof entry.instructions !== 'object') entry.instructions = {};
+    // Rebuild per-extension instruction map on each sync run so removed mnemonics
+    // do not persist as stale entries in riscv_extensions.json.
+    const nextInstructions = {};
     for (const mnemonic of mnemonics) {
       const key = mnemonicToInstrDictKey(mnemonic);
       const details = instrDict[key];
@@ -136,9 +138,10 @@ for (const [extId, mnemonics] of Object.entries(extensionInstructions)) {
         missingInstructions.set(extId, missing);
         continue;
       }
-      entry.instructions[mnemonic] = details;
+      nextInstructions[mnemonic] = details;
       addedCount += 1;
     }
+    entry.instructions = nextInstructions;
   }
 }
 


### PR DESCRIPTION
## Summary
- Reworked `scripts/sync_instructions.mjs` to rebuild each extension's `instructions` object from current `extensionInstructions` mappings on every sync run.
- Prevented stale instruction entries from persisting in `src/riscv_extensions.json` after mnemonics are removed or reassigned.
- Preserved existing missing-extension and missing-instruction reporting behavior.

## Why
The previous sync logic mutated existing instruction maps in place and only added/overwrote keys.
When a mnemonic was removed from `extensionInstructions`, its old entry could remain in the catalog, causing stale UI/search/validation data.

## Test plan
- [x] Run `node --check scripts/sync_instructions.mjs`.
- [x] Temporarily remove one mnemonic from an extension in `extensionInstructions`.
- [x] Run sync and verify that mnemonic is removed from that extension’s `instructions` in `src/riscv_extensions.json`.
- [x] Restore mnemonic, rerun sync, verify it is re-added.
- [x] Run sync twice with no input changes to confirm deterministic output behavior.