### PR TITLE
feat: Add dry-run support to synchronization tooling

### DIFF
--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -103,6 +103,7 @@ function mnemonicToInstrDictKey(mnemonic) {
 }
 
 const workspaceRoot = process.cwd();
+const isDryRun =process.argv.includes('--dry-run');
 const instrDictPath = path.join(workspaceRoot, 'src', 'instr_dict.json');
 const catalogPath = path.join(workspaceRoot, 'src', 'riscv_extensions.json');
 const visualizerPath = path.join(workspaceRoot, 'src', 'risc_v_visualizer.jsx');
@@ -142,9 +143,26 @@ for (const [extId, mnemonics] of Object.entries(extensionInstructions)) {
   }
 }
 
-fs.writeFileSync(catalogPath, `${JSON.stringify(extensionsCatalog, null, 2)}\n`);
+if (isDryRun) {
+  console.log(
+    '[Dry Run] No files were modified.'
+  );
+} else {
+  fs.writeFileSync(
+    catalogPath,
+    `${JSON.stringify(extensionsCatalog, null, 2)}\n`
+  );
+}
 
-console.log(`Updated ${path.relative(workspaceRoot, catalogPath)} with ${addedCount} instruction entries.`);
+if (isDryRun) {
+  console.log(
+    `[Dry Run] Would update ${path.relative(workspaceRoot, catalogPath)} with ${addedCount} instruction entries.`
+  );
+} else {
+  console.log(
+    `Updated ${path.relative(workspaceRoot, catalogPath)} with ${addedCount} instruction entries.`
+  );
+}
 if (missingExtensions.size) {
   console.warn(`Extensions referenced in JSX but not found in YAML: ${Array.from(missingExtensions).sort().join(', ')}`);
 }


### PR DESCRIPTION
## Summary

Added `--dry-run` support to `sync_instructions.mjs` to allow synchronization previews without modifying files.

## Features

* Added `--dry-run` CLI flag support
* Prevented file writes during dry-run execution
* Added dry-run specific synchronization summary output
* Preserved existing synchronization behavior for normal execution

## Why

The synchronization script currently writes updates directly to `riscv_extensions.json` during execution.

This enhancement improves contributor workflows by allowing synchronization changes to be inspected safely before writing updates.

The feature helps contributors:

* preview synchronization results
* inspect extension mapping changes
* debug synchronization behavior
* avoid accidental file modifications

## Testing

Tested locally by:

* running normal synchronization mode
* running `--dry-run` mode
* verifying synchronization summaries
* verifying no files were modified during dry-run execution


## Issue : #111 