### PR TITLE
Improve clarity of Atomic (A) extension metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -802,7 +801,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -829,7 +827,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1053,7 +1050,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3002,7 +2998,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3306,7 +3301,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3929,7 +3923,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4059,7 +4052,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -4109,7 +4101,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -3576,335 +3576,161 @@
     {
       "id": "A",
       "name": "A",
-      "desc": "Atomics Bundle",
-      "use": "LR/SC & AMO ops in hardware",
+      "desc": "Atomic memory operations extension (RV A)",
+      "use": "Provides load-reserved/store-conditional (LR/SC) and atomic memory operations (AMO) for safe concurrent programming in hardware",
       "discontinued": 0,
       "instructions": {
         "LR.W": {
           "encoding": "00010--00000-----010-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv_a"
-          ],
+          "variable_fields": ["rd", "rs1", "aq", "rl"],
+          "extension": ["rv_a"],
           "match": "0x1000202f",
           "mask": "0xf9f0707f"
         },
         "SC.W": {
           "encoding": "00011------------010-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv_a"],
           "match": "0x1800202f",
           "mask": "0xf800707f"
         },
         "AMOSWAP.W": {
           "encoding": "00001------------010-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv_a"],
           "match": "0x800202f",
           "mask": "0xf800707f"
         },
         "AMOADD.W": {
           "encoding": "00000------------010-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv_a"],
           "match": "0x202f",
           "mask": "0xf800707f"
         },
         "AMOXOR.W": {
           "encoding": "00100------------010-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv_a"],
           "match": "0x2000202f",
           "mask": "0xf800707f"
         },
         "AMOOR.W": {
           "encoding": "01000------------010-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv_a"],
           "match": "0x4000202f",
           "mask": "0xf800707f"
         },
         "AMOAND.W": {
           "encoding": "01100------------010-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv_a"],
           "match": "0x6000202f",
           "mask": "0xf800707f"
         },
         "AMOMIN.W": {
           "encoding": "10000------------010-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv_a"],
           "match": "0x8000202f",
           "mask": "0xf800707f"
         },
         "AMOMAX.W": {
           "encoding": "10100------------010-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv_a"],
           "match": "0xa000202f",
           "mask": "0xf800707f"
         },
         "AMOMINU.W": {
           "encoding": "11000------------010-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv_a"],
           "match": "0xc000202f",
           "mask": "0xf800707f"
         },
         "AMOMAXU.W": {
           "encoding": "11100------------010-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv_a"],
           "match": "0xe000202f",
           "mask": "0xf800707f"
         },
         "LR.D": {
           "encoding": "00010--00000-----011-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv64_a"
-          ],
+          "variable_fields": ["rd", "rs1", "aq", "rl"],
+          "extension": ["rv64_a"],
           "match": "0x1000302f",
           "mask": "0xf9f0707f"
         },
         "SC.D": {
           "encoding": "00011------------011-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv64_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv64_a"],
           "match": "0x1800302f",
           "mask": "0xf800707f"
         },
         "AMOSWAP.D": {
           "encoding": "00001------------011-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv64_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv64_a"],
           "match": "0x800302f",
           "mask": "0xf800707f"
         },
         "AMOADD.D": {
           "encoding": "00000------------011-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv64_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv64_a"],
           "match": "0x302f",
           "mask": "0xf800707f"
         },
         "AMOXOR.D": {
           "encoding": "00100------------011-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv64_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv64_a"],
           "match": "0x2000302f",
           "mask": "0xf800707f"
         },
         "AMOOR.D": {
           "encoding": "01000------------011-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv64_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv64_a"],
           "match": "0x4000302f",
           "mask": "0xf800707f"
         },
         "AMOAND.D": {
           "encoding": "01100------------011-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv64_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv64_a"],
           "match": "0x6000302f",
           "mask": "0xf800707f"
         },
         "AMOMIN.D": {
           "encoding": "10000------------011-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv64_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv64_a"],
           "match": "0x8000302f",
           "mask": "0xf800707f"
         },
         "AMOMAX.D": {
           "encoding": "10100------------011-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv64_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv64_a"],
           "match": "0xa000302f",
           "mask": "0xf800707f"
         },
         "AMOMINU.D": {
           "encoding": "11000------------011-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv64_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv64_a"],
           "match": "0xc000302f",
           "mask": "0xf800707f"
         },
         "AMOMAXU.D": {
           "encoding": "11100------------011-----0101111",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2",
-            "aq",
-            "rl"
-          ],
-          "extension": [
-            "rv64_a"
-          ],
+          "variable_fields": ["rd", "rs1", "rs2", "aq", "rl"],
+          "extension": ["rv64_a"],
           "match": "0xe000302f",
           "mask": "0xf800707f"
         }


### PR DESCRIPTION
## Summary
Improves clarity and documentation quality of the RISC-V Atomic (A) extension metadata.

## Changes
- Expanded description of atomic memory operations extension
- Clarified usage of LR/SC and AMO instructions in concurrent programming contexts

## Motivation
Improves readability and understanding of extension purposes for users exploring the ISA landscape.