### PR TITLE
Add the Sh* augmented-hypervisor extensions (UDB completeness gap)

### DIFF
--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -21510,6 +21510,62 @@
       "desc": "Trace & Instrumentation",
       "use": "Trace / instrumentation spec tag",
       "url": "https://github.com/riscv/riscv-isa-manual"
+    },
+    {
+      "id": "Sha",
+      "name": "Sha",
+      "tags": ["rv_sha"],
+      "desc": "Augmented hypervisor",
+      "use": "Bundle of hypervisor augmentation requirements (profiles)",
+      "url": "https://github.com/riscv/riscv-isa-manual"
+    },
+    {
+      "id": "Shcounterenw",
+      "name": "Shcounterenw",
+      "tags": ["rv_shcounterenw"],
+      "desc": "Hypervisor counter enable",
+      "use": "Writable hcounteren for all supported counters",
+      "url": "https://github.com/riscv/riscv-isa-manual"
+    },
+    {
+      "id": "Shgatpa",
+      "name": "Shgatpa",
+      "tags": ["rv_shgatpa"],
+      "desc": "SvNNx4 guest translation for all supported S-mode modes, plus Bare",
+      "use": "Guest-physical address translation requirement",
+      "url": "https://github.com/riscv/riscv-isa-manual"
+    },
+    {
+      "id": "Shtvala",
+      "name": "Shtvala",
+      "tags": ["rv_shtvala"],
+      "desc": "Hypervisor Trap Value (htval) provides all needed values",
+      "use": "htval reporting requirement",
+      "url": "https://github.com/riscv/riscv-isa-manual"
+    },
+    {
+      "id": "Shvsatpa",
+      "name": "Shvsatpa",
+      "tags": ["rv_shvsatpa"],
+      "desc": "Virtual Supervisor address translation supports all supported S-mode modes",
+      "use": "VS-stage address translation requirement",
+      "url": "https://github.com/riscv/riscv-isa-manual"
+    },
+    {
+      "id": "Shvstvala",
+      "name": "Shvstvala",
+      "tags": ["rv_shvstvala"],
+      "desc": "Virtual Supervisor Trap Value (vstval) provides all needed values",
+      "use": "vstval reporting requirement",
+      "url": "https://github.com/riscv/riscv-isa-manual"
+    },
+    {
+      "id": "Shvstvecd",
+      "name": "Shvstvecd",
+      "tags": ["rv_shvstvecd"],
+      "desc": "Virtual Supervisor Trap Vector (vstvec) supports Direct mode",
+      "use": "vstvec Direct mode requirement",
+      "url": "https://github.com/riscv/riscv-isa-manual"
     }
   ]
 }


### PR DESCRIPTION
## Add the `Sh*` augmented-hypervisor extensions

Closes a completeness gap found by diffing this landscape against the **RISC-V Unified Database** (`riscv/riscv-unified-db`), the authoritative extension set.

### What was missing

The entire **`Sh*` "augmented hypervisor"** family exists in UDB but had **zero** representation here:

| Extension | Description |
|---|---|
| `Sha` | Augmented hypervisor (the umbrella bundle) |
| `Shcounterenw` | Hypervisor counter enable — writable `hcounteren` for all supported counters |
| `Shgatpa` | SvNNx4 guest translation for all supported S-mode modes, plus Bare |
| `Shtvala` | Hypervisor Trap Value (`htval`) provides all needed values |
| `Shvsatpa` | Virtual Supervisor address translation supports all supported S-mode modes |
| `Shvstvala` | Virtual Supervisor Trap Value (`vstval`) provides all needed values |
| `Shvstvecd` | Virtual Supervisor Trap Vector (`vstvec`) supports Direct mode |

These are privileged extensions mandated by the application-processor profiles (e.g. RVA23), so they matter for profile-completeness.

### Where they were added

All 7 are added to the **`s_trap`** category, alongside their supervisor analogues (`Sstvala`, `Sstvecd`, `Ssstateen`, …). Descriptions are taken from UDB's `long_name`. Two of them (`Shgatpa`, `Shvsatpa`) are address-translation-related and could alternatively live in `s_mem` — happy to move them if that fits the taxonomy better.

### Scope / diff

Pure addition — 7 entries, no other lines touched. The full UDB diff was **164 UDB extensions vs 218 here; 156 in common; these 8 in UDB but not in the landscape** (the 7 above + `Sm`).

### Known follow-up (not in this PR)

`Sm` (Machine mode) is also in UDB but appears here only as version-split `Sm1p11` / `Sm1p12` / `Sm1p13`. That's a naming/granularity difference rather than a clean omission, so it's left for a separate discussion on whether to add a canonical `Sm` entry.
