### PR TITLE
feat: add canonical tag normalizer for automated sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,26 @@ How it works:
 - For each conflict, the report includes a plain-language reason, common mask, and an example word that matches both patterns.
 
 You can use **Copy report** in the modal to copy a full conflict report for sharing.
+
+
+## Extension Tag Normalization
+
+The sync script supports canonical tag normalization to bridge naming differences between `riscv-opcodes` and the landscape catalog.
+
+### Supported Conventions
+
+- `riscv-opcodes`: `rv_zba`, `rv64_zba`, `rv_zicsr`
+- landscape catalog: `Zba`, `Zicsr`
+- manual overrides for known tag-family mismatches (for example `rv_zicbo` -> `zicbom`)
+
+### Usage
+
+```bash
+node scripts/sync_instructions.mjs --use-normalizer
+```
+
+### What `--use-normalizer` Adds
+
+- Normalized extension ID fallback when direct catalog ID lookup fails.
+- Tag reconciliation diagnostics across `instr_dict.json` extension tags.
+- Explicit unmatched-tag warnings for follow-up mapping work.

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "description": "",
   "main": "index.js",
   "homepage": "https://rpsene.github.io/riscv-extensions-landscape/",
-"scripts": {
-  "build": "webpack",
-  "predeploy": "npm run build",
-  "deploy": "gh-pages -d dist --branch gh-pages --dotfiles",
-  "test": "echo \"Error: no test specified\" && exit 1"
-},
+  "scripts": {
+    "build": "webpack",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist --branch gh-pages --dotfiles",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "test:tag-normalizer": "node scripts/lib/tests/tag_normalizer.test.mjs"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/scripts/lib/tag_normalizer.mjs
+++ b/scripts/lib/tag_normalizer.mjs
@@ -1,0 +1,92 @@
+﻿/**
+ * Canonical tag normalizer for RISC-V extension names.
+ *
+ * Bridges naming conventions between:
+ * - riscv-opcodes: rv_zba, rv64_zba, rv_zicsr
+ * - landscape catalog: Zba, Zicsr
+ * - ISA manual: Zba, Zicsr
+ *
+ * @module tag_normalizer
+ */
+
+'use strict';
+
+/** @type {Record<string, string>} */
+export const MANUAL_OVERRIDES = {
+  rv_svinval_h: 'svinval',
+  rv_zicbo: 'zicbom',
+};
+
+/** @type {string[]} */
+export const G_COMPONENTS = ['i', 'm', 'a', 'f', 'd', 'zicsr', 'zifencei'];
+
+const PREFIX_RE = /^rv(?:32|64|128)?_/i;
+
+/**
+ * Normalize an extension tag to canonical form.
+ *
+ * @param {string} tag - Raw tag (e.g., 'rv64_zba', 'Zba').
+ * @param {{ warnUnknown?: boolean, knownCatalogTags?: Set<string> }} [options] - Optional behavior toggles.
+ * @returns {string} Normalized tag (e.g., 'zba').
+ * @throws {TypeError} If tag is not a string.
+ * @throws {Error} If tag is empty after trimming.
+ */
+export function normalizeTag(tag, options = {}) {
+  if (typeof tag !== 'string') {
+    throw new TypeError('normalizeTag(tag): tag must be a string.');
+  }
+
+  const trimmed = tag.trim();
+  if (!trimmed) {
+    throw new Error('normalizeTag(tag): tag cannot be empty.');
+  }
+
+  const rawLower = trimmed.toLowerCase();
+  if (Object.prototype.hasOwnProperty.call(MANUAL_OVERRIDES, rawLower)) {
+    return MANUAL_OVERRIDES[rawLower];
+  }
+
+  const withoutPrefix = rawLower.replace(PREFIX_RE, '');
+  const tokens = withoutPrefix.split(/[_\s]+/).filter(Boolean);
+  const normalized = (tokens[0] ?? withoutPrefix).trim();
+
+  if (
+    options.warnUnknown &&
+    options.knownCatalogTags &&
+    !options.knownCatalogTags.has(normalized)
+  ) {
+    console.warn(`normalizeTag: unresolved tag '${tag}' -> '${normalized}'`);
+  }
+
+  return normalized;
+}
+
+/**
+ * Expand G composite extension into constituent extensions.
+ *
+ * @param {string} tag - Extension tag.
+ * @returns {string[]} Constituent tags or [normalizedTag] if not G.
+ */
+export function expandGExtension(tag) {
+  const normalized = normalizeTag(tag);
+  if (normalized === 'g') {
+    return [...G_COMPONENTS];
+  }
+  return [normalized];
+}
+
+/**
+ * Normalize and expand extension tags into canonical token candidates.
+ *
+ * @param {string} tag - Raw extension tag.
+ * @param {{ includeGExpansion?: boolean }} [options] - Expansion options.
+ * @returns {string[]} Canonical candidate tags.
+ */
+export function normalizeTagCandidates(tag, options = {}) {
+  const includeGExpansion = options.includeGExpansion ?? true;
+  const normalized = normalizeTag(tag);
+  if (includeGExpansion && normalized === 'g') {
+    return [...G_COMPONENTS];
+  }
+  return [normalized];
+}

--- a/scripts/lib/tests/tag_normalizer.test.mjs
+++ b/scripts/lib/tests/tag_normalizer.test.mjs
@@ -1,0 +1,72 @@
+﻿import assert from 'node:assert/strict';
+
+import {
+  normalizeTag,
+  expandGExtension,
+  MANUAL_OVERRIDES,
+  normalizeTagCandidates,
+} from '../tag_normalizer.mjs';
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`[PASS] ${name}`);
+  } catch (error) {
+    console.error(`[FAIL] ${name}`);
+    console.error(error instanceof Error ? error.stack : error);
+    process.exitCode = 1;
+  }
+}
+
+runTest('normalizes rv_zba to zba', () => {
+  assert.equal(normalizeTag('rv_zba'), 'zba');
+});
+
+runTest('normalizes rv64_zba to zba', () => {
+  assert.equal(normalizeTag('rv64_zba'), 'zba');
+});
+
+runTest('normalizes Zba to zba', () => {
+  assert.equal(normalizeTag('Zba'), 'zba');
+});
+
+runTest('expands G to canonical component list', () => {
+  assert.deepEqual(expandGExtension('G'), ['i', 'm', 'a', 'f', 'd', 'zicsr', 'zifencei']);
+});
+
+runTest('applies manual overrides', () => {
+  assert.equal(MANUAL_OVERRIDES.rv_svinval_h, 'svinval');
+  assert.equal(normalizeTag('rv_svinval_h'), 'svinval');
+});
+
+runTest('unknown tags pass through with warning when enabled', () => {
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (msg) => warnings.push(String(msg));
+
+  try {
+    const normalized = normalizeTag('rv_unknown_foo', {
+      warnUnknown: true,
+      knownCatalogTags: new Set(['zba', 'zicsr']),
+    });
+    assert.equal(normalized, 'unknown');
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /unresolved tag/i);
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+runTest('throws on empty or invalid inputs', () => {
+  assert.throws(() => normalizeTag(''), /cannot be empty/i);
+  assert.throws(() => normalizeTag(42), /must be a string/i);
+});
+
+runTest('candidate normalization expands G and returns singleton for non-G', () => {
+  assert.deepEqual(normalizeTagCandidates('g'), ['i', 'm', 'a', 'f', 'd', 'zicsr', 'zifencei']);
+  assert.deepEqual(normalizeTagCandidates('rv_zicsr'), ['zicsr']);
+});
+
+if (process.exitCode && process.exitCode !== 0) {
+  throw new Error('tag_normalizer tests failed.');
+}

--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -1,10 +1,20 @@
-import fs from 'node:fs';
+﻿import fs from 'node:fs';
 import path from 'node:path';
 import vm from 'node:vm';
+
+import { normalizeTag, normalizeTagCandidates } from './lib/tag_normalizer.mjs';
 
 function die(message) {
   console.error(message);
   process.exit(1);
+}
+
+function parseArgs(argv) {
+  const flags = new Set(argv.slice(2));
+  return {
+    useNormalizer: flags.has('--use-normalizer'),
+    dryRun: flags.has('--dry-run'),
+  };
 }
 
 function findMatchingBrace(text, openIndex) {
@@ -22,7 +32,7 @@ function findMatchingBrace(text, openIndex) {
       continue;
     }
 
-    if (ch === '\\\\') {
+    if (ch === '\\') {
       if (inSingle || inDouble || inTemplate) escape = true;
       continue;
     }
@@ -81,7 +91,8 @@ function extractExtensionInstructions(jsxText) {
 }
 
 function buildExtensionIndex(extensionsCatalog) {
-  const index = new Map();
+  const byId = new Map();
+  const byNormalized = new Map();
 
   for (const [category, entries] of Object.entries(extensionsCatalog)) {
     if (!Array.isArray(entries)) continue;
@@ -89,19 +100,90 @@ function buildExtensionIndex(extensionsCatalog) {
       if (!entry || typeof entry !== 'object') continue;
       const id = entry.id;
       if (!id) continue;
-      const list = index.get(id) ?? [];
-      list.push({ category, entry });
-      index.set(id, list);
+      const location = { category, entry };
+
+      const directList = byId.get(id) ?? [];
+      directList.push(location);
+      byId.set(id, directList);
+
+      const normalized = normalizeTag(id);
+      const normalizedList = byNormalized.get(normalized) ?? [];
+      normalizedList.push(location);
+      byNormalized.set(normalized, normalizedList);
     }
   }
 
-  return index;
+  return { byId, byNormalized };
+}
+
+function buildKnownCatalogTagSet(extensionsCatalog) {
+  const known = new Set();
+  for (const entries of Object.values(extensionsCatalog)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (entry && typeof entry === 'object' && entry.id) {
+        known.add(normalizeTag(entry.id));
+      }
+    }
+  }
+  return known;
+}
+
+function resolveExtensionLocations(extId, index, useNormalizer) {
+  const direct = index.byId.get(extId);
+  if (direct && direct.length) {
+    return { locations: direct, resolution: 'direct' };
+  }
+
+  if (!useNormalizer) {
+    return { locations: null, resolution: 'not_found' };
+  }
+
+  const normalized = normalizeTag(extId);
+  const normalizedMatches = index.byNormalized.get(normalized);
+  if (normalizedMatches && normalizedMatches.length) {
+    return { locations: normalizedMatches, resolution: 'normalized' };
+  }
+
+  return { locations: null, resolution: 'not_found' };
 }
 
 function mnemonicToInstrDictKey(mnemonic) {
   return String(mnemonic).trim().toLowerCase().replaceAll('.', '_');
 }
 
+function collectTagNormalizationStats(instrDict, knownCatalogTags) {
+  const matched = [];
+  const unmatched = [];
+  const seen = new Set();
+
+  for (const payload of Object.values(instrDict)) {
+    if (!payload || typeof payload !== 'object') continue;
+    const tags = payload.extension;
+    if (!Array.isArray(tags)) continue;
+
+    for (const rawTag of tags) {
+      const tag = String(rawTag || '').trim();
+      if (!tag || seen.has(tag)) continue;
+      seen.add(tag);
+
+      const candidates = normalizeTagCandidates(tag, { includeGExpansion: true });
+      const firstMatch = candidates.find((candidate) => knownCatalogTags.has(candidate));
+      if (firstMatch) {
+        matched.push({ tag, normalized: firstMatch, reason: 'normalized_candidate_match' });
+      } else {
+        unmatched.push({ tag, candidates, reason: 'no_catalog_candidate_match' });
+      }
+    }
+  }
+
+  matched.sort((a, b) => a.tag.localeCompare(b.tag));
+  unmatched.sort((a, b) => a.tag.localeCompare(b.tag));
+
+  return { matched, unmatched };
+}
+
+const options = parseArgs(process.argv);
 const workspaceRoot = process.cwd();
 const instrDictPath = path.join(workspaceRoot, 'src', 'instr_dict.json');
 const catalogPath = path.join(workspaceRoot, 'src', 'riscv_extensions.json');
@@ -117,13 +199,15 @@ const extIndex = buildExtensionIndex(extensionsCatalog);
 const missingExtensions = new Set();
 const missingInstructions = new Map();
 let addedCount = 0;
+let normalizedResolutionCount = 0;
 
 for (const [extId, mnemonics] of Object.entries(extensionInstructions)) {
-  const locations = extIndex.get(extId);
+  const { locations, resolution } = resolveExtensionLocations(extId, extIndex, options.useNormalizer);
   if (!locations || locations.length === 0) {
     missingExtensions.add(extId);
     continue;
   }
+  if (resolution === 'normalized') normalizedResolutionCount += 1;
 
   for (const { entry } of locations) {
     if (!entry.instructions || typeof entry.instructions !== 'object') entry.instructions = {};
@@ -142,16 +226,37 @@ for (const [extId, mnemonics] of Object.entries(extensionInstructions)) {
   }
 }
 
-fs.writeFileSync(catalogPath, `${JSON.stringify(extensionsCatalog, null, 2)}\n`);
+if (!options.dryRun) {
+  fs.writeFileSync(catalogPath, `${JSON.stringify(extensionsCatalog, null, 2)}\n`);
+}
 
-console.log(`Updated ${path.relative(workspaceRoot, catalogPath)} with ${addedCount} instruction entries.`);
+console.log(
+  `${options.dryRun ? 'Dry run: would update' : 'Updated'} ${path.relative(workspaceRoot, catalogPath)} with ${addedCount} instruction entries.`
+);
+if (options.useNormalizer) {
+  console.log(`Normalizer assisted extension resolution count: ${normalizedResolutionCount}`);
+}
 if (missingExtensions.size) {
-  console.warn(`Extensions referenced in JSX but not found in YAML: ${Array.from(missingExtensions).sort().join(', ')}`);
+  console.warn(`Extensions referenced in JSX but not found in catalog: ${Array.from(missingExtensions).sort().join(', ')}`);
 }
 if (missingInstructions.size) {
   const sorted = Array.from(missingInstructions.entries()).sort(([a], [b]) => a.localeCompare(b));
   console.warn('Instructions missing from instr_dict.json (by extension):');
   for (const [extId, list] of sorted) {
     console.warn(`- ${extId}: ${list.length}`);
+  }
+}
+
+if (options.useNormalizer) {
+  const knownCatalogTags = buildKnownCatalogTagSet(extensionsCatalog);
+  const normalizationStats = collectTagNormalizationStats(instrDict, knownCatalogTags);
+  console.log(
+    `Tag normalization summary: ${normalizationStats.matched.length} matched candidates, ${normalizationStats.unmatched.length} unmatched candidates.`
+  );
+  if (normalizationStats.unmatched.length) {
+    console.warn('Unmatched riscv-opcodes tags after normalization:');
+    for (const row of normalizationStats.unmatched) {
+      console.warn(`- ${row.tag} -> [${row.candidates.join(', ')}]`);
+    }
   }
 }


### PR DESCRIPTION
Implements semantic tag normalization to unblock automated sync between riscv-opcodes and the landscape catalog.

- Adds scripts/lib/tag_normalizer.mjs with full JSDoc documentation

- Supports rv_/rv32_/rv64_ prefix stripping, lowercase normalization

- Handles G expansion (I+M+A+F+D+Zicsr+Zifencei)

- Includes comprehensive test suite

- Adds --use-normalizer flag to sync script (opt-in)

- Documents normalization rules in README

Based on analysis from PR #1.