### PR TITLE
analysis: extension tag reconciliation report

### DIFF
--- a/analysis/README.md
+++ b/analysis/README.md
@@ -1,0 +1,17 @@
+# Analysis Artifacts
+
+This directory contains reproducible analysis artifacts for PR #1.
+
+## Files
+
+- `TAG_RECONCILIATION_REPORT.md`: Human-readable extension tag reconciliation report.
+- `results.json`: Machine-readable reconciliation output used by downstream tooling.
+
+## Reproduction
+
+Run the reconciliation workflow against:
+
+- `src/instr_dict.json`
+- `src/riscv_extensions.json`
+
+using the `riscv-explorer` reconciliation engine and save outputs into this folder.

--- a/analysis/TAG_RECONCILIATION_REPORT.md
+++ b/analysis/TAG_RECONCILIATION_REPORT.md
@@ -1,0 +1,149 @@
+# Extension Tag Reconciliation Analysis
+
+## Executive Summary
+The RISC-V Extensions Landscape catalog currently lists **220 extensions**. Automated synchronization with upstream `riscv-opcodes` is blocked by naming mismatches. This analysis identified **98 reconcilable tags**, **8 tags requiring manual review**, and **8 unmatched tags**.
+
+## Methodology
+1. **Semantic Normalization**: Strip `rv_` / `rv32_` / `rv64_` prefixes and lowercase for comparison.
+2. **Alias Resolution**: Expand `G = I + M + A + F + D + Zicsr + Zifencei`.
+3. **Fuzzy Matching**: Levenshtein similarity for near-matches (threshold: `0.8`).
+4. **Confidence Scoring**: exact=1.0, normalized=0.95, fuzzy=0.7-0.9.
+
+## Key Findings
+
+### Fully Reconciled (Confidence >= 0.95)
+| riscv-opcodes Tag | Catalog Name | Confidence | Reason |
+|---|---|---:|---|
+| `rv32_c` | `C` | 0.95 | normalized match |
+| `rv32_c_f` | `C` | 0.95 | normalized match |
+| `rv32_d_zfa` | `D` | 0.95 | normalized match |
+| `rv32_zk` | `Zk` | 0.95 | normalized match |
+| `rv32_zkn` | `Zkn` | 0.95 | normalized match |
+| `rv32_zknd` | `Zknd` | 0.95 | normalized match |
+| `rv32_zkne` | `Zkne` | 0.95 | normalized match |
+| `rv32_zknh` | `Zknh` | 0.95 | normalized match |
+| `rv64_a` | `A` | 0.95 | normalized match |
+| `rv64_c` | `C` | 0.95 | normalized match |
+| `rv64_d` | `D` | 0.95 | normalized match |
+| `rv64_f` | `F` | 0.95 | normalized match |
+| `rv64_h` | `H` | 0.95 | normalized match |
+| `rv64_m` | `M` | 0.95 | normalized match |
+| `rv64_q` | `Q` | 0.95 | normalized match |
+| `rv64_q_zfa` | `Q` | 0.95 | normalized match |
+| `rv64_zacas` | `Zacas` | 0.95 | normalized match |
+| `rv64_zba` | `Zba` | 0.95 | normalized match |
+| `rv64_zbb` | `Zbb` | 0.95 | normalized match |
+| `rv64_zbkb` | `Zbkb` | 0.95 | normalized match |
+| `rv64_zbs` | `Zbs` | 0.95 | normalized match |
+| `rv64_zcb` | `Zcb` | 0.95 | normalized match |
+| `rv64_zfh` | `Zfh` | 0.95 | normalized match |
+| `rv64_zk` | `Zk` | 0.95 | normalized match |
+| `rv64_zkn` | `Zkn` | 0.95 | normalized match |
+| `rv64_zknd` | `Zknd` | 0.95 | normalized match |
+| `rv64_zkne` | `Zkne` | 0.95 | normalized match |
+| `rv64_zknh` | `Zknh` | 0.95 | normalized match |
+| `rv64_zkr` | `Zkr` | 0.95 | normalized match |
+| `rv64_zks` | `Zks` | 0.95 | normalized match |
+| `rv_a` | `A` | 0.95 | normalized match |
+| `rv_c` | `C` | 0.95 | normalized match |
+| `rv_c_d` | `C` | 0.95 | normalized match |
+| `rv_d` | `D` | 0.95 | normalized match |
+| `rv_d_zfa` | `D` | 0.95 | normalized match |
+| `rv_d_zfhmin` | `D` | 0.95 | normalized match |
+| `rv_f` | `F` | 0.95 | normalized match |
+| `rv_f_zfa` | `F` | 0.95 | normalized match |
+| `rv_h` | `H` | 0.95 | normalized match |
+| `rv_m` | `M` | 0.95 | normalized match |
+| `rv_q` | `Q` | 0.95 | normalized match |
+| `rv_q_zfa` | `Q` | 0.95 | normalized match |
+| `rv_q_zfhmin` | `Q` | 0.95 | normalized match |
+| `rv_s` | `S` | 0.95 | normalized match |
+| `rv_sdext` | `Sdext` | 0.95 | normalized match |
+| `rv_smrnmi` | `Smrnmi` | 0.95 | normalized match |
+| `rv_ssctr` | `Ssctr` | 0.95 | normalized match |
+| `rv_svinval` | `Svinval` | 0.95 | normalized match |
+| `rv_svinval_h` | `H` | 0.95 | normalized match |
+| `rv_u` | `U` | 0.95 | normalized match |
+| `rv_v` | `V` | 0.95 | normalized match |
+| `rv_zabha` | `Zabha` | 0.95 | normalized match |
+| `rv_zabha_zacas` | `Zabha` | 0.95 | normalized match |
+| `rv_zacas` | `Zacas` | 0.95 | normalized match |
+| `rv_zalasr` | `Zalasr` | 0.95 | normalized match |
+| `rv_zawrs` | `Zawrs` | 0.95 | normalized match |
+| `rv_zba` | `Zba` | 0.95 | normalized match |
+| `rv_zbb` | `Zbb` | 0.95 | normalized match |
+| `rv_zbc` | `Zbc` | 0.95 | normalized match |
+| `rv_zbkb` | `Zbkb` | 0.95 | normalized match |
+| `rv_zbkc` | `Zbkc` | 0.95 | normalized match |
+| `rv_zbkx` | `Zbkx` | 0.95 | normalized match |
+| `rv_zbs` | `Zbs` | 0.95 | normalized match |
+| `rv_zcb` | `Zcb` | 0.95 | normalized match |
+| `rv_zcmop` | `Zcmop` | 0.95 | normalized match |
+| `rv_zcmp` | `Zcmp` | 0.95 | normalized match |
+| `rv_zcmt` | `Zcmt` | 0.95 | normalized match |
+| `rv_zfbfmin` | `Zfbfmin` | 0.95 | normalized match |
+| `rv_zfh` | `Zfh` | 0.95 | normalized match |
+| `rv_zfh_zfa` | `Zfa` | 0.95 | normalized match |
+| `rv_zfhmin` | `Zfhmin` | 0.95 | normalized match |
+| `rv_zibi` | `Zibi` | 0.95 | normalized match |
+| `rv_zicfiss` | `Zicfiss` | 0.95 | normalized match |
+| `rv_zicond` | `Zicond` | 0.95 | normalized match |
+| `rv_zicsr` | `Zicsr` | 0.95 | normalized match |
+| `rv_zifencei` | `Zifencei` | 0.95 | normalized match |
+| `rv_zimop` | `Zimop` | 0.95 | normalized match |
+| `rv_zk` | `Zk` | 0.95 | normalized match |
+| `rv_zkn` | `Zkn` | 0.95 | normalized match |
+| `rv_zknh` | `Zknh` | 0.95 | normalized match |
+| `rv_zkr` | `Zkr` | 0.95 | normalized match |
+| `rv_zks` | `Zks` | 0.95 | normalized match |
+| `rv_zksed` | `Zksed` | 0.95 | normalized match |
+| `rv_zksh` | `Zksh` | 0.95 | normalized match |
+| `rv_zvabd` | `Zvabd` | 0.95 | normalized match |
+| `rv_zvbb` | `Zvbb` | 0.95 | normalized match |
+| `rv_zvbc` | `Zvbc` | 0.95 | normalized match |
+| `rv_zvfbfmin` | `Zvfbfmin` | 0.95 | normalized match |
+| `rv_zvfbfwma` | `Zvfbfwma` | 0.95 | normalized match |
+| `rv_zvfofp8min` | `Zvfofp8min` | 0.95 | normalized match |
+| `rv_zvkg` | `Zvkg` | 0.95 | normalized match |
+| `rv_zvkn` | `Zvkn` | 0.95 | normalized match |
+| `rv_zvkned` | `Zvkned` | 0.95 | normalized match |
+| `rv_zvknha` | `Zvknha` | 0.95 | normalized match |
+| `rv_zvknhb` | `Zvknhb` | 0.95 | normalized match |
+| `rv_zvks` | `Zvks` | 0.95 | normalized match |
+| `rv_zvksed` | `Zvksed` | 0.95 | normalized match |
+| `rv_zvksh` | `Zvksh` | 0.95 | normalized match |
+
+### Needs Manual Review (0.7 <= Confidence < 0.95)
+| riscv-opcodes Tag | Suggested Catalog | Confidence | Reason |
+|---|---|---:|---|
+| `rv64_zbp` | `Zba` | 0.833 | fuzzy match |
+| `rv_zbp` | `Zba` | 0.833 | fuzzy match |
+| `rv_zicbo` | `Zicbom` | 0.867 | fuzzy match |
+| `rv_zvfbdot32f` | `Zvbdota` | 0.820 | fuzzy match |
+| `rv_zvfofp4min` | `Zvfofp8min` | 0.880 | fuzzy match |
+| `rv_zvfqbdot8f` | `Zvbdota` | 0.820 | fuzzy match |
+| `rv_zvqbdot8i` | `Zvbdota` | 0.833 | fuzzy match |
+| `rv_zvqdotq` | `Zvbdota` | 0.843 | fuzzy match |
+
+### Unmatched (Confidence < 0.7)
+| riscv-opcodes Tag | Issue |
+|---|---|
+| `rv64_i` | base ISA alias requires explicit RV32I/RV64I policy mapping |
+| `rv_i` | base ISA alias requires explicit RV32I/RV64I policy mapping |
+| `rv_system` | umbrella/system meta-tag has no direct catalog extension |
+| `rv_zvfqldot8f` | no confident catalog equivalent after normalization/fuzzy matching |
+| `rv_zvfwbdot16bf` | no confident catalog equivalent after normalization/fuzzy matching |
+| `rv_zvfwldot16bf` | no confident catalog equivalent after normalization/fuzzy matching |
+| `rv_zvqldot8i` | no confident catalog equivalent after normalization/fuzzy matching |
+| `rv_zvzip` | no confident catalog equivalent after normalization/fuzzy matching |
+
+## Impact Assessment
+Current catalog coverage in this repository snapshot is **71/220 (32.27%)**. Implementing the **98 fully reconciled mappings** is projected to unblock instruction data for approximately **12 additional currently-unmapped extensions**, raising mapped extension coverage to about **83/220 (37.73%)**.
+
+## Recommended Next Steps
+1. Add normalization layer to `scripts/sync_instructions.mjs`.
+2. Add a manual override map for the **8 review-needed tags**.
+3. Define policy for meta-tags and custom/vendor tags (`X*`, umbrella tags, profile aliases).
+
+## Appendix: Raw Data
+See [results.json](./results.json) for machine-readable reconciliation data.

--- a/analysis/results.json
+++ b/analysis/results.json
@@ -1,0 +1,726 @@
+{
+  "generated_at": "2026-05-05T21:57:48.973078+00:00",
+  "methodology": {
+    "normalization_rules": [
+      "strip_rv_prefix",
+      "strip_rv32_prefix",
+      "strip_rv64_prefix",
+      "lowercase_normalization",
+      "underscore_tokenization",
+      "alias_expansion_g_extension"
+    ],
+    "fuzzy_threshold": 0.8,
+    "confidence_policy": {
+      "exact": 1.0,
+      "normalized": 0.95,
+      "fuzzy_range": [
+        0.7,
+        0.9
+      ]
+    }
+  },
+  "summary": {
+    "total_opcodes_tags": 114,
+    "total_catalog_extensions": 220,
+    "fully_reconciled": 98,
+    "needs_review": 8,
+    "unmatched": 8
+  },
+  "fully_reconciled": [
+    {
+      "opcodes_tag": "rv32_c",
+      "catalog_name": "C",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv32_c_f",
+      "catalog_name": "C",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv32_d_zfa",
+      "catalog_name": "D",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv32_zk",
+      "catalog_name": "Zk",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv32_zkn",
+      "catalog_name": "Zkn",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv32_zknd",
+      "catalog_name": "Zknd",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv32_zkne",
+      "catalog_name": "Zkne",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv32_zknh",
+      "catalog_name": "Zknh",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_a",
+      "catalog_name": "A",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_c",
+      "catalog_name": "C",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_d",
+      "catalog_name": "D",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_f",
+      "catalog_name": "F",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_h",
+      "catalog_name": "H",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_m",
+      "catalog_name": "M",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_q",
+      "catalog_name": "Q",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_q_zfa",
+      "catalog_name": "Q",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zacas",
+      "catalog_name": "Zacas",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zba",
+      "catalog_name": "Zba",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zbb",
+      "catalog_name": "Zbb",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zbkb",
+      "catalog_name": "Zbkb",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zbs",
+      "catalog_name": "Zbs",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zcb",
+      "catalog_name": "Zcb",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zfh",
+      "catalog_name": "Zfh",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zk",
+      "catalog_name": "Zk",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zkn",
+      "catalog_name": "Zkn",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zknd",
+      "catalog_name": "Zknd",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zkne",
+      "catalog_name": "Zkne",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zknh",
+      "catalog_name": "Zknh",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zkr",
+      "catalog_name": "Zkr",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv64_zks",
+      "catalog_name": "Zks",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_a",
+      "catalog_name": "A",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_c",
+      "catalog_name": "C",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_c_d",
+      "catalog_name": "C",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_d",
+      "catalog_name": "D",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_d_zfa",
+      "catalog_name": "D",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_d_zfhmin",
+      "catalog_name": "D",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_f",
+      "catalog_name": "F",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_f_zfa",
+      "catalog_name": "F",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_h",
+      "catalog_name": "H",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_m",
+      "catalog_name": "M",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_q",
+      "catalog_name": "Q",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_q_zfa",
+      "catalog_name": "Q",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_q_zfhmin",
+      "catalog_name": "Q",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_s",
+      "catalog_name": "S",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_sdext",
+      "catalog_name": "Sdext",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_smrnmi",
+      "catalog_name": "Smrnmi",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_ssctr",
+      "catalog_name": "Ssctr",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_svinval",
+      "catalog_name": "Svinval",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_svinval_h",
+      "catalog_name": "H",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_u",
+      "catalog_name": "U",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_v",
+      "catalog_name": "V",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zabha",
+      "catalog_name": "Zabha",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zabha_zacas",
+      "catalog_name": "Zabha",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zacas",
+      "catalog_name": "Zacas",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zalasr",
+      "catalog_name": "Zalasr",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zawrs",
+      "catalog_name": "Zawrs",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zba",
+      "catalog_name": "Zba",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zbb",
+      "catalog_name": "Zbb",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zbc",
+      "catalog_name": "Zbc",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zbkb",
+      "catalog_name": "Zbkb",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zbkc",
+      "catalog_name": "Zbkc",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zbkx",
+      "catalog_name": "Zbkx",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zbs",
+      "catalog_name": "Zbs",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zcb",
+      "catalog_name": "Zcb",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zcmop",
+      "catalog_name": "Zcmop",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zcmp",
+      "catalog_name": "Zcmp",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zcmt",
+      "catalog_name": "Zcmt",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zfbfmin",
+      "catalog_name": "Zfbfmin",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zfh",
+      "catalog_name": "Zfh",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zfh_zfa",
+      "catalog_name": "Zfa",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zfhmin",
+      "catalog_name": "Zfhmin",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zibi",
+      "catalog_name": "Zibi",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zicfiss",
+      "catalog_name": "Zicfiss",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zicond",
+      "catalog_name": "Zicond",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zicsr",
+      "catalog_name": "Zicsr",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zifencei",
+      "catalog_name": "Zifencei",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zimop",
+      "catalog_name": "Zimop",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zk",
+      "catalog_name": "Zk",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zkn",
+      "catalog_name": "Zkn",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zknh",
+      "catalog_name": "Zknh",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zkr",
+      "catalog_name": "Zkr",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zks",
+      "catalog_name": "Zks",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zksed",
+      "catalog_name": "Zksed",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zksh",
+      "catalog_name": "Zksh",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvabd",
+      "catalog_name": "Zvabd",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvbb",
+      "catalog_name": "Zvbb",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvbc",
+      "catalog_name": "Zvbc",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvfbfmin",
+      "catalog_name": "Zvfbfmin",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvfbfwma",
+      "catalog_name": "Zvfbfwma",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvfofp8min",
+      "catalog_name": "Zvfofp8min",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvkg",
+      "catalog_name": "Zvkg",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvkn",
+      "catalog_name": "Zvkn",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvkned",
+      "catalog_name": "Zvkned",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvknha",
+      "catalog_name": "Zvknha",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvknhb",
+      "catalog_name": "Zvknhb",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvks",
+      "catalog_name": "Zvks",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvksed",
+      "catalog_name": "Zvksed",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    },
+    {
+      "opcodes_tag": "rv_zvksh",
+      "catalog_name": "Zvksh",
+      "confidence": 0.95,
+      "reason": "normalized match"
+    }
+  ],
+  "needs_review": [
+    {
+      "opcodes_tag": "rv64_zbp",
+      "suggested_catalog": "Zba",
+      "confidence": 0.833,
+      "reason": "fuzzy match"
+    },
+    {
+      "opcodes_tag": "rv_zbp",
+      "suggested_catalog": "Zba",
+      "confidence": 0.833,
+      "reason": "fuzzy match"
+    },
+    {
+      "opcodes_tag": "rv_zicbo",
+      "suggested_catalog": "Zicbom",
+      "confidence": 0.867,
+      "reason": "fuzzy match"
+    },
+    {
+      "opcodes_tag": "rv_zvfbdot32f",
+      "suggested_catalog": "Zvbdota",
+      "confidence": 0.82,
+      "reason": "fuzzy match"
+    },
+    {
+      "opcodes_tag": "rv_zvfofp4min",
+      "suggested_catalog": "Zvfofp8min",
+      "confidence": 0.88,
+      "reason": "fuzzy match"
+    },
+    {
+      "opcodes_tag": "rv_zvfqbdot8f",
+      "suggested_catalog": "Zvbdota",
+      "confidence": 0.82,
+      "reason": "fuzzy match"
+    },
+    {
+      "opcodes_tag": "rv_zvqbdot8i",
+      "suggested_catalog": "Zvbdota",
+      "confidence": 0.833,
+      "reason": "fuzzy match"
+    },
+    {
+      "opcodes_tag": "rv_zvqdotq",
+      "suggested_catalog": "Zvbdota",
+      "confidence": 0.843,
+      "reason": "fuzzy match"
+    }
+  ],
+  "unmatched": [
+    {
+      "opcodes_tag": "rv64_i",
+      "issue": "base ISA alias requires explicit RV32I/RV64I policy mapping",
+      "confidence": 0.0,
+      "reason": "no match found"
+    },
+    {
+      "opcodes_tag": "rv_i",
+      "issue": "base ISA alias requires explicit RV32I/RV64I policy mapping",
+      "confidence": 0.0,
+      "reason": "no match found"
+    },
+    {
+      "opcodes_tag": "rv_system",
+      "issue": "umbrella/system meta-tag has no direct catalog extension",
+      "confidence": 0.0,
+      "reason": "no match found"
+    },
+    {
+      "opcodes_tag": "rv_zvfqldot8f",
+      "issue": "no confident catalog equivalent after normalization/fuzzy matching",
+      "confidence": 0.0,
+      "reason": "no match found"
+    },
+    {
+      "opcodes_tag": "rv_zvfwbdot16bf",
+      "issue": "no confident catalog equivalent after normalization/fuzzy matching",
+      "confidence": 0.0,
+      "reason": "no match found"
+    },
+    {
+      "opcodes_tag": "rv_zvfwldot16bf",
+      "issue": "no confident catalog equivalent after normalization/fuzzy matching",
+      "confidence": 0.0,
+      "reason": "no match found"
+    },
+    {
+      "opcodes_tag": "rv_zvqldot8i",
+      "issue": "no confident catalog equivalent after normalization/fuzzy matching",
+      "confidence": 0.0,
+      "reason": "no match found"
+    },
+    {
+      "opcodes_tag": "rv_zvzip",
+      "issue": "no confident catalog equivalent after normalization/fuzzy matching",
+      "confidence": 0.0,
+      "reason": "no match found"
+    }
+  ],
+  "statistics": {
+    "current_mapped_extensions": 71,
+    "current_coverage_percent": 32.27,
+    "projected_mapped_extensions_if_fully_reconciled_applied": 83,
+    "projected_coverage_percent_if_fully_reconciled_applied": 37.73,
+    "additional_unmapped_extensions_unblocked": 12
+  }
+}


### PR DESCRIPTION
This commit adds a comprehensive analysis of extension tag mismatches between riscv-opcodes and the landscape catalog.

- Identifies reconcilable tags via semantic normalization

- Provides confidence-scored fuzzy matching results

- Includes machine-readable results.json for tooling integration

No code changes — research-only PR to validate approach before implementation.

Related to the mentorship goal of unblocking automated sync.