### PR TITLE
fix: remove duplicate bundle script from HTML template

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,5 @@
 </head>
 <body>
   <div id="root"></div>
-  <script src="/bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
This PR removes the manually added `/bundle.js` script tag from `public/index.html`.

The project already uses `HtmlWebpackPlugin`, which injects the generated bundle into `dist/index.html` during the Webpack build. Keeping the manual script caused the built HTML to include `bundle.js` twice.

## Changes
- Removed the hard-coded `/bundle.js` script tag from `public/index.html`.

## Results
- `dist/index.html` now includes only one generated bundle script.
- Avoids loading the application bundle twice.
- Keeps the HTML template compatible with Webpack’s automatic asset injection.

## Testing
- Ran `npm run build`.
- Confirmed the build completed successfully.
- Confirmed `dist/index.html` contains only one `bundle.js` script tag.