### PR TITLE
Improve sync script warning summaries and reporting

### DIFF
--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -144,14 +144,46 @@ for (const [extId, mnemonics] of Object.entries(extensionInstructions)) {
 
 fs.writeFileSync(catalogPath, `${JSON.stringify(extensionsCatalog, null, 2)}\n`);
 
-console.log(`Updated ${path.relative(workspaceRoot, catalogPath)} with ${addedCount} instruction entries.`);
+console.log('\n=== Instruction Sync Summary ===');
+console.log(`Updated file: ${path.relative(workspaceRoot, catalogPath)}`);
+console.log(`Total instruction entries added: ${addedCount}`);
+
 if (missingExtensions.size) {
-  console.warn(`Extensions referenced in JSX but not found in YAML: ${Array.from(missingExtensions).sort().join(', ')}`);
-}
-if (missingInstructions.size) {
-  const sorted = Array.from(missingInstructions.entries()).sort(([a], [b]) => a.localeCompare(b));
-  console.warn('Instructions missing from instr_dict.json (by extension):');
-  for (const [extId, list] of sorted) {
-    console.warn(`- ${extId}: ${list.length}`);
+  console.warn('\n=== Missing Extensions ===');
+
+  const sortedExtensions = Array.from(missingExtensions).sort();
+
+  console.warn(`Count: ${sortedExtensions.length}`);
+
+  for (const ext of sortedExtensions) {
+    console.warn(`- ${ext}`);
   }
 }
+
+if (missingInstructions.size) {
+  console.warn('\n=== Missing Instructions ===');
+
+  const sorted = Array.from(missingInstructions.entries())
+    .sort(([a], [b]) => a.localeCompare(b));
+
+  let totalMissing = 0;
+
+  for (const [, list] of sorted) {
+    totalMissing += list.length;
+  }
+
+  console.warn(`Extensions with missing instructions: ${sorted.length}`);
+  console.warn(`Total missing instructions: ${totalMissing}`);
+
+  for (const [extId, list] of sorted) {
+    console.warn(`\n- ${extId}`);
+
+    const uniqueList = [...new Set(list)].sort();
+
+    for (const instr of uniqueList) {
+      console.warn(`   • ${instr}`);
+    }
+  }
+}
+
+console.log('\nSync completed.\n');


### PR DESCRIPTION
## Summary

Improved the logging and warning output of `sync_instructions.mjs` to make synchronization results easier to inspect and debug.

## Changes
- Added structured sync summary output
- Added counts for missing extensions and instructions
- Improved formatting and readability of warnings
- Display actual missing instruction names instead of only counts
- Added final sync completion message

## Why
The previous warning output was difficult to scan when debugging synchronization and extension mapping issues. These improvements make it easier to identify missing mappings and instruction gaps during sync operations.