### PR TITLE
feat: Add extension tag reconciliation support for synchronization tooling

### DIFF
--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -101,17 +101,21 @@ function buildExtensionIndex(extensionsCatalog) {
 function mnemonicToInstrDictKey(mnemonic) {
   return String(mnemonic).trim().toLowerCase().replaceAll('.', '_');
 }
-
+function normalizeExtensionId(extId) {
+  return extensionAliases[extId] || extId;
+}
 const workspaceRoot = process.cwd();
 const instrDictPath = path.join(workspaceRoot, 'src', 'instr_dict.json');
 const catalogPath = path.join(workspaceRoot, 'src', 'riscv_extensions.json');
 const visualizerPath = path.join(workspaceRoot, 'src', 'risc_v_visualizer.jsx');
+const aliasPath = path.join(workspaceRoot,'src','extension_aliases.json');
 
 const instrDict = JSON.parse(fs.readFileSync(instrDictPath, 'utf8'));
 const extensionsCatalog = JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
 const visualizerSource = fs.readFileSync(visualizerPath, 'utf8');
 
 const extensionInstructions = extractExtensionInstructions(visualizerSource);
+const extensionAliases = JSON.parse(fs.readFileSync(aliasPath, 'utf8'));
 const extIndex = buildExtensionIndex(extensionsCatalog);
 
 const missingExtensions = new Set();
@@ -119,7 +123,9 @@ const missingInstructions = new Map();
 let addedCount = 0;
 
 for (const [extId, mnemonics] of Object.entries(extensionInstructions)) {
-  const locations = extIndex.get(extId);
+   const normalizedExtId =normalizeExtensionId(extId);
+   const locations =extIndex.get(normalizedExtId);
+
   if (!locations || locations.length === 0) {
     missingExtensions.add(extId);
     continue;

--- a/src/extension_aliases.json
+++ b/src/extension_aliases.json
@@ -1,0 +1,7 @@
+{
+  "zicntr": "Zicntr",
+  "zihpm": "Zihpm",
+  "svnapot": "Svnapot",
+  "svpbmt": "Svpbmt",
+  "zvk": "Zvk"
+}


### PR DESCRIPTION
## Summary

Added extension tag reconciliation support to improve synchronization compatibility between the catalog and upstream `riscv-opcodes` naming conventions.

## Features

* Added centralized extension alias mapping support
* Added `extension_aliases.json` for maintaining extension identifier aliases
* Added normalization logic during synchronization lookup
* Improved synchronization compatibility for mismatched extension tags

## Why

The project currently contains extension-tag mismatches between:

* catalog extension identifiers
* upstream `riscv-opcodes` naming conventions

These inconsistencies prevent synchronization tooling from automatically linking instruction metadata for several extensions.

This contribution introduces a lightweight reconciliation layer that allows synchronization tooling to resolve extension aliases before lookup.

## Benefits

* improves synchronization flexibility
* reduces manual reconciliation effort
* supports future alias expansion
* improves automation readiness for extension synchronization workflows

## Testing

Tested locally by:

* running `node scripts/sync_instructions.mjs`
* verifying synchronization completed successfully
* verifying alias normalization integrates correctly into extension lookup flow


## Issue : #107 