### PR TITLE
fix: add Svinval, Sdext, Smrnmi, Ssctr, Zibi to extensionInstructions — 8 instructions were silently unreachable

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1929,6 +1929,29 @@ const RISCVExplorer = () => {
       'ECALL',
       'EBREAK',
     ],
+    // Supervisor memory management — virtual address invalidation (Volume II)
+    Svinval: [
+      'SINVAL.VMA',
+      'SFENCE.W.INVAL',
+      'SFENCE.INVAL.IR',
+    ],
+    // Debug extension — debug-mode return
+    Sdext: [
+      'DRET',
+    ],
+    // Non-maskable interrupt return
+    Smrnmi: [
+      'MNRET',
+    ],
+    // Supervisor counter-timer — clear shadow counter
+    Ssctr: [
+      'SCTRCLR',
+    ],
+    // Immediate branch (Zibi — Integer Branch Immediate)
+    Zibi: [
+      'BEQI',
+      'BNEI',
+    ],
   };
 
   const extensionCsrs = {

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -20239,7 +20239,35 @@
       "name": "Zibi",
       "desc": "Interruptible Mem Ops",
       "use": "Interruptible load/store semantics",
-      "url": "https://github.com/riscv/riscv-isa-manual"
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {
+        "BEQI": {
+          "encoding": "-----------------010-----1100011",
+          "variable_fields": [
+            "imm12hi",
+            "imm5",
+            "imm12lo"
+          ],
+          "extension": [
+            "rv_zibi"
+          ],
+          "match": "0x2063",
+          "mask": "0x707f"
+        },
+        "BNEI": {
+          "encoding": "-----------------011-----1100011",
+          "variable_fields": [
+            "imm12hi",
+            "imm5",
+            "imm12lo"
+          ],
+          "extension": [
+            "rv_zibi"
+          ],
+          "match": "0x3063",
+          "mask": "0x707f"
+        }
+      }
     },
     {
       "id": "Zicntr",
@@ -20610,7 +20638,39 @@
       "name": "Svinval",
       "desc": "Fine-Grained TLB Invalidate",
       "use": "Fine-grain TLB shootdown instructions",
-      "url": "https://github.com/riscv/riscv-isa-manual"
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {
+        "SINVAL.VMA": {
+          "encoding": "0001011----------000000001110011",
+          "variable_fields": [
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_svinval"
+          ],
+          "match": "0x16000073",
+          "mask": "0xfe007fff"
+        },
+        "SFENCE.W.INVAL": {
+          "encoding": "00011000000000000000000001110011",
+          "variable_fields": [],
+          "extension": [
+            "rv_svinval"
+          ],
+          "match": "0x18000073",
+          "mask": "0xffffffff"
+        },
+        "SFENCE.INVAL.IR": {
+          "encoding": "00011000000100000000000001110011",
+          "variable_fields": [],
+          "extension": [
+            "rv_svinval"
+          ],
+          "match": "0x18100073",
+          "mask": "0xffffffff"
+        }
+      }
     },
     {
       "id": "Svade",
@@ -20801,7 +20861,18 @@
       "name": "Smrnmi",
       "desc": "Resumable NMI",
       "use": "Restartable non-maskable interrupts",
-      "url": "https://github.com/riscv/riscv-isa-manual"
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {
+        "MNRET": {
+          "encoding": "01110000001000000000000001110011",
+          "variable_fields": [],
+          "extension": [
+            "rv_smrnmi"
+          ],
+          "match": "0x70200073",
+          "mask": "0xffffffff"
+        }
+      }
     }
   ],
   "s_trap": [
@@ -20810,7 +20881,18 @@
       "name": "Sdext",
       "desc": "External Debug",
       "use": "External debug architecture",
-      "url": "https://github.com/riscv/riscv-isa-manual"
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {
+        "DRET": {
+          "encoding": "01111011001000000000000001110011",
+          "variable_fields": [],
+          "extension": [
+            "rv_sdext"
+          ],
+          "match": "0x7b200073",
+          "mask": "0xffffffff"
+        }
+      }
     },
     {
       "id": "Sdtrig",
@@ -20859,7 +20941,18 @@
       "name": "Ssctr",
       "desc": "Control Transfer Records (S)",
       "use": "Hardware CFI logs (S)",
-      "url": "https://github.com/riscv/riscv-isa-manual"
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {
+        "SCTRCLR": {
+          "encoding": "00010000010000000000000001110011",
+          "variable_fields": [],
+          "extension": [
+            "rv_ssctr"
+          ],
+          "match": "0x10400073",
+          "mask": "0xffffffff"
+        }
+      }
     },
     {
       "id": "Sddbltrp",


### PR DESCRIPTION
## Summary

Adds 5 missing extensions to the `extensionInstructions` mapping in
`risc_v_visualizer.jsx` so `sync_instructions.mjs` can populate their
instruction data from `instr_dict.json`.

Closes #81

## Root Cause

`sync_instructions.mjs` only iterates over keys present in
`extensionInstructions`. These 5 catalog IDs were completely absent
from that mapping — no error, no warning, just silent data loss.
All 8 instructions existed in `instr_dict.json` with correct encodings.

## Changes

**`src/risc_v_visualizer.jsx`** — added to `extensionInstructions`:

```javascript
// Supervisor memory management — virtual address invalidation (Volume II)
Svinval: ['SINVAL.VMA', 'SFENCE.W.INVAL', 'SFENCE.INVAL.IR'],

// Debug extension — debug-mode return
Sdext: ['DRET'],

// Non-maskable interrupt return
Smrnmi: ['MNRET'],

// Supervisor counter-timer — clear shadow counter
Ssctr: ['SCTRCLR'],

// Immediate branch (Zibi — Integer Branch Immediate)
Zibi: ['BEQI', 'BNEI'],
```

**`src/riscv_extensions.json`** — auto-updated by sync script

## Before / After

| Extension | Before | After |
|-----------|--------|-------|
| Svinval | 0 | 3 (SINVAL.VMA, SFENCE.W.INVAL, SFENCE.INVAL.IR) |
| Sdext | 0 | 1 (DRET) |
| Smrnmi | 0 | 1 MNRET) |
| Ssctr | 0 | 1 (SCTRCLR) |
| Zibi | 0 | 2 (BEQI, BNEI) |

**Catalog total: 1416 → 1424 instruction entries (+8 restored)**

## Testing

```bash
node scripts/sync_instructions.mjs
# Updated src/riscv_extensions.json with 1424 instruction entries.

npm run build
python3 -m http.server 8080 -d dist
# Search Svinval → 3 instructions visible
# Search Sdext   → DRET visible
# Search Smrnmi  → MNRET visible
# Search Ssctr   → SCTRCLR visible
# Search Zibi    → BEQI + BNEI visible
```

## Relation to LFX Mentorship Task B

This fix contributes to the mentorship goal of mapping supervisor-level
extensions (s_mem, s_interrupt, s_trap groups). These extensions had
all required data already present in `instr_dict.json` — they just
needed to be registered in `extensionInstructions` to become reachable.