### PR TITLE
Bug: Fix SPA routing for Docker nginx deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ FROM nginx:alpine
 # Copy the build output from Stage 1 to Nginx's html directory
 # Note: If you use CRA, change '/app/dist' to '/app/build'
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+
+    gzip on;
+    gzip_types text/javascript application/javascript text/css;
+}


### PR DESCRIPTION
## Summary

Added nginx configuration for SPA routing support in Docker deployments.

## Changes

* added `nginx.conf`
* configured SPA fallback routing using `try_files`
* updated `Dockerfile` to copy nginx configuration into container

## Why

Currently, Docker nginx deployments return `404` errors when:

* refreshing nested routes
* opening shared links directly
* navigating directly to SPA routes

This happens because nginx attempts to resolve routes as physical file paths instead of serving `index.html`.

The added configuration ensures unknown routes correctly fall back to the React SPA entrypoint.

## Testing

Verified configuration changes locally and confirmed nginx SPA fallback configuration is correctly included in the Docker image setup.
