### PR TITLE
Bug: Fix missing Zcmop instruction mnemonic

### DIFF
--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -99,7 +99,18 @@ function buildExtensionIndex(extensionsCatalog) {
 }
 
 function mnemonicToInstrDictKey(mnemonic) {
-  return String(mnemonic).trim().toLowerCase().replaceAll('.', '_');
+  if (
+    mnemonic === 'mop_r_N' ||
+    mnemonic === 'mop_rr_N' ||
+    mnemonic === 'c_mop_N'
+  ) {
+    return mnemonic;
+  }
+
+  return String(mnemonic)
+    .trim()
+    .toLowerCase()
+    .replaceAll('.', '_');
 }
 
 const workspaceRoot = process.cwd();

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1497,8 +1497,7 @@ const RISCVExplorer = () => {
       'CM.JALT',
     ],
     Zcmop: [
-      // May-be-operations (reserved NOPs)
-      // Note: C.MOP.N has encoding but naming mismatch in dictionary
+      'c_mop_N',
     ],
     B: [
       // Aggregates Zba + Zbb + Zbc + Zbs

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -13895,7 +13895,19 @@
       "desc": "Compressed May-Be-Ops",
       "use": "Reserved 16-bit NOP/future ops",
       "url": "https://github.com/riscv/riscv-isa-manual",
-      "instructions": {}
+      "instructions": {
+        "c_mop_N": {
+          "encoding": "----------------01100---10000001",
+          "variable_fields": [
+            "c_mop_t"
+          ],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6081",
+          "mask": "0xf8ff"
+        }
+      }
     },
     {
       "id": "Zclsd",


### PR DESCRIPTION
## Summary

Added missing `c_mop_N` instruction mapping for the `Zcmop` extension and updated synchronization handling for case-sensitive instruction keys.

## Changes

* added missing `c_mop_N` instruction entry
* added synchronization handling for case-sensitive compressed MOP instruction keys
* regenerated synchronized instruction metadata

## Why

The `c_mop_N` instruction entry already exists in `instr_dict.json` with valid encoding and match/mask values, but the `Zcmop` extension instruction list was missing the mapping.

Additionally, synchronization normalization lowercased the canonical instruction key, preventing correct resolution of the case-sensitive dictionary entry.

This change preserves compatibility for existing normalization behavior while correctly synchronizing the compressed MOP instruction entry.

## Testing

Tested locally by:

* running `node scripts/sync_instructions.mjs`
* verifying synchronized instruction metadata updated successfully
* verifying no missing warning remained for `Zcmop`
