### PR TITLE
use debouncedQuery in ExtensionBlock renders to eliminate per-keystroke grid re-renders

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,29 +4,31 @@
   "description": "",
   "main": "index.js",
   "homepage": "https://rpsene.github.io/riscv-extensions-landscape/",
-"scripts": {
-  "build": "webpack",
-  "predeploy": "npm run build",
-  "deploy": "gh-pages -d dist --branch gh-pages --dotfiles",
-  "test": "echo \"Error: no test specified\" && exit 1"
-},
+  "scripts": {
+    "dev": "webpack serve --mode development",
+    "build": "webpack",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist --branch gh-pages --dotfiles",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "gh-pages": "^6.0.0",
     "@babel/core": "^7.23.0",
     "@babel/preset-react": "^7.22.0",
     "autoprefixer": "^10.4.16",
     "babel-loader": "^9.1.3",
     "css-loader": "^6.8.1",
+    "gh-pages": "^6.0.0",
     "html-webpack-plugin": "^5.5.4",
     "postcss": "^8.4.32",
     "postcss-loader": "^7.3.4",
     "style-loader": "^3.3.3",
     "tailwindcss": "^3.4.0",
     "webpack": "^5.89.0",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.2.3"
   },
   "dependencies": {
     "lucide-react": "^0.294.0",

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -2642,7 +2642,7 @@ const RISCVExplorer = () => {
                 <ExtensionBlock
                   key={item.id}
                   data={item}
-                  searchQuery={searchQuery}
+                  searchQuery={debouncedQuery}
                   colorClass="bg-blue-950 border-blue-800 text-blue-100"
                 />
               ))}
@@ -2659,7 +2659,7 @@ const RISCVExplorer = () => {
 	                <ExtensionBlock
                   key={item.id}
                   data={item}
-                  searchQuery={searchQuery}
+                  searchQuery={debouncedQuery}
                   colorClass="bg-emerald-950 border-emerald-800 text-emerald-100"
                 />
               ))}
@@ -2677,7 +2677,7 @@ const RISCVExplorer = () => {
 	                  <ExtensionBlock
                     key={item.id}
                     data={item}
-                    searchQuery={searchQuery}
+                    searchQuery={debouncedQuery}
                     colorClass="bg-purple-950/50 border-purple-800/50 text-purple-100"
                   />
                 ))}
@@ -2693,7 +2693,7 @@ const RISCVExplorer = () => {
 	                  <ExtensionBlock
 	                    key={item.id}
 	                    data={item}
-	                    searchQuery={searchQuery}
+	                    searchQuery={debouncedQuery}
 	                    colorClass="bg-amber-950/40 border-amber-800/50 text-amber-100"
 	                  />
 	                ))}
@@ -2709,7 +2709,7 @@ const RISCVExplorer = () => {
 	                  <ExtensionBlock
 	                    key={item.id}
                     data={item}
-                    searchQuery={searchQuery}
+                    searchQuery={debouncedQuery}
                     colorClass="bg-indigo-950/50 border-indigo-800/50 text-indigo-100"
                   />
                 ))}
@@ -2725,7 +2725,7 @@ const RISCVExplorer = () => {
                   <ExtensionBlock
                     key={item.id}
                     data={item}
-                    searchQuery={searchQuery}
+                    searchQuery={debouncedQuery}
                     colorClass="bg-pink-950/50 border-pink-800/50 text-pink-100"
                   />
                 ))}
@@ -2741,7 +2741,7 @@ const RISCVExplorer = () => {
 		                  <ExtensionBlock
 		                    key={item.id}
 		                    data={item}
-		                    searchQuery={searchQuery}
+		                    searchQuery={debouncedQuery}
 		                    colorClass="bg-sky-950/40 border-sky-800/40 text-sky-100"
 		                  />
 		                ))}
@@ -2757,7 +2757,7 @@ const RISCVExplorer = () => {
 		                  <ExtensionBlock
 		                    key={item.id}
 		                    data={item}
-		                    searchQuery={searchQuery}
+		                    searchQuery={debouncedQuery}
 		                    colorClass="bg-fuchsia-950/40 border-fuchsia-800/40 text-fuchsia-100"
 		                  />
 		                ))}
@@ -2773,7 +2773,7 @@ const RISCVExplorer = () => {
                   <ExtensionBlock
                     key={item.id}
                     data={item}
-                    searchQuery={searchQuery}
+                    searchQuery={debouncedQuery}
                     colorClass="bg-teal-950/50 border-teal-800/50 text-teal-100"
                   />
                 ))}
@@ -2789,7 +2789,7 @@ const RISCVExplorer = () => {
 	                  <ExtensionBlock
                     key={item.id}
                     data={item}
-                    searchQuery={searchQuery}
+                    searchQuery={debouncedQuery}
                     colorClass="bg-red-950/50 border-red-800/50 text-red-100"
                   />
                 ))}
@@ -2805,7 +2805,7 @@ const RISCVExplorer = () => {
 	                  <ExtensionBlock
                     key={item.id}
                     data={item}
-                    searchQuery={searchQuery}
+                    searchQuery={debouncedQuery}
                     colorClass="bg-slate-800 border-slate-600 text-slate-300"
                   />
                 ))}
@@ -2821,7 +2821,7 @@ const RISCVExplorer = () => {
 	                  <ExtensionBlock
 	                    key={item.id}
 	                    data={item}
-	                    searchQuery={searchQuery}
+	                    searchQuery={debouncedQuery}
 	                    colorClass="bg-violet-950/40 border-violet-800/40 text-violet-100"
 	                  />
 	                ))}
@@ -2837,7 +2837,7 @@ const RISCVExplorer = () => {
 	                  <ExtensionBlock
 	                    key={item.id}
 	                    data={item}
-	                    searchQuery={searchQuery}
+	                    searchQuery={debouncedQuery}
 	                    colorClass="bg-orange-950/50 border-orange-800/50 text-orange-100"
 	                  />
 	                ))}
@@ -2853,7 +2853,7 @@ const RISCVExplorer = () => {
 	                  <ExtensionBlock
 	                    key={item.id}
 	                    data={item}
-	                    searchQuery={searchQuery}
+	                    searchQuery={debouncedQuery}
 	                    colorClass="bg-orange-950/30 border-orange-700/30 text-orange-100"
 	                  />
 	                ))}
@@ -2874,7 +2874,7 @@ const RISCVExplorer = () => {
                     <ExtensionBlock
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchQuery={debouncedQuery}
                       colorClass="bg-cyan-950/30 border-cyan-800/30 text-cyan-100"
                     />
                   ))}
@@ -2887,7 +2887,7 @@ const RISCVExplorer = () => {
                     <ExtensionBlock
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchQuery={debouncedQuery}
                       colorClass="bg-cyan-950/30 border-cyan-800/30 text-cyan-100"
                     />
                   ))}
@@ -2902,7 +2902,7 @@ const RISCVExplorer = () => {
                     <ExtensionBlock
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchQuery={debouncedQuery}
                       colorClass="bg-cyan-950/30 border-cyan-800/30 text-cyan-100"
                     />
                   ))}


### PR DESCRIPTION
## Description

Fixes a performance issue where all 222 `<ExtensionBlock>` components
re-rendered on every single keystroke during search input.

The raw `searchQuery` state was passed to every tile in the grid, forcing
React to reconcile the entire component tree on each input change — causing
noticeable typing lag and UI slowdown.

## Changes Made

- Replaced `searchQuery={searchQuery}` with `searchQuery={debouncedQuery}`
  across all `<ExtensionBlock>` usages in the extension grid
- Tile highlights now update only after the 300ms debounce settles,
  eliminating unnecessary per-keystroke re-renders

## Related Issues

Resolves #51

## Testing

- [x] Verified grid tiles no longer re-render on every keystroke
- [x] Verified tile highlights update correctly after debounce completes
- [x] Build compiles successfully with no errors