### PR TITLE
Bug: Fix missing Zimop instruction mnemonics

### DIFF
--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -99,7 +99,17 @@ function buildExtensionIndex(extensionsCatalog) {
 }
 
 function mnemonicToInstrDictKey(mnemonic) {
-  return String(mnemonic).trim().toLowerCase().replaceAll('.', '_');
+  if (
+    mnemonic === 'mop_r_N' ||
+    mnemonic === 'mop_rr_N'
+  ) {
+    return mnemonic;
+  }
+
+  return String(mnemonic)
+    .trim()
+    .toLowerCase()
+    .replaceAll('.', '_');
 }
 
 const workspaceRoot = process.cwd();

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1259,9 +1259,9 @@ const RISCVExplorer = () => {
       // Shadow stack atomic swap
       'SSAMOSWAP.W', 'SSAMOSWAP.D',
     ],
-    Zimop: [
-      // May-be operations (reserved NOPs)
-      // Note: MOP.R.N, MOP.RR.N have encoding but naming mismatch in dictionary
+   Zimop: [
+    'mop_r_N',
+    'mop_rr_N',
     ],
     F: [
       // Load/Store

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -16991,7 +16991,38 @@
       "desc": "May-Be-Ops (NOP family)",
       "use": "Reserved NOP encodings for future",
       "url": "https://github.com/riscv/riscv-isa-manual",
-      "instructions": {}
+      "instructions": {
+        "mop_r_N": {
+          "encoding": "1-00--0111-------100-----1110011",
+          "variable_fields": [
+            "mop_r_t_30",
+            "mop_r_t_27_26",
+            "mop_r_t_21_20",
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x81c04073",
+          "mask": "0xb3c0707f"
+        },
+        "mop_rr_N": {
+          "encoding": "1-00--1----------100-----1110011",
+          "variable_fields": [
+            "mop_rr_t_30",
+            "mop_rr_t_27_26",
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x82004073",
+          "mask": "0xb200707f"
+        }
+      }
     }
   ],
   "z_crypto": [


### PR DESCRIPTION
## Summary

Added missing `mop_r_N` and `mop_rr_N` instruction mappings for the `Zimop` extension and updated synchronization handling for case-sensitive instruction keys.

## Changes

* added missing `mop_r_N` instruction mapping
* added missing `mop_rr_N` instruction mapping
* added targeted synchronization handling for case-sensitive instruction keys
* regenerated synchronized instruction metadata

## Why

The `Zimop` extension was missing instruction synchronization despite valid entries already existing in `instr_dict.json`.

The synchronization tooling lowercased instruction keys during normalization, which prevented case-sensitive `Zimop` instruction keys from resolving correctly.

This change preserves compatibility for existing normalization behavior while correctly synchronizing the `Zimop` instruction entries.

## Testing

Tested locally by:

* running `node scripts/sync_instructions.mjs`
* verifying synchronized instruction count increased from 1416 → 1418
* verifying no missing instruction warnings remained for `Zimop`
