### PR TITLE
feat: add Zvkn and Zvks vector crypto instruction mappings

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1737,6 +1737,20 @@ const RISCVExplorer = () => {
       // Vector GCM/GMAC
       'VGHSH.VV', 'VGMUL.VV',
     ],
+    Zvkn: [
+      // Vector NIST suite (AES + SHA + bitmanip)
+      'VAESDF.VS', 'VAESDF.VV',
+      'VAESDM.VS', 'VAESDM.VV',
+      'VAESEF.VS', 'VAESEF.VV',
+      'VAESEM.VS', 'VAESEM.VV',
+      'VAESKF1.VI', 'VAESKF2.VI',
+      'VAESZ.VS',
+      'VANDN.VV', 'VANDN.VX',
+      'VBREV8.V', 'VREV8.V',
+      'VROL.VV', 'VROL.VX',
+      'VROR.VI', 'VROR.VV', 'VROR.VX',
+      'VSHA2CH.VV', 'VSHA2CL.VV', 'VSHA2MS.VV',
+    ],
     Zvkned: [
       // Vector AES
       'VAESDF.VV', 'VAESDF.VS',
@@ -1753,6 +1767,15 @@ const RISCVExplorer = () => {
     Zvknhb: [
       // Vector SHA-256/512
       'VSHA2MS.VV', 'VSHA2CH.VV', 'VSHA2CL.VV',
+    ],
+    Zvks: [
+      // Vector ShangMi suite (SM4 + SM3 + bitmanip)
+      'VANDN.VV', 'VANDN.VX',
+      'VBREV8.V', 'VREV8.V',
+      'VROL.VV', 'VROL.VX',
+      'VROR.VI', 'VROR.VV', 'VROR.VX',
+      'VSM3C.VI', 'VSM3ME.VV',
+      'VSM4K.VI', 'VSM4R.VS', 'VSM4R.VV',
     ],
     Zvksed: [
       // Vector SM4

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -19499,7 +19499,342 @@
       "name": "Zvkn",
       "desc": "Vector NIST Suite",
       "use": "Vector AES/SHA suite",
-      "url": "https://github.com/riscv/riscv-isa-manual"
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {
+        "VAESDF.VS": {
+          "encoding": "1010011-----00001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa600a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDF.VV": {
+          "encoding": "1010001-----00001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa200a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDM.VS": {
+          "encoding": "1010011-----00000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa6002077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDM.VV": {
+          "encoding": "1010001-----00000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa2002077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEF.VS": {
+          "encoding": "1010011-----00011010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa601a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEF.VV": {
+          "encoding": "1010001-----00011010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa201a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEM.VS": {
+          "encoding": "1010011-----00010010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa6012077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEM.VV": {
+          "encoding": "1010001-----00010010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa2012077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESKF1.VI": {
+          "encoding": "1000101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0x8a002077",
+          "mask": "0xfe00707f"
+        },
+        "VAESKF2.VI": {
+          "encoding": "1010101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xaa002077",
+          "mask": "0xfe00707f"
+        },
+        "VAESZ.VS": {
+          "encoding": "1010011-----00111010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa603a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VANDN.VV": {
+          "encoding": "000001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4000057",
+          "mask": "0xfc00707f"
+        },
+        "VANDN.VX": {
+          "encoding": "000001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4004057",
+          "mask": "0xfc00707f"
+        },
+        "VBREV8.V": {
+          "encoding": "010010------01000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x48042057",
+          "mask": "0xfc0ff07f"
+        },
+        "VREV8.V": {
+          "encoding": "010010------01001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4804a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VROL.VV": {
+          "encoding": "010101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54000057",
+          "mask": "0xfc00707f"
+        },
+        "VROL.VX": {
+          "encoding": "010101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54004057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VI": {
+          "encoding": "01010------------011-----1010111",
+          "variable_fields": [
+            "zimm6hi",
+            "vm",
+            "vs2",
+            "zimm6lo",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50003057",
+          "mask": "0xf800707f"
+        },
+        "VROR.VV": {
+          "encoding": "010100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50000057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VX": {
+          "encoding": "010100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50004057",
+          "mask": "0xfc00707f"
+        },
+        "VSHA2CH.VV": {
+          "encoding": "1011101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xba002077",
+          "mask": "0xfe00707f"
+        },
+        "VSHA2CL.VV": {
+          "encoding": "1011111----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xbe002077",
+          "mask": "0xfe00707f"
+        },
+        "VSHA2MS.VV": {
+          "encoding": "1011011----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xb6002077",
+          "mask": "0xfe00707f"
+        }
+      }
     },
     {
       "id": "Zvknc",
@@ -19789,7 +20124,220 @@
       "name": "Zvks",
       "desc": "Vector ShangMi Suite",
       "use": "Vector SMx algorithms",
-      "url": "https://github.com/riscv/riscv-isa-manual"
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {
+        "VANDN.VV": {
+          "encoding": "000001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4000057",
+          "mask": "0xfc00707f"
+        },
+        "VANDN.VX": {
+          "encoding": "000001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4004057",
+          "mask": "0xfc00707f"
+        },
+        "VBREV8.V": {
+          "encoding": "010010------01000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x48042057",
+          "mask": "0xfc0ff07f"
+        },
+        "VREV8.V": {
+          "encoding": "010010------01001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4804a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VROL.VV": {
+          "encoding": "010101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54000057",
+          "mask": "0xfc00707f"
+        },
+        "VROL.VX": {
+          "encoding": "010101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54004057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VI": {
+          "encoding": "01010------------011-----1010111",
+          "variable_fields": [
+            "zimm6hi",
+            "vm",
+            "vs2",
+            "zimm6lo",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50003057",
+          "mask": "0xf800707f"
+        },
+        "VROR.VV": {
+          "encoding": "010100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50000057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VX": {
+          "encoding": "010100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50004057",
+          "mask": "0xfc00707f"
+        },
+        "VSM3C.VI": {
+          "encoding": "1010111----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksh",
+            "rv_zvks"
+          ],
+          "match": "0xae002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM3ME.VV": {
+          "encoding": "1000001----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksh",
+            "rv_zvks"
+          ],
+          "match": "0x82002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM4K.VI": {
+          "encoding": "1000011----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0x86002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM4R.VS": {
+          "encoding": "1010011-----10000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0xa6082077",
+          "mask": "0xfe0ff07f"
+        },
+        "VSM4R.VV": {
+          "encoding": "1010001-----10000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0xa2082077",
+          "mask": "0xfe0ff07f"
+        }
+      }
     },
     {
       "id": "Zvksc",


### PR DESCRIPTION
## What
Adds instruction mappings for two vector cryptography extensions 
that were missing from `extensionInstructions` in the visualizer:

- **Zvkn** (Vector NIST Suite) — 23 instructions: AES encrypt/decrypt, 
  SHA-2, and bitmanip (VANDN, VBREV8, VROL, VROR)
- **Zvks** (Vector ShangMi Suite) — 14 instructions: SM4, SM3, 
  and bitmanip

## Why
Both extensions existed in the catalog (`riscv_extensions.json`) 
and had full encoding data in `instr_dict.json`, but were not 
registered in `extensionInstructions`, so the sync script never 
populated them. They showed as empty in the UI.

## How to verify
```bash
node scripts/sync_instructions.mjs
```
Sync completes with zero warnings. Both extensions now show 
full instruction data in the landscape UI.

## Related
Part of the effort to map the remaining extensions that 
currently show no instruction data.