### PR TITLE
fix: Add missing deprecated instructions (SLO, SLOI, SRO, SROI) to the UI visualizer

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1510,6 +1510,9 @@ const RISCVExplorer = () => {
 
       // Zbb: Logical operations
       'ANDN', 'ORN', 'XNOR',
+      // Zbb: Deprecated logical operations
+      // adding these manually bcoz they are missing lol
+      'SLO', 'SLOI', 'SRO', 'SROI',
       // Zbb: Count leading/trailing zeros and population count
       'CLZ', 'CTZ', 'CPOP',
       'CLZW', 'CTZW', 'CPOPW',
@@ -1540,7 +1543,12 @@ const RISCVExplorer = () => {
     Zbb: [
       // Logical operations
       'ANDN', 'ORN', 'XNOR',
-      // Count leading/trailing zeros and population count
+      // logical operations that are old I guess
+      'SLO', 
+      'SLOI', // not sure why this one has I but whatever
+      'SRO', 
+      'SROI',
+      // Zbb: Count leading/trailing zeros and population count
       'CLZ', 'CTZ', 'CPOP',
       // RV64 word variants
       'CLZW', 'CTZW', 'CPOPW',

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1511,7 +1511,6 @@ const RISCVExplorer = () => {
       // Zbb: Logical operations
       'ANDN', 'ORN', 'XNOR',
       // Zbb: Deprecated logical operations
-      // adding these manually bcoz they are missing lol
       'SLO', 'SLOI', 'SRO', 'SROI',
       // Zbb: Count leading/trailing zeros and population count
       'CLZ', 'CTZ', 'CPOP',
@@ -1543,11 +1542,8 @@ const RISCVExplorer = () => {
     Zbb: [
       // Logical operations
       'ANDN', 'ORN', 'XNOR',
-      // logical operations that are old I guess
-      'SLO', 
-      'SLOI', // not sure why this one has I but whatever
-      'SRO', 
-      'SROI',
+      // Deprecated logical operations
+      'SLO', 'SLOI', 'SRO', 'SROI',
       // Zbb: Count leading/trailing zeros and population count
       'CLZ', 'CTZ', 'CPOP',
       // RV64 word variants


### PR DESCRIPTION
### Description

The B extension snapshot deprecated four instructions: `SLO`, `SLOI`, `SRO`, and `SROI`. While these exist in `src/riscv_extensions.json` with their complete encoding metadata, they were previously omitted from the instruction groupings in `src/risc_v_visualizer.jsx`. As a result, they were effectively invisible in the Instruction Set Snapshot and mnemonic navigation UI.

This PR addresses the omission by adding the missing mnemonics to the `B` and `Zbb` instruction groupings, successfully resolving the discrepancy between the underlying JSON catalog and the frontend rendering.

### Changes Made
- Added `SLO`, `SLOI`, `SRO`, and `SROI` to the `B` and `Zbb` instruction arrays within `src/risc_v_visualizer.jsx`.
- Added standard code comments indicating these are deprecated instructions to match surrounding conventions.

### Validation
- Validated via a local build check (`npm run build`).
- No build regression introduced; compiles cleanly.
