### PR TITLE
Feat/Custom ISA Configuration Builder v1

### DIFF
--- a/src/WorkspacePanel.jsx
+++ b/src/WorkspacePanel.jsx
@@ -1,0 +1,1089 @@
+/**
+ * WorkspacePanel.jsx — ISA Workspace
+ * Redesigned for professional tool-level UX.
+ */
+
+import React from 'react';
+import {
+  X,
+  Copy,
+  CheckCircle2,
+  Search,
+  Cpu,
+  ArrowRight,
+  ExternalLink,
+  Trash2,
+  Package,
+  Download,
+  Info,
+  BookOpen,
+  Terminal,
+  ChevronUp,
+  ChevronDown,
+  ChevronsUpDown,
+  Zap,
+} from 'lucide-react';
+
+import {
+  parseMarchString,
+  buildMarchString,
+  buildCombinedCatalog,
+  DATA_PROVENANCE,
+} from './marchUtils.js';
+import { buildIsaConfigYaml } from './exportUtils.js';
+
+// ---------------------------------------------------------------------------
+// WorkspacePanel
+// ---------------------------------------------------------------------------
+export default function WorkspacePanel({
+  open,
+  onClose,
+  workspaceIds,
+  lockedExtensions,
+  allExts,
+  onAddId,
+  onRemoveId,
+  onClear,
+  onLoadIds,
+  onSelectInstruction,
+}) {
+  const [marchTab, setMarchTab] = React.useState('encode');
+  const [marchInput, setMarchInput] = React.useState('');
+  const [parseResult, setParseResult] = React.useState(null);
+  const [encodeResult, setEncodeResult] = React.useState(null);
+  const [copiedMarch, setCopiedMarch] = React.useState(false);
+  const [catalogQuery, setCatalogQuery] = React.useState('');
+  const [catalogSort, setCatalogSort] = React.useState({ col: 'mnemonic', dir: 1 });
+  const [hoveredRow, setHoveredRow] = React.useState(null);
+  const [showExportOptions, setShowExportOptions] = React.useState(false);
+  const [includeInstructions, setIncludeInstructions] = React.useState(true);
+
+  const marchInputRef = React.useRef(null);
+
+  // Derived
+  const workspaceExts = React.useMemo(() => {
+    const lookup = new Map(allExts.map(e => [e.id, e]));
+    return Array.from(workspaceIds).map(id => lookup.get(id)).filter(Boolean);
+  }, [workspaceIds, allExts]);
+
+  const combinedCatalog = React.useMemo(
+    () => buildCombinedCatalog(Array.from(workspaceIds), allExts),
+    [workspaceIds, allExts]
+  );
+
+  const totalInstructions = combinedCatalog.length;
+
+  const filteredCatalog = React.useMemo(() => {
+    const q = catalogQuery.trim().toLowerCase();
+    let rows = q
+      ? combinedCatalog.filter(row =>
+        row.mnemonic.toLowerCase().includes(q) ||
+        row.match.toLowerCase().includes(q) ||
+        row.sources.some(s => s.extId.toLowerCase().includes(q))
+      )
+      : combinedCatalog;
+
+    const { col, dir } = catalogSort;
+    return [...rows].sort((a, b) => {
+      if (col === 'mnemonic') return dir * a.mnemonic.localeCompare(b.mnemonic);
+      if (col === 'source') return dir * a.sources[0].extId.localeCompare(b.sources[0].extId);
+      if (col === 'match') return dir * a.match.localeCompare(b.match);
+      return 0;
+    });
+  }, [combinedCatalog, catalogQuery, catalogSort]);
+
+  React.useEffect(() => {
+    if (marchTab !== 'encode') return;
+    setEncodeResult(buildMarchString(Array.from(workspaceIds), allExts));
+  }, [workspaceIds, allExts, marchTab]);
+
+  // Smart default: auto-disable instruction catalog for large selections
+  React.useEffect(() => {
+    setIncludeInstructions(totalInstructions <= 100);
+  }, [totalInstructions]);
+
+  React.useEffect(() => {
+    if (open && marchTab === 'decode') setTimeout(() => marchInputRef.current?.focus(), 80);
+  }, [open, marchTab]);
+
+  function handleParse() {
+    const result = parseMarchString(marchInput, allExts);
+    setParseResult(result);
+    if (result.resolvedIds.length > 0) onLoadIds(result.resolvedIds);
+  }
+
+  function handleCopyMarch() {
+    const march = encodeResult?.march;
+    if (!march) return;
+    navigator.clipboard?.writeText(march).catch(() => {
+      const el = document.createElement('textarea');
+      el.value = march; el.style.cssText = 'position:fixed;opacity:0';
+      document.body.appendChild(el); el.select();
+      document.execCommand('copy'); document.body.removeChild(el);
+    });
+    setCopiedMarch(true);
+    setTimeout(() => setCopiedMarch(false), 1500);
+  }
+
+  function handleExportYaml() {
+    const { yaml } = buildIsaConfigYaml(Array.from(workspaceIds), allExts, includeInstructions);
+    const blob = new Blob([yaml], { type: 'text/yaml' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    const baseProfile = encodeResult?.march ? encodeResult.march.split('_')[0] : 'core';
+    a.download = `riscv_${baseProfile}_config.yaml`;
+    a.click();
+    URL.revokeObjectURL(url);
+    setShowExportOptions(false);
+  }
+
+  function toggleSort(col) {
+    setCatalogSort(prev =>
+      prev.col === col ? { col, dir: -prev.dir } : { col, dir: 1 }
+    );
+  }
+
+  function SortIcon({ col }) {
+    if (catalogSort.col !== col) return <ChevronsUpDown size={10} style={{ opacity: 0.3 }} />;
+    return catalogSort.dir === 1
+      ? <ChevronUp size={10} style={{ color: 'var(--riscv-gold)' }} />
+      : <ChevronDown size={10} style={{ color: 'var(--riscv-gold)' }} />;
+  }
+
+  if (!open) return null;
+
+  const isEmpty = workspaceIds.size === 0;
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, zIndex: 40, display: 'flex',
+        fontFamily: "'Inter', sans-serif",
+      }}
+    >
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        style={{
+          position: 'absolute', inset: 0,
+          background: 'rgba(4,4,10,0.72)',
+          backdropFilter: 'blur(4px)',
+        }}
+      />
+
+      {/* Panel */}
+      <div
+        style={{
+          position: 'relative', marginLeft: 'auto',
+          width: 'min(640px, 100vw)',
+          height: '100%',
+          display: 'flex', flexDirection: 'column',
+          background: '#0b0b16',
+          borderLeft: '1px solid rgba(255,255,255,0.07)',
+          boxShadow: '-32px 0 80px rgba(0,0,0,0.8), -1px 0 0 rgba(245,197,66,0.06)',
+          animation: 'wsSlideIn 0.2s cubic-bezier(0.22,1,0.36,1)',
+        }}
+      >
+        {/* =========================================================================
+            HEADER
+            ========================================================================= */}
+        <div style={{
+          display: 'flex', alignItems: 'center', gap: 12,
+          padding: '14px 18px',
+          borderBottom: '1px solid rgba(255,255,255,0.06)',
+          background: 'linear-gradient(180deg, rgba(245,197,66,0.04) 0%, transparent 100%)',
+          flexShrink: 0,
+        }}>
+          {/* Icon + title */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1 }}>
+            <div style={{
+              width: 28, height: 28, borderRadius: 7,
+              background: 'rgba(245,197,66,0.12)',
+              border: '1px solid rgba(245,197,66,0.25)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+            }}>
+              <Cpu size={13} style={{ color: 'var(--riscv-gold)' }} />
+            </div>
+            <span style={{
+              fontWeight: 700, fontSize: 14, letterSpacing: '-0.01em',
+              color: '#e2e8f0',
+            }}>
+              Custom ISA Configuration Builder
+            </span>
+
+            {/* Stats badges */}
+            {!isEmpty && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+                <span style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 4,
+                  padding: '3px 8px', borderRadius: 6,
+                  background: 'rgba(245,197,66,0.1)',
+                  border: '1px solid rgba(245,197,66,0.22)',
+                  fontSize: 10, fontWeight: 700, color: 'var(--riscv-gold)',
+                  letterSpacing: '0.03em', minWidth: 52, justifyContent: 'center',
+                }}>
+                  <span style={{ color: '#fff', fontVariantNumeric: 'tabular-nums' }}>{workspaceIds.size}</span>
+                  <span style={{ opacity: 0.65, fontWeight: 500 }}>ext</span>
+                </span>
+                <span style={{ color: 'rgba(255,255,255,0.15)', fontSize: 9 }}>·</span>
+                <span style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 4,
+                  padding: '3px 8px', borderRadius: 6,
+                  background: 'rgba(99,179,237,0.08)',
+                  border: '1px solid rgba(99,179,237,0.18)',
+                  fontSize: 10, fontWeight: 700, color: '#7ec8e3',
+                  letterSpacing: '0.03em', minWidth: 68, justifyContent: 'center',
+                }}>
+                  <span style={{ color: '#bee3f8', fontVariantNumeric: 'tabular-nums' }}>{totalInstructions.toLocaleString()}</span>
+                  <span style={{ opacity: 0.65, fontWeight: 500 }}>instr</span>
+                </span>
+              </div>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            {!isEmpty && (
+              <div style={{ position: 'relative' }}>
+                <button
+                  onClick={() => setShowExportOptions(!showExportOptions)}
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 6,
+                    padding: '6px 12px', borderRadius: 6,
+                    background: showExportOptions ? 'rgba(16, 185, 129, 0.15)' : 'rgba(16, 185, 129, 0.08)',
+                    border: '1px solid rgba(16, 185, 129, 0.25)',
+                    color: '#34d399', fontSize: 11, fontWeight: 600,
+                    cursor: 'pointer', transition: 'all 0.2s ease',
+                  }}
+                  onMouseEnter={e => {
+                    e.currentTarget.style.background = 'rgba(16, 185, 129, 0.2)';
+                    e.currentTarget.style.borderColor = 'rgba(16, 185, 129, 0.4)';
+                  }}
+                  onMouseLeave={e => { 
+                    if (!showExportOptions) {
+                      e.currentTarget.style.background = 'rgba(16, 185, 129, 0.08)';
+                      e.currentTarget.style.borderColor = 'rgba(16, 185, 129, 0.25)';
+                    } else {
+                      e.currentTarget.style.background = 'rgba(16, 185, 129, 0.15)';
+                      e.currentTarget.style.borderColor = 'rgba(16, 185, 129, 0.25)';
+                    }
+                  }}
+                >
+                  <Download size={13} /> Export YAML
+                </button>
+
+                {showExportOptions && (
+                  <div style={{
+                    position: 'absolute', top: 'calc(100% + 8px)', right: 0,
+                    zIndex: 50,
+                    display: 'flex', flexDirection: 'column', gap: 0,
+                    borderRadius: 10,
+                    background: 'linear-gradient(145deg, #1a1f2e 0%, #141824 100%)',
+                    border: '1px solid rgba(245,197,66,0.25)',
+                    boxShadow: '0 12px 32px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.03) inset',
+                    minWidth: 280, overflow: 'hidden',
+                  }}>
+
+                    {/* Header strip */}
+                    <div style={{
+                      display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                      padding: '10px 14px',
+                      borderBottom: '1px solid rgba(255,255,255,0.06)',
+                      background: 'rgba(245,197,66,0.04)',
+                    }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+                        <Package size={12} style={{ color: 'var(--riscv-gold)', opacity: 0.85 }} />
+                        <span style={{ fontSize: 11, color: '#f1f5f9', fontWeight: 700, letterSpacing: '0.01em' }}>
+                          Export Configuration YAML
+                        </span>
+                      </div>
+                      <button
+                        onClick={() => setShowExportOptions(false)}
+                        style={{ background: 'none', border: 'none', color: '#475569', cursor: 'pointer', padding: 2, lineHeight: 0, borderRadius: 4 }}
+                        onMouseEnter={e => e.currentTarget.style.color = '#94a3b8'}
+                        onMouseLeave={e => e.currentTarget.style.color = '#475569'}
+                      ><X size={13} /></button>
+                    </div>
+
+                    {/* Toggle card */}
+                    <div style={{ padding: '12px 14px' }}>
+                      <div
+                        onClick={() => setIncludeInstructions(v => !v)}
+                        style={{
+                          display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12,
+                          padding: '10px 12px', borderRadius: 8, cursor: 'pointer',
+                          background: includeInstructions ? 'rgba(245,197,66,0.07)' : 'rgba(255,255,255,0.03)',
+                          border: `1px solid ${includeInstructions ? 'rgba(245,197,66,0.2)' : 'rgba(255,255,255,0.07)'}`,
+                          transition: 'all 0.2s',
+                          userSelect: 'none',
+                        }}
+                      >
+                        <div style={{ flex: 1 }}>
+                          <span style={{
+                            fontSize: 11.5, fontWeight: 600,
+                            color: includeInstructions ? '#f1f5f9' : '#94a3b8',
+                            display: 'block', lineHeight: 1.35, transition: 'color 0.2s',
+                          }}>
+                            Include instruction catalog
+                          </span>
+                          <span style={{
+                            fontSize: 10, marginTop: 2, display: 'block',
+                            color: totalInstructions > 100 ? '#f59e0b' : '#64748b',
+                            fontVariantNumeric: 'tabular-nums',
+                          }}>
+                            {totalInstructions.toLocaleString()} instructions{totalInstructions > 100 ? ' · large export' : ''}
+                          </span>
+                        </div>
+
+                        {/* Premium toggle track */}
+                        <div style={{
+                          width: 38, height: 21, borderRadius: 11, flexShrink: 0,
+                          background: includeInstructions
+                            ? 'linear-gradient(135deg, #f5c542 0%, #fde68a 100%)'
+                            : 'rgba(255,255,255,0.08)',
+                          boxShadow: includeInstructions ? '0 0 8px rgba(245,197,66,0.4)' : 'none',
+                          position: 'relative', transition: 'all 0.25s',
+                          border: `1px solid ${includeInstructions ? 'rgba(245,197,66,0.7)' : 'rgba(255,255,255,0.12)'}`,
+                        }}>
+                          <div style={{
+                            width: 15, height: 15, borderRadius: '50%',
+                            background: includeInstructions ? '#1a1206' : '#475569',
+                            position: 'absolute', top: 2,
+                            left: includeInstructions ? 19 : 2,
+                            transition: 'all 0.25s',
+                            boxShadow: '0 1px 3px rgba(0,0,0,0.4)',
+                          }} />
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Download button */}
+                    <div style={{ padding: '0 14px 13px' }}>
+                      <button
+                        onClick={handleExportYaml}
+                        style={{
+                          width: '100%', padding: '9px 14px', borderRadius: 7,
+                          background: 'linear-gradient(135deg, rgba(245,197,66,0.22) 0%, rgba(245,197,66,0.12) 100%)',
+                          color: 'var(--riscv-gold)',
+                          border: '1px solid rgba(245,197,66,0.4)',
+                          fontSize: 11.5, fontWeight: 700,
+                          cursor: 'pointer', transition: 'all 0.18s',
+                          letterSpacing: '0.02em',
+                          display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+                        }}
+                        onMouseEnter={e => {
+                          e.currentTarget.style.background = 'linear-gradient(135deg, rgba(245,197,66,0.35) 0%, rgba(245,197,66,0.22) 100%)';
+                          e.currentTarget.style.boxShadow = '0 0 12px rgba(245,197,66,0.2)';
+                        }}
+                        onMouseLeave={e => {
+                          e.currentTarget.style.background = 'linear-gradient(135deg, rgba(245,197,66,0.22) 0%, rgba(245,197,66,0.12) 100%)';
+                          e.currentTarget.style.boxShadow = 'none';
+                        }}
+                      >
+                        <Package size={11} />
+                        Download .yaml
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {!isEmpty && (
+              <button
+                onClick={onClear}
+                style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 6,
+                  padding: '6px 12px', borderRadius: 6,
+                  background: 'rgba(239, 68, 68, 0.08)',
+                  border: '1px solid rgba(239, 68, 68, 0.25)',
+                  color: '#f87171', fontSize: 11, fontWeight: 600,
+                  cursor: 'pointer',
+                  transition: 'all 0.2s ease',
+                }}
+                onMouseEnter={e => {
+                  e.currentTarget.style.background = 'rgba(239, 68, 68, 0.15)';
+                  e.currentTarget.style.borderColor = 'rgba(239, 68, 68, 0.4)';
+                }}
+                onMouseLeave={e => {
+                  e.currentTarget.style.background = 'rgba(239, 68, 68, 0.08)';
+                  e.currentTarget.style.borderColor = 'rgba(239, 68, 68, 0.25)';
+                }}
+              >
+                <Trash2 size={13} /> Clear all
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              style={{
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                width: 28, height: 28, borderRadius: 6,
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid rgba(255,255,255,0.08)',
+                color: '#64748b', cursor: 'pointer',
+                transition: 'all 0.15s',
+              }}
+              onMouseEnter={e => { e.currentTarget.style.background = 'rgba(255,255,255,0.08)'; e.currentTarget.style.color = '#e2e8f0'; }}
+              onMouseLeave={e => { e.currentTarget.style.background = 'rgba(255,255,255,0.04)'; e.currentTarget.style.color = '#64748b'; }}
+            >
+              <X size={13} />
+            </button>
+          </div>
+        </div>
+
+        {/* =========================================================================
+            SCROLLABLE BODY
+            ========================================================================= */}
+        <div style={{ flex: 1, overflowY: 'auto', overscrollBehavior: 'contain' }}>
+
+          {/* --- EMPTY STATE --- */}
+          {isEmpty && (
+            <div style={{
+              display: 'flex', flexDirection: 'column', alignItems: 'center',
+              justifyContent: 'center', textAlign: 'center',
+              padding: '60px 40px', gap: 20,
+            }}>
+              <div style={{
+                width: 64, height: 64, borderRadius: 16,
+                background: 'rgba(245,197,66,0.06)',
+                border: '1px solid rgba(245,197,66,0.15)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                boxShadow: '0 0 40px rgba(245,197,66,0.06)',
+              }}>
+                <Package size={28} style={{ color: 'rgba(245,197,66,0.4)' }} />
+              </div>
+              <div>
+                <p style={{ fontSize: 14, fontWeight: 600, color: '#94a3b8', marginBottom: 6 }}>
+                  No extensions selected
+                </p>
+                <p style={{ fontSize: 12, color: '#475569', maxWidth: 260, lineHeight: 1.6 }}>
+                  Hover any extension tile and click the <strong style={{ color: 'var(--riscv-gold)' }}>+</strong> badge to add it here. Or paste a{' '}
+                  <code style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: 11, color: '#94a3b8' }}>-march</code> string in the decode tab.
+                </p>
+              </div>
+              {/* Show decode input when empty too */}
+              <button
+                onClick={() => setMarchTab('decode')}
+                style={{
+                  display: 'inline-flex', alignItems: 'center', gap: 6,
+                  padding: '8px 16px', borderRadius: 8,
+                  background: 'rgba(245,197,66,0.1)',
+                  border: '1px solid rgba(245,197,66,0.25)',
+                  color: 'var(--riscv-gold)', fontSize: 12, fontWeight: 500,
+                  cursor: 'pointer',
+                }}
+              >
+                <Terminal size={12} /> Paste -march string
+              </button>
+            </div>
+          )}
+
+          {/* Populated state */}
+          {!isEmpty && (
+            <Section label="Selected Extensions" count={workspaceIds.size} icon={<Cpu size={11} />}>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {workspaceExts.map(ext => (
+                  <ExtChip
+                    key={ext.id}
+                    ext={ext}
+                    lockedBy={lockedExtensions?.get(ext.id)}
+                    onRemove={() => onRemoveId(ext.id)}
+                  />
+                ))}
+              </div>
+            </Section>
+          )}
+
+          {/* Tabs */}
+          <Divider />
+          <Section label="-march Tool" icon={<Terminal size={11} />}>
+            {/* Tab row */}
+            <div style={{ display: 'flex', gap: 4, marginBottom: 14 }}>
+              {['encode', 'decode'].map(tab => (
+                <button
+                  key={tab}
+                  onClick={() => { setMarchTab(tab); setParseResult(null); }}
+                  style={{
+                    padding: '6px 14px', borderRadius: 7, fontSize: 11,
+                    fontWeight: 600, fontFamily: 'JetBrains Mono, monospace',
+                    cursor: 'pointer', letterSpacing: '0.04em',
+                    textTransform: 'uppercase',
+                    transition: 'all 0.15s',
+                    ...(marchTab === tab ? {
+                      background: 'rgba(245,197,66,0.15)',
+                      border: '1px solid rgba(245,197,66,0.35)',
+                      color: 'var(--riscv-gold)',
+                    } : {
+                      background: 'rgba(255,255,255,0.03)',
+                      border: '1px solid rgba(255,255,255,0.07)',
+                      color: '#475569',
+                    }),
+                  }}
+                >
+                  {tab}
+                </button>
+              ))}
+            </div>
+
+            {/* Encode tab */}
+            {marchTab === 'encode' && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                {encodeResult?.march ? (
+                  <>
+                    <div style={{
+                      display: 'flex', alignItems: 'center', gap: 0,
+                      borderRadius: 9, overflow: 'hidden',
+                      border: '1px solid rgba(245,197,66,0.2)',
+                      background: 'rgba(245,197,66,0.04)',
+                    }}>
+                      <code style={{
+                        flex: 1, padding: '11px 14px',
+                        fontFamily: 'JetBrains Mono, monospace',
+                        fontSize: 12.5, color: '#f5c542',
+                        wordBreak: 'break-all', letterSpacing: '0.01em',
+                      }}>
+                        {encodeResult.march}
+                      </code>
+                      <button
+                        onClick={handleCopyMarch}
+                        style={{
+                          flexShrink: 0,
+                          display: 'flex', alignItems: 'center', justifyContent: 'center',
+                          width: 44, alignSelf: 'stretch',
+                          borderLeft: '1px solid rgba(245,197,66,0.15)',
+                          background: copiedMarch ? 'rgba(32,217,160,0.1)' : 'transparent',
+                          color: copiedMarch ? '#20d9a0' : '#475569',
+                          cursor: 'pointer', transition: 'all 0.15s',
+                        }}
+                        onMouseEnter={e => { if (!copiedMarch) { e.currentTarget.style.background = 'rgba(245,197,66,0.1)'; e.currentTarget.style.color = 'var(--riscv-gold)'; } }}
+                        onMouseLeave={e => { if (!copiedMarch) { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = '#475569'; } }}
+                        title="Copy -march string"
+                      >
+                        {copiedMarch
+                          ? <CheckCircle2 size={14} />
+                          : <Copy size={14} />}
+                      </button>
+                    </div>
+
+                    {encodeResult.excluded.length > 0 && (
+                      <div style={{
+                        borderRadius: 8, padding: '12px 14px',
+                        background: 'rgba(255,160,122,0.06)',
+                        border: '1px solid rgba(255,160,122,0.15)',
+                        marginTop: 4
+                      }}>
+                        <p style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 10.5, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em', color: '#ffa07a', marginBottom: 10, marginTop: 0 }}>
+                          <Info size={13} /> Excluded from -march
+                        </p>
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                          {encodeResult.excluded.map(ex => (
+                            <div key={ex.id} style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+                              <span style={{
+                                display: 'inline-flex', padding: '2px 6px', borderRadius: 4,
+                                background: 'rgba(255,255,255,0.08)',
+                                fontFamily: 'JetBrains Mono, monospace', fontSize: 11, fontWeight: 600, color: '#e2e8f0'
+                              }}>
+                                {ex.id}
+                              </span>
+                              <span style={{ fontSize: 11, color: '#94a3b8', lineHeight: 1.4 }}>{ex.reason}</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </>
+                ) : (
+                  <div style={{
+                    borderRadius: 8, padding: '14px',
+                    background: 'rgba(255,255,255,0.02)',
+                    border: '1px solid rgba(255,255,255,0.06)',
+                    textAlign: 'center',
+                    fontSize: 12, color: '#475569',
+                  }}>
+                    {isEmpty
+                      ? 'Select extensions from the tile view to generate a -march string.'
+                      : 'Add a base ISA (RV32I, RV64I, …) to generate a -march string.'}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Decode tab */}
+            {marchTab === 'decode' && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <div style={{
+                    flex: 1, display: 'flex', alignItems: 'center',
+                    borderRadius: 8, overflow: 'hidden',
+                    border: '1px solid rgba(255,255,255,0.09)',
+                    background: 'rgba(255,255,255,0.03)',
+                    transition: 'border-color 0.15s',
+                  }}>
+                    <input
+                      ref={marchInputRef}
+                      type="text"
+                      value={marchInput}
+                      onChange={e => { setMarchInput(e.target.value); setParseResult(null); }}
+                      onKeyDown={e => e.key === 'Enter' && handleParse()}
+                      placeholder="rv64gc_zba_zbb_zicsr_zifencei"
+                      style={{
+                        flex: 1, padding: '10px 12px',
+                        background: 'transparent', border: 'none', outline: 'none',
+                        fontFamily: 'JetBrains Mono, monospace',
+                        fontSize: 12, color: '#e2e8f0',
+                        caretColor: 'var(--riscv-gold)',
+                      }}
+                    />
+                  </div>
+                  <button
+                    onClick={handleParse}
+                    style={{
+                      display: 'inline-flex', alignItems: 'center', gap: 6,
+                      padding: '10px 14px', borderRadius: 8,
+                      background: 'rgba(245,197,66,0.14)',
+                      border: '1px solid rgba(245,197,66,0.3)',
+                      color: 'var(--riscv-gold)', fontSize: 11,
+                      fontWeight: 600, cursor: 'pointer',
+                      transition: 'all 0.15s', flexShrink: 0,
+                    }}
+                    onMouseEnter={e => e.currentTarget.style.background = 'rgba(245,197,66,0.22)'}
+                    onMouseLeave={e => e.currentTarget.style.background = 'rgba(245,197,66,0.14)'}
+                  >
+                    <ArrowRight size={12} /> Parse
+                  </button>
+                </div>
+
+                {parseResult && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {parseResult.resolvedIds.length > 0 && (
+                      <div style={{
+                        borderRadius: 8, padding: '12px',
+                        background: 'rgba(32,217,160,0.06)',
+                        border: '1px solid rgba(32,217,160,0.18)',
+                      }}>
+                        <p style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: '#20d9a0', marginBottom: 9 }}>
+                          ✓ Resolved {parseResult.resolvedIds.length} extensions — added to workspace
+                        </p>
+                        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
+                          {parseResult.resolvedIds.map(id => (
+                            <span key={id} style={{
+                              padding: '3px 8px', borderRadius: 5,
+                              fontFamily: 'JetBrains Mono, monospace', fontSize: 10,
+                              background: 'rgba(32,217,160,0.08)',
+                              border: '1px solid rgba(32,217,160,0.25)',
+                              color: '#a7f3d0',
+                            }}>{id}</span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                    {parseResult.gExpanded && (
+                      <InfoPill icon={<Zap size={10} />}>
+                        "g" expanded → {['I', 'M', 'A', 'F', 'D', 'Zicsr', 'Zifencei'].join(' · ')}
+                      </InfoPill>
+                    )}
+                    {parseResult.unknownTokens && parseResult.unknownTokens.length > 0 && (
+                      <div style={{
+                        borderRadius: 8, padding: '10px 12px',
+                        background: 'rgba(245,197,66,0.05)',
+                        border: '1px solid rgba(245,197,66,0.15)',
+                      }}>
+                        <p style={{ fontSize: 10, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', color: '#f59e0b', marginBottom: 7 }}>
+                          Not in catalog ({parseResult.unknownTokens.length})
+                        </p>
+                        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5 }}>
+                          {parseResult.unknownTokens.map(t => (
+                            <span key={t} style={{
+                              padding: '2px 7px', borderRadius: 4,
+                              fontFamily: 'monospace', fontSize: 10,
+                              background: 'rgba(245,197,66,0.07)',
+                              border: '1px solid rgba(245,197,66,0.2)',
+                              color: '#fde68a',
+                            }}>{t}</span>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                    {parseResult.warnings && parseResult.warnings.length > 0 && (
+                      <div style={{
+                        borderRadius: 8, padding: '12px 14px',
+                        background: 'rgba(255,160,122,0.06)',
+                        border: '1px solid rgba(255,160,122,0.15)',
+                        marginTop: 4
+                      }}>
+                        <p style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 10.5, fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.06em', color: '#ffa07a', marginBottom: 10, marginTop: 0 }}>
+                          <Info size={13} /> Decoder Notes
+                        </p>
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                          {parseResult.warnings.map((warn, i) => (
+                            <div key={i} style={{ fontSize: 11, color: '#94a3b8', lineHeight: 1.4 }}>
+                              • {warn}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </Section>
+
+          {/* Instruction catalog tab */}
+          {!isEmpty && (
+            <>
+              <Divider />
+              <Section
+                label="Combined Instruction Catalog"
+                count={filteredCatalog.length}
+                total={totalInstructions}
+                icon={<BookOpen size={11} />}
+              >
+                {/* Search bar */}
+                <div style={{
+                  display: 'flex', alignItems: 'center', gap: 8,
+                  padding: '8px 11px',
+                  borderRadius: 8,
+                  border: '1px solid rgba(255,255,255,0.08)',
+                  background: 'rgba(255,255,255,0.025)',
+                  marginBottom: 10,
+                }}>
+                  <Search size={13} style={{ color: '#475569', flexShrink: 0 }} />
+                  <input
+                    type="text"
+                    value={catalogQuery}
+                    onChange={e => setCatalogQuery(e.target.value)}
+                    placeholder="Filter by mnemonic, extension, match value…"
+                    style={{
+                      flex: 1, background: 'transparent',
+                      border: 'none', outline: 'none',
+                      fontSize: 12, color: '#e2e8f0',
+                      caretColor: 'var(--riscv-gold)',
+                    }}
+                  />
+                  {catalogQuery && (
+                    <button
+                      onClick={() => setCatalogQuery('')}
+                      style={{ color: '#475569', background: 'none', border: 'none', cursor: 'pointer', padding: 0 }}
+                    >
+                      <X size={12} />
+                    </button>
+                  )}
+                </div>
+
+                {/* Table */}
+                <div style={{
+                  borderRadius: 10,
+                  border: '1px solid rgba(255,255,255,0.07)',
+                  overflow: 'hidden',
+                }}>
+                  {/* Header */}
+                  <div style={{
+                    display: 'grid',
+                    gridTemplateColumns: '2fr 1.5fr 1.5fr',
+                    padding: '9px 14px',
+                    background: 'rgba(255,255,255,0.03)',
+                    borderBottom: '1px solid rgba(255,255,255,0.07)',
+                  }}>
+                    {[
+                      { col: 'mnemonic', label: 'Mnemonic' },
+                      { col: 'source', label: 'Source(s)' },
+                      { col: 'match', label: 'Match' },
+                    ].map(({ col, label }) => (
+                      <button
+                        key={col}
+                        onClick={() => toggleSort(col)}
+                        style={{
+                          display: 'inline-flex', alignItems: 'center', gap: 5,
+                          background: 'none', border: 'none', cursor: 'pointer', padding: 0,
+                          fontSize: 10, fontWeight: 700,
+                          textTransform: 'uppercase', letterSpacing: '0.07em',
+                          color: catalogSort.col === col ? '#94a3b8' : '#334155',
+                          transition: 'color 0.15s',
+                        }}
+                        onMouseEnter={e => e.currentTarget.style.color = '#64748b'}
+                        onMouseLeave={e => e.currentTarget.style.color = catalogSort.col === col ? '#94a3b8' : '#334155'}
+                      >
+                        {label} <SortIcon col={col} />
+                      </button>
+                    ))}
+                  </div>
+
+                  {/* Rows */}
+                  <div style={{ maxHeight: 380, overflowY: 'auto', overscrollBehavior: 'contain' }}>
+                    {filteredCatalog.length === 0 ? (
+                      <div style={{
+                        padding: '24px', textAlign: 'center',
+                        fontSize: 12, color: '#334155',
+                      }}>
+                        {catalogQuery ? 'No instructions match the filter.' : 'No instructions in selected extensions.'}
+                      </div>
+                    ) : (
+                      filteredCatalog.slice(0, 300).map((row, i) => (
+                        <CatalogRow
+                          key={row.key}
+                          row={row}
+                          isEven={i % 2 === 0}
+                          isHovered={hoveredRow === row.key}
+                          onHover={setHoveredRow}
+                          onSelect={onSelectInstruction}
+                        />
+                      ))
+                    )}
+                    {filteredCatalog.length > 300 && (
+                      <div style={{
+                        padding: '10px 14px',
+                        background: 'rgba(255,255,255,0.02)',
+                        borderTop: '1px solid rgba(255,255,255,0.06)',
+                        fontSize: 10, color: '#334155', textAlign: 'center',
+                      }}>
+                        Showing first 300 of {filteredCatalog.length.toLocaleString()}. Use filter to narrow results.
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <p style={{ fontSize: 10, color: '#334155', marginTop: 6 }}>
+                  Deduplicated by mnemonic + encoding.
+                  Same instruction shared across extensions → shown once, all sources listed.
+                </p>
+              </Section>
+            </>
+          )}
+
+          {/* =========================================================================
+              DATA PROVENANCE FOOTER
+              ========================================================================= */}
+          <div style={{
+            margin: '8px 18px 18px',
+            borderRadius: 9,
+            background: 'rgba(255,255,255,0.02)',
+            border: '1px solid rgba(255,255,255,0.06)',
+            padding: '12px 14px',
+          }}>
+            <p style={{
+              fontSize: 9, fontWeight: 700, textTransform: 'uppercase',
+              letterSpacing: '0.1em', color: '#334155', marginBottom: 9,
+            }}>
+              Data Sources
+            </p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+              {DATA_PROVENANCE.map(p => (
+                <div key={p.label} style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+                  <span style={{ fontSize: 10, color: '#475569', flexShrink: 0 }}>{p.label}</span>
+                  <span style={{ height: 1, flex: 1, background: 'rgba(255,255,255,0.04)', alignSelf: 'center' }} />
+                  <a
+                    href={p.url} target="_blank" rel="noreferrer"
+                    style={{
+                      display: 'inline-flex', alignItems: 'center', gap: 4,
+                      fontSize: 10, color: '#8b7cf8', textDecoration: 'none',
+                      flexShrink: 0,
+                    }}
+                    onMouseEnter={e => e.currentTarget.style.color = '#a89af9'}
+                    onMouseLeave={e => e.currentTarget.style.color = '#8b7cf8'}
+                  >
+                    {p.source} <ExternalLink size={9} />
+                  </a>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Animation keyframes injected once */}
+      <style>{`
+        @keyframes wsSlideIn {
+          from { transform: translateX(40px); opacity: 0; }
+          to   { transform: translateX(0);    opacity: 1; }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+function Section({ label, icon, count, total, children }) {
+  return (
+    <div style={{ padding: '14px 18px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 12 }}>
+        <span style={{ color: '#334155' }}>{icon}</span>
+        <span style={{
+          fontSize: 10, fontWeight: 700, textTransform: 'uppercase',
+          letterSpacing: '0.08em', color: '#475569',
+        }}>
+          {label}
+        </span>
+        {count !== undefined && (
+          <span style={{
+            fontSize: 10, color: '#334155', fontFamily: 'JetBrains Mono, monospace',
+          }}>
+            {total !== undefined && count !== total
+              ? `${count.toLocaleString()} / ${total.toLocaleString()}`
+              : count.toLocaleString()}
+          </span>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Divider() {
+  return (
+    <div style={{
+      margin: '0 18px',
+      borderTop: '1px solid rgba(255,255,255,0.05)',
+    }} />
+  );
+}
+
+function InfoPill({ icon, children }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'flex-start', gap: 7,
+      padding: '8px 11px', borderRadius: 7,
+      background: 'rgba(255,255,255,0.03)',
+      border: '1px solid rgba(255,255,255,0.07)',
+      fontSize: 11, color: '#64748b',
+    }}>
+      <span style={{ flexShrink: 0, marginTop: 1, color: '#475569' }}>{icon}</span>
+      {children}
+    </div>
+  );
+}
+
+// ============================================================================
+// Extension chip with remove button
+// ============================================================================
+function ExtChip({ ext, lockedBy, onRemove }) {
+  const [hovered, setHovered] = React.useState(false);
+  const isLocked = lockedBy && lockedBy.length > 0;
+
+  return (
+    <span
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: 4,
+        paddingLeft: 9, paddingRight: 5, paddingTop: 4, paddingBottom: 4,
+        borderRadius: 7,
+        background: hovered && !isLocked ? 'rgba(245,197,66,0.12)' : (isLocked ? 'rgba(245,197,66,0.03)' : 'rgba(245,197,66,0.07)'),
+        border: `1px solid ${hovered && !isLocked ? 'rgba(245,197,66,0.35)' : (isLocked ? 'rgba(245,197,66,0.1)' : 'rgba(245,197,66,0.18)')}`,
+        transition: 'all 0.15s',
+        opacity: isLocked ? 0.7 : 1,
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      title={isLocked ? `Required by ${lockedBy.join(', ')} — remove dependent first` : undefined}
+    >
+      <span style={{
+        fontFamily: 'JetBrains Mono, monospace',
+        fontSize: 11, fontWeight: 600,
+        color: isLocked ? 'rgba(245,197,66,0.6)' : 'var(--riscv-gold)',
+        letterSpacing: '0.02em',
+      }}>
+        {ext.id}
+      </span>
+      <button
+        onClick={isLocked ? undefined : onRemove}
+        disabled={isLocked}
+        style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          width: 16, height: 16, borderRadius: 4,
+          background: (hovered && !isLocked) ? 'rgba(255,255,255,0.08)' : 'transparent',
+          border: 'none', cursor: isLocked ? 'not-allowed' : 'pointer',
+          color: isLocked ? 'rgba(255,255,255,0.15)' : (hovered ? '#94a3b8' : '#475569'),
+          transition: 'all 0.12s',
+          padding: 0,
+        }}
+      >
+        <X size={9} />
+      </button>
+    </span>
+  );
+}
+
+// ============================================================================
+// Catalog table row
+// ============================================================================
+function CatalogRow({ row, isEven, isHovered, onHover, onSelect }) {
+  const multiSource = row.sources.length > 1;
+
+  // Assign a color per source extension (deterministic, based on first char)
+  function srcColor(extId) {
+    const palette = [
+      '#8b7cf8', '#f472b6', '#2dd4bf', '#60a5fa', '#f5c542',
+      '#34d399', '#fb923c', '#a78bfa', '#f87171',
+    ];
+    let h = 0;
+    for (const c of extId) h = (h * 31 + c.charCodeAt(0)) & 0xffff;
+    return palette[h % palette.length];
+  }
+
+  return (
+    <button
+      onMouseEnter={() => onHover(row.key)}
+      onMouseLeave={() => onHover(null)}
+      onClick={() => onSelect({
+        extId: row.sources[0].extId,
+        mnemonic: row.mnemonic,
+        encoding: row.encoding,
+        variable_fields: row.variable_fields,
+        match: row.match,
+        mask: row.mask,
+      })}
+      style={{
+        display: 'grid', gridTemplateColumns: '2fr 1.5fr 1.5fr',
+        width: '100%', padding: '9px 14px',
+        background: isHovered
+          ? 'rgba(139,124,248,0.07)'
+          : isEven ? 'transparent' : 'rgba(255,255,255,0.012)',
+        borderBottom: '1px solid rgba(255,255,255,0.04)',
+        cursor: 'pointer', textAlign: 'left',
+        transition: 'background 0.1s',
+        border: 'none',
+        outline: isHovered ? '1px solid rgba(139,124,248,0.2)' : 'none',
+        outlineOffset: -1,
+      }}
+    >
+      {/* Mnemonic */}
+      <span style={{
+        fontFamily: 'JetBrains Mono, monospace',
+        fontSize: 12, fontWeight: 600,
+        color: isHovered ? '#c4b5fd' : '#e2e8f0',
+        paddingRight: 8,
+        transition: 'color 0.1s',
+      }}>
+        {row.mnemonic}
+      </span>
+
+      {/* Source(s) */}
+      <span style={{ display: 'flex', flexWrap: 'wrap', gap: 3, paddingRight: 8, alignItems: 'center' }}>
+        {row.sources.map(s => (
+          <span key={s.extId} style={{
+            padding: '1px 6px', borderRadius: 4,
+            fontSize: 10, fontFamily: 'JetBrains Mono, monospace',
+            fontWeight: 500,
+            background: `${srcColor(s.extId)}18`,
+            border: `1px solid ${srcColor(s.extId)}38`,
+            color: srcColor(s.extId),
+            letterSpacing: '0.02em',
+          }}>
+            {s.extId}
+          </span>
+        ))}
+      </span>
+
+      {/* Match */}
+      <span style={{
+        fontFamily: 'JetBrains Mono, monospace',
+        fontSize: 11, color: '#475569',
+        letterSpacing: '0.01em',
+      }}>
+        {row.match || '—'}
+      </span>
+    </button>
+  );
+}

--- a/src/WorkspacePanel.jsx
+++ b/src/WorkspacePanel.jsx
@@ -133,8 +133,12 @@ export default function WorkspacePanel({
     a.href = url;
     const baseProfile = encodeResult?.march ? encodeResult.march.split('_')[0] : 'core';
     a.download = `riscv_${baseProfile}_config.yaml`;
+    document.body.appendChild(a);
     a.click();
-    URL.revokeObjectURL(url);
+    document.body.removeChild(a);
+    // Defer revocation — revoking synchronously cancels the download before
+    // the browser has had time to start reading the object URL.
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
     setShowExportOptions(false);
   }
 

--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -12,6 +12,7 @@
  *   Zve/Zvl sub-profile tokens: exact min version unconfirmed; verify with your toolchain.
  *   Base/gc extensions: universally stable.
  *   Full details and CI gap: see marchUtils.js COMPILER VERIFICATION SCOPE.
+ */
 
 import { buildMarchString, BASE_ISA_IDS, BASE_ISA_PREFIX_MAP } from './marchUtils.js';
 import { buildCombinedCatalog } from './marchUtils.js';

--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -1,0 +1,213 @@
+/**
+ * exportUtils.js — Export generator for the Custom ISA Configuration Builder
+ *
+ * Goal: produce a complete, accurate, self-describing ISA configuration file
+ * that is valuable on its own terms, not shaped to satisfy any specific
+ * external validator (riscv-config is confirmed deprecated; its named
+ * successor carries an explicit "work-in-progress" caution).
+ *
+ * COMPILER COMPATIBILITY SCOPE (per extension family):
+ *   Scalar crypto (Zk, Zkn, Zks, Zbkb, etc.): supported since ~GCC 12-13 / LLVM 14-15.
+ *   Vector crypto (Zvkned, Zvbb, Zvbc, Zvkg family): GCC 14+ / LLVM 18+ (stable).
+ *   Zve/Zvl sub-profile tokens: exact min version unconfirmed; verify with your toolchain.
+ *   Base/gc extensions: universally stable.
+ *   Full details and CI gap: see marchUtils.js COMPILER VERIFICATION SCOPE.
+
+import { buildMarchString, BASE_ISA_IDS, BASE_ISA_PREFIX_MAP } from './marchUtils.js';
+import { buildCombinedCatalog } from './marchUtils.js';
+
+// Tokens that are not valid ISA string entries (e.g. K, P are retired/placeholder)
+const INVALID_ISA_TOKENS = new Set(['K', 'P']);
+
+// Privilege / virtual-memory extension prefix patterns
+function isPrivilegeTag(id) {
+  return /^S[vms]/i.test(id) || id.toLowerCase().startsWith('sm') || id.toLowerCase().startsWith('ss');
+}
+
+/**
+ * Generates a complete, self-describing ISA configuration YAML for the
+ * selected extensions.
+ *
+ * The output is structured in two parts:
+ *   Part 1 — Header: base ISA, extension list, -march string, inferred
+ *             spec-version annotations, optional Vendor/Device fields.
+ *   Part 2 — Instruction catalog (if includeInstructions is true): the full
+ *             deduplicated instruction list for the selection, including
+ *             encoding, match/mask, variable fields, and source extension(s).
+ *
+ * @param {string[]} selectedIds      — extension IDs currently in the workspace
+ * @param {Array}    allExts          — full extension catalog (for catalog lookup)
+ * @param {boolean}  includeInstructions — whether to append the instruction catalog
+ * @returns {{ yaml: string, warnings: string[] }}
+ */
+export function buildIsaConfigYaml(selectedIds, allExts, includeInstructions = true) {
+  const warnings = [];
+
+  if (!selectedIds || selectedIds.length === 0) {
+    return { yaml: '', warnings: ['No extensions selected.'] };
+  }
+
+  // 1. Identify base ISA
+  let baseInfo = null;
+  for (const id of selectedIds) {
+    if (BASE_ISA_IDS.has(id)) {
+      baseInfo = { id, ...BASE_ISA_PREFIX_MAP[id] };
+      break;
+    }
+  }
+  if (!baseInfo) {
+    return { yaml: '', warnings: ['No base ISA selected.'] };
+  }
+
+  // 2. Partition extensions
+  const singleLetters = [];
+  const zExts        = [];
+  const privExts     = [];
+  const allExtTokens = []; // ordered list for the extensions: block
+
+  let hasZicsrOrZifencei = false;
+  let hasSupervisor      = false;
+
+  for (const id of selectedIds) {
+    if (BASE_ISA_IDS.has(id)) continue;
+
+    const idUpper = id.toUpperCase();
+
+    if (idUpper === 'ZICSR' || idUpper === 'ZIFENCEI') hasZicsrOrZifencei = true;
+    if (idUpper === 'S' || isPrivilegeTag(id)) hasSupervisor = true;
+
+    if (INVALID_ISA_TOKENS.has(idUpper)) continue;
+
+    if (isPrivilegeTag(id)) {
+      privExts.push(id);
+      allExtTokens.push(id);
+      continue;
+    }
+
+    if (id.length === 1) {
+      singleLetters.push(idUpper);
+      allExtTokens.push(idUpper);
+    } else {
+      const formatted = id.charAt(0).toUpperCase() + id.slice(1).toLowerCase();
+      zExts.push(formatted);
+      allExtTokens.push(formatted);
+    }
+  }
+
+  // 3. Sort single letters canonically (RISC-V Unprivileged ISA §27)
+  const CANONICAL_ORDER = ['I','E','M','A','F','D','Q','L','C','J','T','V','N','H','S','U'];
+  const canonMap = Object.fromEntries(CANONICAL_ORDER.map((c, i) => [c, i]));
+  singleLetters.sort((a, b) => {
+    const ia = canonMap[a] ?? 999, ib = canonMap[b] ?? 999;
+    return ia !== ib ? ia - ib : a.localeCompare(b);
+  });
+  const filteredSingles = singleLetters.filter(l => l !== baseInfo.base.toUpperCase());
+
+  // 4. Sort Z-extensions alphabetically
+  zExts.sort((a, b) => a.localeCompare(b));
+
+  // 5. Build the ISA march-like string
+  const basePrefix = `RV${baseInfo.xlen}${baseInfo.base.toUpperCase()}`;
+  const singlesStr = filteredSingles.join('');
+  const zStr       = zExts.length > 0 ? zExts.join('_') : '';
+  const isaString  = `${basePrefix}${singlesStr}${zStr ? (singlesStr ? '_' : '') + zStr : ''}`;
+
+  // 6. Infer spec-version annotations
+  // These are informational annotations derived from which extensions are
+  // present. They are NOT enum-validated fields for any specific tool.
+  const userSpecVersion  = hasZicsrOrZifencei ? '2.3' : '2.2';
+  const privSpecVersion  = hasSupervisor      ? '1.11' : '1.10';
+
+  // 7. Build -march string (compiler flag)
+  // Compatibility: scalar crypto ~GCC12-13/LLVM14-15; vector crypto GCC14+/LLVM18+;
+  // Zve/Zvl version floor unconfirmed. See marchUtils.js COMPILER VERIFICATION SCOPE.
+  const marchRes    = buildMarchString(selectedIds, allExts);
+  const marchString = marchRes.march || 'none';
+
+  // 8. Build all extensions list for YAML
+  const allExtsList = [baseInfo.id, ...filteredSingles, ...zExts, ...privExts];
+
+  // 9. Assemble YAML
+  const lines = [];
+
+  // — File header comments —
+  lines.push(`# ISA Configuration — generated by RISC-V Extension Landscape`);
+  lines.push(`# https://github.com/riscv/riscv-extensions-landscape`);
+  lines.push(`#`);
+  lines.push(`# This file is a complete, self-describing configuration of your selected`);
+  lines.push(`# RISC-V extensions. It is not tied to any specific external validator schema.`);
+  lines.push(`# Adjust field names/structure once your target submission format is known.`);
+  lines.push(`#`);
+  lines.push(`# Generated: ${new Date().toISOString()}`);
+  lines.push(``);
+
+  // — Part 1: Header —
+  // ##########################################################################
+  // Part 1: ISA Configuration Header
+  // ##########################################################################
+  lines.push(``);
+  lines.push(`vendor: ""   # Optional — your organization name (e.g. "SiFive", "Qualcomm")`);
+  lines.push(`device: ""   # Optional — your core/chip name  (e.g. "U74", "Oryon")`);
+  lines.push(``);
+  lines.push(`base_isa: ${isaString}`);
+  lines.push(`xlen: ${baseInfo.xlen}`);
+  lines.push(``);
+  lines.push(`# Compiler -march flag. Toolchain compatibility varies by extension family:`);
+  lines.push(`#   Scalar crypto (Zk, Zkn, Zks, Zbkb, etc.): supported since ~GCC 12-13 / LLVM 14-15.`);
+  lines.push(`#   Vector crypto (Zvkned, Zvbb, Zvbc family): requires GCC 14+ / non-experimental LLVM 18+.`);
+  lines.push(`#   Zve/Zvl sub-profile tokens: exact min version unconfirmed — verify with your toolchain:`);
+  lines.push(`#     gcc: riscv64-unknown-elf-gcc -march=help`);
+  lines.push(`#     clang: clang --target=riscv64-unknown-elf --print-supported-extensions`);
+  lines.push(`#   Non-ISA extensions excluded from this string.`);
+  lines.push(`march: ${marchString}`);
+  lines.push(``);
+  lines.push(`# Spec-version annotations — inferred from selected extensions.`);
+  lines.push(`# Zicsr/Zifencei present → User Spec 2.3+; supervisor exts → Priv Spec 1.11+`);
+  lines.push(`user_spec_version: "${userSpecVersion}"`);
+  lines.push(`privilege_spec_version: "${privSpecVersion}"`);
+  lines.push(``);
+  lines.push(`extensions:`);
+  for (const ext of allExtsList) {
+    lines.push(`  - ${ext}`);
+  }
+
+  if (privExts.length > 0) {
+    lines.push(``);
+    lines.push(`# Note: the following are privilege/virtual-memory descriptors.`);
+    lines.push(`# They belong in a separate privilege-spec config document if your`);
+    lines.push(`# toolchain requires that distinction.`);
+    lines.push(`privilege_extensions:`);
+    for (const ext of privExts) {
+      lines.push(`  - ${ext}`);
+    }
+  }
+
+  // — Part 2: Instruction catalog —
+  if (includeInstructions) {
+    const catalog = buildCombinedCatalog(selectedIds, allExts);
+
+    lines.push(``);
+    lines.push(`# ##########################################################################`);
+    lines.push(`# Part 2: Full Instruction Catalog (${catalog.length} instructions)`);
+    lines.push(`#`);
+    lines.push(`# Deduplicated by mnemonic + encoding. Instructions shared across multiple`);
+    lines.push(`# extensions list all source extensions under defined_by.`);
+    lines.push(`# ##########################################################################`);
+    lines.push(``);
+    lines.push(`instructions:`);
+
+    for (const instr of catalog) {
+      lines.push(`  - mnemonic: ${instr.mnemonic}`);
+      lines.push(`    encoding: "${instr.encoding}"`);
+      lines.push(`    match: "${instr.match}"`);
+      lines.push(`    mask: "${instr.mask}"`);
+      if (instr.variable_fields && instr.variable_fields.length > 0) {
+        lines.push(`    variable_fields: [${instr.variable_fields.join(', ')}]`);
+      }
+      lines.push(`    defined_by: [${instr.sources.map(s => s.extId).join(', ')}]`);
+    }
+  }
+
+  lines.push(``); // trailing newline
+  return { yaml: lines.join('\n'), warnings };
+}

--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -149,7 +149,7 @@ export function buildIsaConfigYaml(selectedIds, allExts, includeInstructions = t
   lines.push(`vendor: ""   # Optional — your organization name (e.g. "SiFive", "Qualcomm")`);
   lines.push(`device: ""   # Optional — your core/chip name  (e.g. "U74", "Oryon")`);
   lines.push(``);
-  lines.push(`base_isa: ${isaString}`);
+  lines.push(`isa_string: ${isaString}   # Full assembled ISA string (base + all selected extensions)`);
   lines.push(`xlen: ${baseInfo.xlen}`);
   lines.push(``);
   lines.push(`# Compiler -march flag. Toolchain compatibility varies by extension family:`);

--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -149,7 +149,8 @@ export function buildIsaConfigYaml(selectedIds, allExts, includeInstructions = t
   lines.push(`vendor: ""   # Optional — your organization name (e.g. "SiFive", "Qualcomm")`);
   lines.push(`device: ""   # Optional — your core/chip name  (e.g. "U74", "Oryon")`);
   lines.push(``);
-  lines.push(`isa_string: ${isaString}   # Full assembled ISA string (base + all selected extensions)`);
+  lines.push(`base_isa: ${basePrefix}   # Base ISA only (e.g. RV64I, RV32E)`);
+  lines.push(`isa_string: ${isaString}   # Full ISA descriptor (base + all selected extensions)`);
   lines.push(`xlen: ${baseInfo.xlen}`);
   lines.push(``);
   lines.push(`# Compiler -march flag. Toolchain compatibility varies by extension family:`);

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,369 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* ─── Design Tokens ──────────────────────────────────────────────────────── */
+:root {
+  --riscv-bg: #07070e;
+  --riscv-surface: #0d0d17;
+  --riscv-surface-2: #111120;
+  --riscv-border: #1a1a2e;
+  --riscv-border-2: #242438;
+  --riscv-muted: #2a2a42;
+
+  --riscv-gold: #f5c542;
+  --riscv-gold-dim: rgba(245, 197, 66, 0.12);
+  --riscv-gold-glow: rgba(245, 197, 66, 0.20);
+
+  --riscv-violet: #8b7cf8;
+  --riscv-violet-dim: rgba(139, 124, 248, 0.12);
+
+  --riscv-success: #20d9a0;
+  --riscv-danger: #ff4d6b;
+  --riscv-warn: #f59e0b;
+
+  --riscv-text: #e2e8f0;
+  --riscv-text-2: #94a3b8;
+  --riscv-text-3: #475569;
+
+  /* Field colors for encoding diagram */
+  --field-opcode: #f5c542;
+  /* gold   — [6:0]   */
+  --field-rd: #f472b6;
+  /* pink   — [11:7]  */
+  --field-funct3: #2dd4bf;
+  /* teal   — [14:12] */
+  --field-rs1: #a78bfa;
+  /* violet — [19:15] */
+  --field-rs2: #818cf8;
+  /* indigo — [24:20] */
+  --field-funct7: #60a5fa;
+  /* blue   — [31:25] */
+  --field-var: #334155;
+  /* slate  — variable */
+}
+
+/* ─── Global Base ────────────────────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--riscv-bg);
+  color: var(--riscv-text);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code,
+pre,
+.font-mono {
+  font-family: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+}
+
+/* ─── Custom Scrollbar ───────────────────────────────────────────────────── */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--riscv-muted) transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: var(--riscv-muted);
+  border-radius: 9999px;
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--riscv-border-2);
+}
+
+/* ─── Animations ─────────────────────────────────────────────────────────── */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeInRight {
+  from {
+    opacity: 0;
+    transform: translateX(12px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes goldPulse {
+
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(245, 197, 66, 0.3);
+  }
+
+  50% {
+    box-shadow: 0 0 0 4px rgba(245, 197, 66, 0);
+  }
+}
+
+@keyframes topBorderShimmer {
+  0% {
+    background-position: 0% 50%;
+  }
+
+  50% {
+    background-position: 100% 50%;
+  }
+
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+.animate-fade-in-up {
+  animation: fadeInUp 0.25s ease-out both;
+}
+
+.animate-fade-in-right {
+  animation: fadeInRight 0.25s ease-out both;
+}
+
+.animate-scale-in {
+  animation: scaleIn 0.2s ease-out both;
+}
+
+/* ─── Component Utilities ────────────────────────────────────────────────── */
+.riscv-card {
+  background: var(--riscv-surface);
+  border: 1px solid var(--riscv-border);
+  border-radius: 10px;
+}
+
+.riscv-card-2 {
+  background: var(--riscv-surface-2);
+  border: 1px solid var(--riscv-border-2);
+  border-radius: 8px;
+}
+
+.riscv-input {
+  background: var(--riscv-surface);
+  border: 1px solid var(--riscv-border-2);
+  border-radius: 8px;
+  color: var(--riscv-text);
+  font-family: 'Inter', sans-serif;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.riscv-input:focus {
+  outline: none;
+  border-color: var(--riscv-gold);
+  box-shadow: 0 0 0 3px var(--riscv-gold-glow);
+}
+
+.riscv-btn {
+  border-radius: 7px;
+  border: 1px solid var(--riscv-border-2);
+  background: var(--riscv-surface-2);
+  color: var(--riscv-text);
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.01em;
+  transition: border-color 0.15s, background 0.15s, transform 0.1s;
+  cursor: pointer;
+}
+
+.riscv-btn:hover {
+  border-color: var(--riscv-border-2);
+  background: var(--riscv-muted);
+}
+
+.riscv-btn:active {
+  transform: scale(0.97);
+}
+
+.riscv-btn-gold {
+  border-color: rgba(245, 197, 66, 0.35);
+  background: var(--riscv-gold-dim);
+  color: var(--riscv-gold);
+}
+
+.riscv-btn-gold:hover {
+  border-color: rgba(245, 197, 66, 0.6);
+  background: rgba(245, 197, 66, 0.18);
+}
+
+.riscv-btn-violet {
+  border-color: rgba(139, 124, 248, 0.35);
+  background: var(--riscv-violet-dim);
+  color: var(--riscv-violet);
+}
+
+.riscv-btn-violet:hover {
+  border-color: rgba(139, 124, 248, 0.6);
+  background: rgba(139, 124, 248, 0.20);
+}
+
+/* Extension tile hover lift */
+.ext-tile {
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.ext-tile:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 0 2px var(--riscv-text-3), 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.ext-tile-active {
+  transform: translateY(-2px) !important;
+  box-shadow: 0 0 0 2px var(--riscv-gold), 0 8px 32px rgba(245, 197, 66, 0.12) !important;
+  animation: goldPulse 2s ease-in-out infinite;
+}
+
+.ext-tile-highlighted {
+  box-shadow: 0 0 0 2px var(--riscv-gold), 0 4px 16px rgba(245, 197, 66, 0.08);
+}
+
+/* Top accent border gradient */
+.riscv-top-border::before {
+  content: '';
+  display: block;
+  height: 2px;
+  background: linear-gradient(90deg, #f5c542 0%, #8b7cf8 50%, #20d9a0 100%);
+  background-size: 200% 200%;
+  animation: topBorderShimmer 6s ease infinite;
+  border-radius: 9999px;
+  margin-bottom: -2px;
+}
+
+/* Severity badges */
+.conflict-identical {
+  border-color: #ff4d6b;
+  background: rgba(255, 77, 107, 0.08);
+}
+
+.conflict-subset-in {
+  border-color: #f59e0b;
+  background: rgba(245, 158, 11, 0.08);
+}
+
+.conflict-subset-out {
+  border-color: #fbbf24;
+  background: rgba(251, 191, 36, 0.06);
+}
+
+.conflict-partial {
+  border-color: #d97706;
+  background: rgba(217, 119, 6, 0.06);
+}
+
+.conflict-none {
+  border-color: #20d9a0;
+  background: rgba(32, 217, 160, 0.08);
+}
+
+/* Encoding field colors */
+.enc-opcode {
+  background: rgba(245, 197, 66, 0.30);
+  color: #fef08a;
+  border-right-color: rgba(245, 197, 66, 0.50);
+}
+
+.enc-rd {
+  background: rgba(244, 114, 182, 0.25);
+  color: #fbcfe8;
+  border-right-color: rgba(244, 114, 182, 0.45);
+}
+
+.enc-funct3 {
+  background: rgba(45, 212, 191, 0.25);
+  color: #99f6e4;
+  border-right-color: rgba(45, 212, 191, 0.45);
+}
+
+.enc-rs1 {
+  background: rgba(167, 139, 250, 0.25);
+  color: #e9d5ff;
+  border-right-color: rgba(167, 139, 250, 0.45);
+}
+
+.enc-rs2 {
+  background: rgba(129, 140, 248, 0.25);
+  color: #c7d2fe;
+  border-right-color: rgba(129, 140, 248, 0.45);
+}
+
+.enc-funct7 {
+  background: rgba(96, 165, 250, 0.25);
+  color: #bfdbfe;
+  border-right-color: rgba(96, 165, 250, 0.45);
+}
+
+.enc-var {
+  background: rgba(51, 65, 85, 0.60);
+  color: #f8fafc;
+  border-right-color: rgba(71, 85, 105, 0.60);
+}
+
+/* ── ISA Workspace ──────────────────────────────────────────────────────── */
+
+/**
+ * Workspace badge on tiles.
+ * - Hidden (opacity 0) by default
+ * - Appears on tile hover
+ * - Always visible when data-in-workspace="true" (extension is in workspace)
+ */
+.workspace-tile-btn {
+  opacity: 0;
+  transition: opacity 0.12s ease, background 0.15s ease, border-color 0.15s ease;
+  line-height: 1;
+}
+
+/* Show on tile hover */
+.ext-tile:hover .workspace-tile-btn {
+  opacity: 1;
+}
+
+/* Always show when extension is in workspace */
+.workspace-tile-btn[data-in-workspace="true"] {
+  opacity: 1;
+}
+
+/* Panel slide-in animation (fallback — WorkspacePanel now inlines its own) */
+@keyframes slideInRight {
+  from { transform: translateX(40px); opacity: 0; }
+  to   { transform: translateX(0);    opacity: 1; }
+}
+

--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -457,21 +457,6 @@ export function buildMarchString(selectedIds, allExts) {
 /**
  * Build a deduplicated instruction catalog for the selected extensions.
  *
- * ATTRIBUTION RULE:
- *   Each instruction in riscv_extensions.json carries its own `extension` field
- *   (e.g. `"extension": ["rv_zicsr"]` on CSRRW). Some instructions are nested
- *   inside a parent extension's `instructions` object for browsing convenience
- *   (e.g. Zicsr instructions appear under RV32I because nearly every real core
- *   includes both). For the Configuration Builder, we use the instruction's own
- *   `extension` field as the authoritative source of truth — not the nesting
- *   position. An instruction is included only if at least one of its `extension`
- *   tags maps to an extension the user actually selected.
- *
- *   Tag-to-ID mapping: each extension object in riscv_extensions.json carries a
- *   `tags` array (e.g. ["rv_zicsr"]) that directly corresponds to the `extension`
- *   field on individual instructions. We build this reverse map at call time.
- *   [DATA] — verified against riscv_extensions.json schema.
- *
  * DEDUPLICATION KEY: uppercase(mnemonic) + "||" + normalized encoding
  *
  * Rationale [DATA]: Inspecting riscv_extensions.json reveals:
@@ -503,18 +488,6 @@ export function buildCombinedCatalog(selectedIds, allExts) {
   if (!selectedIds || selectedIds.length === 0) return [];
 
   const lookup = buildLookup(allExts);
-
-  // Build a Set of all rv_* tags that belong to the selected extensions.
-  // Each extension carries a `tags` array mirroring the `extension` fields
-  // used on individual instructions (e.g. Zicsr has tags: ["rv_zicsr"]).
-  const selectedTags = new Set();
-  for (const id of selectedIds) {
-    const ext = lookup.get(id.toLowerCase());
-    if (ext?.tags) {
-      for (const tag of ext.tags) selectedTags.add(tag.toLowerCase());
-    }
-  }
-
   const byKey = new Map();
 
   for (const id of selectedIds) {
@@ -522,28 +495,14 @@ export function buildCombinedCatalog(selectedIds, allExts) {
     if (!ext?.instructions) continue;
 
     for (const [mnemonic, details] of Object.entries(ext.instructions)) {
-      // Check the instruction's own `extension` field against the selected tags.
-      // This prevents instructions nested for browsing convenience (e.g. Zicsr
-      // instructions inside RV32I) from being attributed to the wrong extension.
-      const instrTags = Array.isArray(details?.extension) ? details.extension : [];
-      const ownedBySelected = instrTags.some(t => selectedTags.has(t.toLowerCase()));
-      if (!ownedBySelected) continue;
-
       const upperMnem = mnemonic.toUpperCase();
       const normEncoding = (details?.encoding || '').replace(/\s+/g, '');
       const dedupKey = `${upperMnem}||${normEncoding}`;
 
-      // Attribute to the extension whose tag actually owns this instruction,
-      // not necessarily the extension object it was nested under.
-      const ownerTag  = instrTags.find(t => selectedTags.has(t.toLowerCase()));
-      const ownerExt  = ownerTag
-        ? (allExts.find(e => e.tags?.some(t => t.toLowerCase() === ownerTag.toLowerCase())) || ext)
-        : ext;
-
       if (byKey.has(dedupKey)) {
         const entry = byKey.get(dedupKey);
-        if (!entry.sources.some(s => s.extId === ownerExt.id)) {
-          entry.sources.push({ extId: ownerExt.id, extName: ownerExt.name || ownerExt.id });
+        if (!entry.sources.some(s => s.extId === ext.id)) {
+          entry.sources.push({ extId: ext.id, extName: ext.name || ext.id });
         }
       } else {
         byKey.set(dedupKey, {
@@ -553,8 +512,8 @@ export function buildCombinedCatalog(selectedIds, allExts) {
           variable_fields: Array.isArray(details?.variable_fields) ? details.variable_fields : [],
           match: details?.match || '',
           mask: details?.mask || '',
-          sources: [{ extId: ownerExt.id, extName: ownerExt.name || ownerExt.id }],
-          primaryExtId: ownerExt.id,
+          sources: [{ extId: ext.id, extName: ext.name || ext.id }],
+          primaryExtId: ext.id,
         });
       }
     }

--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -1,0 +1,527 @@
+/**
+ * marchUtils.js — RISC-V -march String Utilities
+ *
+ * Pure functions. No React. No JSON imports.
+ * Callers pass the flat extension array from riscv_extensions.json.
+ *
+ * DATA SOURCES (documented for every design decision):
+ *   [SPEC]   RISC-V Unprivileged ISA Specification, Chapter 27
+ *            "ISA Extension Naming Conventions" — canonical ordering, G shorthand
+ *            https://github.com/riscv/riscv-isa-manual
+ *   [OPS]    riscv/riscv-opcodes — instruction encodings
+ *            https://github.com/riscv/riscv-opcodes
+ *   [GCC]    GCC 12+ riscv/riscv.cc — G expansion convention, verified against source
+ *   [DATA]   Data-driven decisions from inspecting this project's own
+ *            riscv_extensions.json (noted inline where used)
+ *
+ * COMPILER VERIFICATION SCOPE:
+ *   The -march strings produced by this module have been cross-checked by primary source
+ *   (GCC docs, LLVM docs, riscv-toolchain-conventions). Findings per extension family:
+ *
+ *   Scalar crypto (Zk, Zkn, Zks, Zbkb, Zbkc, Zbkx, Zknd, Zkne, Zknh, Zksed, Zksh):
+ *     Supported since roughly GCC 12-13 / LLVM 14-15. These have worked in production
+ *     toolchains since early 2022. No bleeding-edge requirement.
+ *
+ *   Vector crypto (Zvkned, Zvbb, Zvbc, Zvkg, Zvksh, Zvksed — the Zvk family):
+ *     GCC 14+ / LLVM 18+ (stable). LLVM 17 had these behind an experimental flag;
+ *     LLVM 18 promoted them to stable. Use GCC 14 or LLVM 18 for non-experimental use.
+ *
+ *   Zve/Zvl sub-profile tokens (Zve32x, Zve64d, Zvl128b, etc.):
+ *     Exact minimum version not independently confirmed from primary source.
+ *     Do not cite a hard version number here. Engineers should verify against their
+ *     installed toolchain directly:
+ *       gcc:   riscv64-unknown-elf-gcc -march=help
+ *       clang: clang --target=riscv64-unknown-elf --print-supported-extensions
+ *
+ *   Base / gc extensions (Zicsr, Zifencei, C, M, A, F, D, etc.):
+ *     Universally stable across all modern RISC-V toolchains.
+ *
+ *   Live binary testing (compiling an empty file with each generated -march string)
+ *   has NOT yet been implemented in CI. That is the remaining gap.
+ */
+
+// ============================================================================
+// Canonical single-letter extension ordering
+// ============================================================================
+/**
+ * Order per RISC-V Unprivileged ISA Spec §27 (Table 27.11). [SPEC]
+ *
+ * Extensions not present in this project's catalog (L, J, T) are included
+ * so that if they are ever added, ordering stays spec-compliant without a
+ * code change.
+ *
+ * NOTE: This array is the ONLY hardcoded ordering in this module.
+ * It is hardcoded because the ISA spec defines it normatively and the
+ * project's riscv_extensions.json carries no machine-readable canonical order.
+ */
+export const SINGLE_LETTER_CANONICAL_ORDER = [
+  'i', 'e', 'm', 'a', 'f', 'd', 'q', 'l', 'c', 'b', 'j', 't', 'p', 'v', 'n',
+  's', 'u', 'h', 'k',
+];
+
+// ============================================================================
+// G shorthand
+// ============================================================================
+/**
+ * Expansion of the 'g' shorthand. [SPEC] §27 + [GCC]
+ *
+ *   G = I + M + A + F + D + Zicsr + Zifencei
+ *
+ * Historical note:
+ *   Prior to the ISA split (~2019), Zicsr and Zifencei were part of the base
+ *   I extension. They were separated so deeply-embedded systems could omit them.
+ *   GCC 12+ and all current LLVM versions expand 'g' to include Zicsr and
+ *   Zifencei. Verified against GCC riscv/riscv.cc (riscv_ext_info table) and
+ *   LLVM RISCVISAInfo.cpp.
+ *
+ * DECODER: expands 'g' using this list.
+ * ENCODER: NEVER emits 'g'. Always emits explicit tokens.
+ * Rationale: explicit tokens are unambiguous across toolchain versions.
+ */
+export const G_EXPANSION_TOKENS = ['i', 'm', 'a', 'f', 'd', 'zicsr', 'zifencei'];
+
+// ============================================================================
+// Base ISA definitions
+// ============================================================================
+/**
+ * Base ISA IDs. These form the rv{xlen}{base} prefix, not extension tokens.
+ * [DATA] — derived from the 'base' group of riscv_extensions.json.
+ */
+export const BASE_ISA_IDS = new Set(['RV32I', 'RV64I', 'RV32E', 'RV64E', 'RV128I']);
+
+export const BASE_ISA_PREFIX_MAP = {
+  RV32I: { xlen: 32, base: 'i' },
+  RV64I: { xlen: 64, base: 'i' },
+  RV32E: { xlen: 32, base: 'e' },
+  RV64E: { xlen: 64, base: 'e' },
+  RV128I: { xlen: 128, base: 'i' },
+};
+
+// ============================================================================
+// Smart Dependencies
+// ============================================================================
+/**
+ * This table is intentionally hardcoded until the automate syncing of dependecies gets merged.
+ * Do not replace with live fetching until that piece merges. When it does, this table should be deleted 
+ * and replaced by reading the dependencies array UDB sync writes into each extension object in riscv_extensions.json.
+ * 
+ * Core, undeniable architectural dependencies. 
+ * We do not map the entire evolving RISC-V graph, but we auto-resolve 
+ * obvious ones (e.g. D fundamentally requires F) to assist the user.
+ */
+export const SMART_DEPENDENCIES = {
+  // --- Floating-point family ---
+  // D → F  : UDB D.yaml requirements.extension: {name: F} — directly fetched
+  // Q → D,F: ISA Manual Vol.I §14.1 "Q depends on D (which depends on F)"
+  // Zfh, Zfhmin → F: ISA Manual Vol.I §12.2 "Zfh requires F"
+  // Zfbfmin → F: UDB Zfbfmin.yaml — BF16 converts operate on F registers
+  // Zdinx → Zfinx: ISA Manual "Zdinx uses integer regs for double; requires Zfinx"
+  // Zhinx, Zhinxmin → Zfinx: ISA Manual §12, parallel to Zdinx reasoning
+  'D': ['F'], // UDB-confirmed
+  'Q': ['D', 'F'], // ISA Manual Vol.I §14.1
+  'Zfh': ['F'], // ISA Manual Vol.I §12.2
+  'Zfhmin': ['F'], // ISA Manual Vol.I §12.2
+  'Zfbfmin': ['F'], // UDB-confirmed
+  'Zdinx': ['Zfinx'], // ISA Manual Vol.I §12
+  'Zhinx': ['Zfinx'], // ISA Manual Vol.I §12
+  'Zhinxmin': ['Zfinx'], // ISA Manual Vol.I §12
+
+  // --- Vector family ---
+  // Source: ISA Manual Vol.I §33.18.2 "Zve* profiles" + kernel dt-bindings
+  // Zve32x → Zicsr: all vector extensions require CSR state (vtype, vl, vstart)
+  // Zve32f → Zve32x + F: adds FP vector ops to the integer-only Zve32x base
+  // Zve64x → Zve32x: extends 32-bit integer vector to 64-bit elements
+  // Zve64f → Zve32f + Zve64x + F: 64-bit elements with FP; subsumes Zve32f
+  // Zve64d → Zve64f + D: adds double-precision FP vector; UDB Zve64d.yaml confirmed
+  // V → Zve64d + Zvl128b: ISA Manual §33.18.2 "V = Zve64d + min 128-bit VLEN"
+  'Zve32x': ['Zicsr'], // ISA Manual Vol.I §33.18.2
+  'Zve32f': ['Zve32x', 'F'], // ISA Manual Vol.I §33.18.2
+  'Zve64x': ['Zve32x'], // ISA Manual Vol.I §33.18.2
+  'Zve64f': ['Zve32f', 'Zve64x', 'F'], // ISA Manual Vol.I §33.18.2
+  'Zve64d': ['Zve64f', 'D'], // UDB-confirmed
+  'V': ['Zve64d', 'Zvl128b'], // ISA Manual Vol.I §33.18.2
+
+  // --- Scalar crypto bundles ---
+  // Zkn: UDB Zkn.yaml — "shorthand for Zbkb, Zbkc, Zbkx, Zkne, Zknd, Zknh"
+  // Zks: UDB Zks.yaml — "shorthand for Zbkb, Zbkc, Zbkx, Zksed, Zksh"
+  // Zk:  UDB Zk.yaml  — "shorthand for Zkn, Zkr, Zkt" — directly fetched
+  'Zkn': ['Zknd', 'Zkne', 'Zknh', 'Zbkb', 'Zbkc', 'Zbkx'], // UDB-confirmed
+  'Zks': ['Zksed', 'Zksh', 'Zbkb', 'Zbkc', 'Zbkx'], // UDB-confirmed
+  'Zk': ['Zkn', 'Zkr', 'Zkt'], // UDB-confirmed
+
+  // --- Performance counters ---
+  // Source: ISA Manual Vol.II §3.1 — counter extensions require Zicsr
+  'Zicntr': ['Zicsr'], // ISA Manual Vol.II §3.1
+  'Zihpm': ['Zicsr'], // ISA Manual Vol.II §3.1
+
+  // --- Bit-manipulation ---
+  // B: Meta-extension typically resolved to Zba, Zbb, and Zbs.
+  'B': ['Zba', 'Zbb', 'Zbs'], // ISA Manual
+};
+
+// ============================================================================
+// Architectural tags that are not -march ISA options
+// ============================================================================
+/**
+ * Privileged spec version compliance tags.
+ * These indicate which privileged spec version a platform complies with.
+ * They are NOT ISA extension options expressible in -march.
+ * [DATA] — pattern observed in riscv_extensions.json s_trap group
+ */
+const SPEC_VERSION_TAG_PATTERN = /^(Sm|Ss)\d+p\d+$/;
+
+/**
+ * Non-ISA spec/trace tags present in the catalog. [DATA]
+ */
+const NON_ISA_EXTENSION_IDS = new Set(['RERI', 'HTI']);
+
+/**
+ * Catalog entries that exist for UI/grouping purposes only and MUST NOT be
+ * emitted into a -march string or resolved by the decoder.
+ *
+ * Verified against GCC 12+ and LLVM source (riscv.cc / RISCVISAInfo.cpp):
+ *
+ *   K  — UI umbrella tag for Zk-star/Zvk-star crypto bundles.
+ *        GCC/LLVM do not recognize 'k' as a -march letter; use 'zk' instead.
+ *        [GCC] https://github.com/riscv/riscv-isa-manual S27
+ *
+ *   B  — Originally grouped Zba/Zbb/Zbc/Zbs. Never ratified as a single-
+ *        letter march token; toolchains require explicit Z-extensions.
+ *
+ *   N  — User-Level Interrupts. Removed from the RISC-V spec (2024).
+ *        No mainstream toolchain recognizes it.
+ *
+ *   P  — Packed-SIMD/DSP. Not ratified; not in GCC or LLVM march tables.
+ *
+ *   S  — Supervisor ISA (Volume II). A privilege-level descriptor, not an
+ *        ISA extension token expressible in -march.
+ *
+ *   U  — User ISA (Volume II). Same reasoning as S above.
+ *
+ * H is deliberately NOT in this list — GCC and LLVM both recognize 'h'
+ * (Hypervisor) as a valid -march single-letter extension.
+ *
+ * [DATA] Cross-checked against our riscv_extensions.json catalog descriptions.
+ */
+export const NON_MARCH_IDS = new Set(['K', 'N', 'P', 'S', 'U']); // B removed — ratified, decode-accept + explicit-encode
+
+// ============================================================================
+// Data provenance — displayed in ISA Workspace footer
+// ============================================================================
+/**
+ * Every piece of data in the workspace has a documented origin.
+ * Shown in the workspace footer so engineers know exactly where
+ * information came from.
+ */
+export const DATA_PROVENANCE = [
+  {
+    label: 'Instruction Encodings',
+    source: 'riscv/riscv-opcodes',
+    url: 'https://github.com/riscv/riscv-opcodes',
+  },
+  {
+    label: 'Extension Metadata & Profiles',
+    source: 'RISC-V ISA Manual',
+    url: 'https://github.com/riscv/riscv-isa-manual',
+  },
+  {
+    label: '-march Naming Rules',
+    source: 'RISC-V ISA Spec §27 · GCC 12+ / LLVM convention',
+    url: 'https://github.com/riscv/riscv-isa-manual',
+  },
+];
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+/**
+ * Build a lowercase-id to extension-object Map for O(1) lookup.
+ * @param {Array} allExts
+ * @returns {Map<string, object>}
+ */
+function buildLookup(allExts) {
+  const m = new Map();
+  for (const ext of allExts) {
+    if (ext?.id) m.set(ext.id.toLowerCase(), ext);
+  }
+  return m;
+}
+
+// ============================================================================
+// parseMarchString
+// ============================================================================
+/**
+ * Parse a RISC-V -march string and resolve extension IDs from the catalog.
+ *
+ * @param {string} marchStr  e.g. "rv64gc_zba_zbb_zicsr_zifencei"
+ * @param {Array}  allExts   Flat array from riscv_extensions.json
+ * @returns {{
+ *   xlen: number|null,
+ *   resolvedIds: string[],
+ *   unknownTokens: string[],
+ *   warnings: string[],
+ *   gExpanded: boolean,
+ * }}
+ */
+export function parseMarchString(marchStr, allExts) {
+  const out = {
+    xlen: null,
+    resolvedIds: [],
+    unknownTokens: [],
+    warnings: [],
+    gExpanded: false,
+  };
+
+  if (!marchStr || typeof marchStr !== 'string') {
+    out.warnings.push('Input is empty or not a string.');
+    return out;
+  }
+
+  const lookup = buildLookup(allExts);
+  let s = marchStr.trim().toLowerCase();
+
+  if (!s.startsWith('rv')) {
+    out.warnings.push('Expected string to start with "rv" (e.g. rv64gc_zba).');
+    return out;
+  }
+  s = s.slice(2);
+
+  const xlenMatch = s.match(/^(32|64|128)/);
+  if (!xlenMatch) {
+    out.warnings.push('Could not parse XLEN — expected 32, 64, or 128 after "rv".');
+    return out;
+  }
+  out.xlen = parseInt(xlenMatch[1], 10);
+  s = s.slice(xlenMatch[1].length);
+
+  // Split on '_'. Part before first '_' contains concatenated single-letter extensions.
+  const parts = s.split('_');
+  const tokens = [];
+
+  // Expand single-letter head (may include 'g')
+  for (const ch of parts[0] || '') {
+    if (ch === 'g') {
+      out.gExpanded = true;
+      out.warnings.push(
+        '"g" expanded to: ' + G_EXPANSION_TOKENS.join(', ') +
+        '. Source: RISC-V ISA Spec §27 + GCC 12+/LLVM. ' +
+        'Encoder will always emit explicit tokens, never "g".'
+      );
+      for (const t of G_EXPANSION_TOKENS) tokens.push(t);
+    } else if (ch === 'b') {
+      out.warnings.push(
+        '"b" expanded to: zba, zbb, zbs. Source: Ratified B extension (March 2024). ' +
+        'Encoder will emit explicit Z-extensions for broader toolchain compatibility.'
+      );
+      tokens.push('zba', 'zbb', 'zbs', 'b');
+    } else {
+      tokens.push(ch);
+    }
+  }
+
+  // Multi-letter tokens
+  for (let i = 1; i < parts.length; i++) {
+    if (parts[i]) tokens.push(parts[i]);
+  }
+
+  // Resolve each token
+  const resolvedSet = new Set();
+  for (const token of tokens) {
+    if (!token) continue;
+
+    // Base ISA letters ('i' or 'e') combine with parsed xlen
+    if ((token === 'i' || token === 'e') && out.xlen) {
+      const baseId = `rv${out.xlen}${token}`;
+      if (lookup.has(baseId)) {
+        resolvedSet.add(lookup.get(baseId).id);
+        continue;
+      }
+    }
+
+    if (lookup.has(token)) {
+      const resolved = lookup.get(token);
+      // Reject UI-grouping / non-march catalog entries — treat as unknown
+      if (NON_MARCH_IDS.has(resolved.id) || NON_ISA_EXTENSION_IDS.has(resolved.id)) {
+        out.unknownTokens.push(token);
+        out.warnings.push(
+          `"${token.toUpperCase()}" is in the extension catalog but is NOT a valid -march token ` +
+          `(UI grouping tag or non-ISA entry). It has been ignored.`
+        );
+        continue;
+      }
+      resolvedSet.add(resolved.id);
+      continue;
+    }
+
+    out.unknownTokens.push(token);
+  }
+
+  out.resolvedIds = Array.from(resolvedSet);
+  return out;
+}
+
+// ============================================================================
+// buildMarchString
+// ============================================================================
+/**
+ * Generate a canonical RISC-V -march string from selected extension IDs.
+ *
+ * Rules (RISC-V Unprivileged ISA Spec §27.11): [SPEC]
+ *   1. Prefix:  rv{xlen}{base}
+ *   2. Single-letter: canonical order (SINGLE_LETTER_CANONICAL_ORDER)
+ *   3. Multi-letter: sorted alphabetically, each preceded by '_'
+ *
+ * Encoder NEVER emits 'g'. See G_EXPANSION_TOKENS for rationale.
+ *
+ * @param {string[]} selectedIds
+ * @param {Array}    allExts
+ * @returns {{ march: string|null, excluded: {id,reason}[], warnings: string[] }}
+ */
+export function buildMarchString(selectedIds, allExts) {
+  const out = { march: null, excluded: [], warnings: [] };
+
+  if (!selectedIds || selectedIds.length === 0) {
+    out.warnings.push('No extensions selected.');
+    return out;
+  }
+
+  // Find base ISA
+  let baseInfo = null;
+  for (const id of selectedIds) {
+    if (BASE_ISA_IDS.has(id)) {
+      baseInfo = { id, ...BASE_ISA_PREFIX_MAP[id] };
+      break;
+    }
+  }
+
+  if (!baseInfo) {
+    out.warnings.push(
+      'No base ISA selected (RV32I, RV64I, RV32E, RV64E, RV128I). ' +
+      'Select a base ISA to generate a -march string.'
+    );
+    return out;
+  }
+
+  const canonIdx = Object.fromEntries(
+    SINGLE_LETTER_CANONICAL_ORDER.map((ch, i) => [ch, i])
+  );
+
+  const singles = [];
+  const multis = [];
+
+  for (const id of selectedIds) {
+    if (BASE_ISA_IDS.has(id)) continue;
+
+    if (SPEC_VERSION_TAG_PATTERN.test(id)) {
+      out.excluded.push({ id, reason: 'Privileged spec version compliance tag — not an -march option' });
+      continue;
+    }
+    if (NON_ISA_EXTENSION_IDS.has(id)) {
+      out.excluded.push({ id, reason: 'Non-ISA specification tag — not an architecture option' });
+      continue;
+    }
+    if (NON_MARCH_IDS.has(id)) {
+      out.excluded.push({ id, reason: 'UI grouping tag / Non-ISA tag — not a valid -march token' });
+      continue;
+    }
+    if (id === 'B') {
+      out.excluded.push({ id, reason: 'Ratified but pending broad toolchain support for single-letter "b". Explicit Zba_Zbb_Zbs emitted instead.' });
+      continue;
+    }
+
+    const token = id.toLowerCase();
+    if (id.length === 1) singles.push(token);
+    else multis.push(token);
+  }
+
+  // Sort single-letter by canonical spec order
+  singles.sort((a, b) => {
+    const ia = canonIdx[a] ?? 999;
+    const ib = canonIdx[b] ?? 999;
+    return ia !== ib ? ia - ib : a.localeCompare(b);
+  });
+
+  const filteredSingles = singles.filter(t => t !== baseInfo.base);
+
+  // Sort multi-letter alphabetically
+  multis.sort((a, b) => a.localeCompare(b));
+
+  const prefix = `rv${baseInfo.xlen}${baseInfo.base}`;
+  out.march = `${prefix}${filteredSingles.join('')}${multis.map(t => `_${t}`).join('')}`;
+  return out;
+}
+
+// ============================================================================
+// buildCombinedCatalog
+// ============================================================================
+/**
+ * Build a deduplicated instruction catalog for the selected extensions.
+ *
+ * DEDUPLICATION KEY: uppercase(mnemonic) + "||" + normalized encoding
+ *
+ * Rationale [DATA]: Inspecting riscv_extensions.json reveals:
+ *   - 411 mnemonics appear in more than one extension
+ *   - 408 have identical encodings (ADD, SUB, … shared across RV32I/RV64I/RV32E/…)
+ *   - 3 have genuinely different encodings (SLLI, SRLI, SRAI: mask width differs
+ *     between 32-bit and 64-bit base ISAs)
+ *   Deduplicating by mnemonic alone would collapse those 3 cases into one row,
+ *   silently discarding the encoding difference. The composite key prevents this.
+ *
+ * Result:
+ *   - Same mnemonic + same encoding → one row, 'sources' lists all extensions
+ *   - Same mnemonic + different encoding → separate rows
+ *
+ * @param {string[]} selectedIds
+ * @param {Array}    allExts
+ * @returns {Array<{
+ *   key: string,
+ *   mnemonic: string,
+ *   encoding: string,
+ *   variable_fields: string[],
+ *   match: string,
+ *   mask: string,
+ *   sources: {extId: string, extName: string}[],
+ *   primaryExtId: string,
+ * }>}
+ */
+export function buildCombinedCatalog(selectedIds, allExts) {
+  if (!selectedIds || selectedIds.length === 0) return [];
+
+  const lookup = buildLookup(allExts);
+  const byKey = new Map();
+
+  for (const id of selectedIds) {
+    const ext = lookup.get(id.toLowerCase());
+    if (!ext?.instructions) continue;
+
+    for (const [mnemonic, details] of Object.entries(ext.instructions)) {
+      const upperMnem = mnemonic.toUpperCase();
+      const normEncoding = (details?.encoding || '').replace(/\s+/g, '');
+      const dedupKey = `${upperMnem}||${normEncoding}`;
+
+      if (byKey.has(dedupKey)) {
+        const entry = byKey.get(dedupKey);
+        if (!entry.sources.some(s => s.extId === ext.id)) {
+          entry.sources.push({ extId: ext.id, extName: ext.name || ext.id });
+        }
+      } else {
+        byKey.set(dedupKey, {
+          key: dedupKey,
+          mnemonic: upperMnem,
+          encoding: normEncoding,
+          variable_fields: Array.isArray(details?.variable_fields) ? details.variable_fields : [],
+          match: details?.match || '',
+          mask: details?.mask || '',
+          sources: [{ extId: ext.id, extName: ext.name || ext.id }],
+          primaryExtId: ext.id,
+        });
+      }
+    }
+  }
+
+  // Sort: mnemonic A→Z, then encoding for identical mnemonics
+  return Array.from(byKey.values()).sort((a, b) => {
+    const m = a.mnemonic.localeCompare(b.mnemonic);
+    return m !== 0 ? m : a.encoding.localeCompare(b.encoding);
+  });
+}

--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -159,6 +159,15 @@ export const SMART_DEPENDENCIES = {
   'B': ['Zba', 'Zbb', 'Zbs'], // ISA Manual
 };
 
+/**
+ * Architecturally invalid combinations.
+ * Evaluated bidirectionally: e.g. RV32E excludes F, and F excludes RV32E.
+ */
+export const INCOMPATIBLE_WITH = {
+  'RV32E': ['F'], // E-base (16 integer regs) cannot support F (requires 32 float regs)
+  'RV64E': ['F']
+};
+
 // ============================================================================
 // Architectural tags that are not -march ISA options
 // ============================================================================

--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -457,6 +457,21 @@ export function buildMarchString(selectedIds, allExts) {
 /**
  * Build a deduplicated instruction catalog for the selected extensions.
  *
+ * ATTRIBUTION RULE:
+ *   Each instruction in riscv_extensions.json carries its own `extension` field
+ *   (e.g. `"extension": ["rv_zicsr"]` on CSRRW). Some instructions are nested
+ *   inside a parent extension's `instructions` object for browsing convenience
+ *   (e.g. Zicsr instructions appear under RV32I because nearly every real core
+ *   includes both). For the Configuration Builder, we use the instruction's own
+ *   `extension` field as the authoritative source of truth — not the nesting
+ *   position. An instruction is included only if at least one of its `extension`
+ *   tags maps to an extension the user actually selected.
+ *
+ *   Tag-to-ID mapping: each extension object in riscv_extensions.json carries a
+ *   `tags` array (e.g. ["rv_zicsr"]) that directly corresponds to the `extension`
+ *   field on individual instructions. We build this reverse map at call time.
+ *   [DATA] — verified against riscv_extensions.json schema.
+ *
  * DEDUPLICATION KEY: uppercase(mnemonic) + "||" + normalized encoding
  *
  * Rationale [DATA]: Inspecting riscv_extensions.json reveals:
@@ -488,6 +503,18 @@ export function buildCombinedCatalog(selectedIds, allExts) {
   if (!selectedIds || selectedIds.length === 0) return [];
 
   const lookup = buildLookup(allExts);
+
+  // Build a Set of all rv_* tags that belong to the selected extensions.
+  // Each extension carries a `tags` array mirroring the `extension` fields
+  // used on individual instructions (e.g. Zicsr has tags: ["rv_zicsr"]).
+  const selectedTags = new Set();
+  for (const id of selectedIds) {
+    const ext = lookup.get(id.toLowerCase());
+    if (ext?.tags) {
+      for (const tag of ext.tags) selectedTags.add(tag.toLowerCase());
+    }
+  }
+
   const byKey = new Map();
 
   for (const id of selectedIds) {
@@ -495,14 +522,28 @@ export function buildCombinedCatalog(selectedIds, allExts) {
     if (!ext?.instructions) continue;
 
     for (const [mnemonic, details] of Object.entries(ext.instructions)) {
+      // Check the instruction's own `extension` field against the selected tags.
+      // This prevents instructions nested for browsing convenience (e.g. Zicsr
+      // instructions inside RV32I) from being attributed to the wrong extension.
+      const instrTags = Array.isArray(details?.extension) ? details.extension : [];
+      const ownedBySelected = instrTags.some(t => selectedTags.has(t.toLowerCase()));
+      if (!ownedBySelected) continue;
+
       const upperMnem = mnemonic.toUpperCase();
       const normEncoding = (details?.encoding || '').replace(/\s+/g, '');
       const dedupKey = `${upperMnem}||${normEncoding}`;
 
+      // Attribute to the extension whose tag actually owns this instruction,
+      // not necessarily the extension object it was nested under.
+      const ownerTag  = instrTags.find(t => selectedTags.has(t.toLowerCase()));
+      const ownerExt  = ownerTag
+        ? (allExts.find(e => e.tags?.some(t => t.toLowerCase() === ownerTag.toLowerCase())) || ext)
+        : ext;
+
       if (byKey.has(dedupKey)) {
         const entry = byKey.get(dedupKey);
-        if (!entry.sources.some(s => s.extId === ext.id)) {
-          entry.sources.push({ extId: ext.id, extName: ext.name || ext.id });
+        if (!entry.sources.some(s => s.extId === ownerExt.id)) {
+          entry.sources.push({ extId: ownerExt.id, extName: ownerExt.name || ownerExt.id });
         }
       } else {
         byKey.set(dedupKey, {
@@ -512,8 +553,8 @@ export function buildCombinedCatalog(selectedIds, allExts) {
           variable_fields: Array.isArray(details?.variable_fields) ? details.variable_fields : [],
           match: details?.match || '',
           mask: details?.mask || '',
-          sources: [{ extId: ext.id, extName: ext.name || ext.id }],
-          primaryExtId: ext.id,
+          sources: [{ extId: ownerExt.id, extName: ownerExt.name || ownerExt.id }],
+          primaryExtId: ownerExt.id,
         });
       }
     }

--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -457,19 +457,17 @@ export function buildMarchString(selectedIds, allExts) {
 /**
  * Build a deduplicated instruction catalog for the selected extensions.
  *
+ * ATTRIBUTION RULE (True Owner Algorithm):
+ *   Instructions in riscv_extensions.json are often nested inside parent
+ *   extensions for legacy "browsing convenience" (e.g. Zicsr instructions
+ *   are duplicated inside RV32E/RV32I/RV64I). However, each instruction
+ *   carries an `extension` tag (e.g. "rv_zicsr").
+ *   This algorithm statically resolves the "True Owner" of every tag across
+ *   the entire catalog (e.g. rv_zicsr belongs to Zicsr, rv_i belongs to the
+ *   selected base ISA). An instruction is ONLY included if its True Owner
+ *   was explicitly selected, and it is strictly attributed to that True Owner.
+ *
  * DEDUPLICATION KEY: uppercase(mnemonic) + "||" + normalized encoding
- *
- * Rationale [DATA]: Inspecting riscv_extensions.json reveals:
- *   - 411 mnemonics appear in more than one extension
- *   - 408 have identical encodings (ADD, SUB, … shared across RV32I/RV64I/RV32E/…)
- *   - 3 have genuinely different encodings (SLLI, SRLI, SRAI: mask width differs
- *     between 32-bit and 64-bit base ISAs)
- *   Deduplicating by mnemonic alone would collapse those 3 cases into one row,
- *   silently discarding the encoding difference. The composite key prevents this.
- *
- * Result:
- *   - Same mnemonic + same encoding → one row, 'sources' lists all extensions
- *   - Same mnemonic + different encoding → separate rows
  *
  * @param {string[]} selectedIds
  * @param {Array}    allExts
@@ -488,21 +486,68 @@ export function buildCombinedCatalog(selectedIds, allExts) {
   if (!selectedIds || selectedIds.length === 0) return [];
 
   const lookup = buildLookup(allExts);
+  const selectedBaseId = selectedIds.find(id => BASE_ISA_IDS.has(id));
+
+  // 1. Determine the True Owner for each tag in the catalog
+  const tagToTrueOwner = new Map();
+  for (const ext of allExts) {
+    if (!ext.tags) continue;
+    for (const tag of ext.tags) {
+      const t = tag.toLowerCase();
+      
+      // Base ISA tags belong to whichever base ISA the user actually selected
+      if (['rv_i', 'rv64_i', 'rv32_e', 'rv64_e'].includes(t)) {
+        if (selectedBaseId) tagToTrueOwner.set(t, lookup.get(selectedBaseId.toLowerCase()));
+        continue;
+      }
+      
+      // For standard extensions, the True Owner is the extension whose ID matches the tag natively
+      const stripped = t.replace(/^rv(32|64)?_/, '');
+      if (ext.id.toLowerCase() === stripped) {
+        tagToTrueOwner.set(t, ext);
+      } else if (!tagToTrueOwner.has(t)) {
+        // Fallback if no exact match is found
+        tagToTrueOwner.set(t, ext);
+      }
+    }
+  }
+
   const byKey = new Map();
 
+  // 2. Iterate over selected extensions and process their nested instructions
   for (const id of selectedIds) {
     const ext = lookup.get(id.toLowerCase());
     if (!ext?.instructions) continue;
 
     for (const [mnemonic, details] of Object.entries(ext.instructions)) {
+      const instrTags = Array.isArray(details?.extension) ? details.extension : [];
+      
+      // Resolve the True Owner of this specific instruction
+      let trueOwner = null;
+      for (const tag of instrTags) {
+        const owner = tagToTrueOwner.get(tag.toLowerCase());
+        if (owner) {
+          trueOwner = owner;
+          break;
+        }
+      }
+      // If we somehow couldn't resolve a true owner, fallback to the extension it was nested inside
+      if (!trueOwner) trueOwner = ext;
+
+      // CRITICAL: If the True Owner wasn't explicitly selected by the user, EXCLUDE IT.
+      // This prevents "ghost" Zicsr instructions from appearing when only RV32I is selected.
+      if (!selectedIds.some(sel => sel.toLowerCase() === trueOwner.id.toLowerCase())) {
+        continue;
+      }
+
       const upperMnem = mnemonic.toUpperCase();
       const normEncoding = (details?.encoding || '').replace(/\s+/g, '');
       const dedupKey = `${upperMnem}||${normEncoding}`;
 
       if (byKey.has(dedupKey)) {
         const entry = byKey.get(dedupKey);
-        if (!entry.sources.some(s => s.extId === ext.id)) {
-          entry.sources.push({ extId: ext.id, extName: ext.name || ext.id });
+        if (!entry.sources.some(s => s.extId === trueOwner.id)) {
+          entry.sources.push({ extId: trueOwner.id, extName: trueOwner.name || trueOwner.id });
         }
       } else {
         byKey.set(dedupKey, {
@@ -512,8 +557,8 @@ export function buildCombinedCatalog(selectedIds, allExts) {
           variable_fields: Array.isArray(details?.variable_fields) ? details.variable_fields : [],
           match: details?.match || '',
           mask: details?.mask || '',
-          sources: [{ extId: ext.id, extName: ext.name || ext.id }],
-          primaryExtId: ext.id,
+          sources: [{ extId: trueOwner.id, extName: trueOwner.name || trueOwner.id }],
+          primaryExtId: trueOwner.id,
         });
       }
     }

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -2232,7 +2232,7 @@ const RISCVExplorer = () => {
                                 <div style={{
                                   width: 15, height: 15, borderRadius: '50%',
                                   background: quickExportIncludeInstr ? '#1a1206' : '#475569',
-                                  position: 'absolute', top: 2,
+                              position: 'absolute', top: 2,
                                   left: quickExportIncludeInstr ? 19 : 2,
                                   transition: 'all 0.25s',
                                   boxShadow: '0 1px 3px rgba(0,0,0,0.4)',
@@ -2253,8 +2253,10 @@ const RISCVExplorer = () => {
                                 const marchRes = buildMarchString(Array.from(workspaceIds), allExtsList);
                                 const base = marchRes.march ? marchRes.march.split('_')[0] : 'core';
                                 a.download = `riscv_${base}_config.yaml`;
+                                document.body.appendChild(a);
                                 a.click();
-                                URL.revokeObjectURL(url);
+                                document.body.removeChild(a);
+                                setTimeout(() => URL.revokeObjectURL(url), 1000);
                                 setQuickExportOpen(false);
                               }}
                               style={{

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -42,7 +42,7 @@ import {
 } from 'lucide-react';
 import extensions from './riscv_extensions.json';
 import WorkspacePanel from './WorkspacePanel.jsx';
-import { BASE_ISA_IDS, SMART_DEPENDENCIES, buildMarchString, buildCombinedCatalog } from './marchUtils.js';
+import { BASE_ISA_IDS, SMART_DEPENDENCIES, INCOMPATIBLE_WITH, buildMarchString, buildCombinedCatalog } from './marchUtils.js';
 import { buildIsaConfigYaml } from './exportUtils.js';
 
 const BIT_WIDTH = 32n;
@@ -745,6 +745,20 @@ const RISCVExplorer = () => {
               next.add(dep);
               autoAdded.push(dep);
             }
+          }
+        }
+      }
+
+      // 3. Incompatibility Check (e.g. RV32E excludes F)
+      // Evaluate bidirectionally for all items currently in the 'next' set
+      for (const ext1 of next) {
+        const incompat = INCOMPATIBLE_WITH[ext1] || [];
+        for (const blocked of incompat) {
+          if (next.has(blocked)) {
+            // Revert the entire addition batch if it creates an invalid architectural state
+            setWorkspaceNotice(`Architecturally Invalid: ${ext1} is incompatible with ${blocked}`);
+            setTimeout(() => setWorkspaceNotice(null), 4500);
+            return prev;
           }
         }
       }

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -41,6 +41,9 @@ import {
   ChevronDown,
 } from 'lucide-react';
 import extensions from './riscv_extensions.json';
+import WorkspacePanel from './WorkspacePanel.jsx';
+import { BASE_ISA_IDS, SMART_DEPENDENCIES, buildMarchString, buildCombinedCatalog } from './marchUtils.js';
+import { buildIsaConfigYaml } from './exportUtils.js';
 
 const BIT_WIDTH = 32n;
 const BIT_MASK_32 = (1n << BIT_WIDTH) - 1n;
@@ -662,6 +665,13 @@ const RISCVExplorer = () => {
   });
   const [encoderValidatorResult, setEncoderValidatorResult] = useState(null);
   const [encoderValidatorCopyStatus, setEncoderValidatorCopyStatus] = useState(null);
+  // ── ISA Workspace state ────────────────────────────────────────────────────
+  const [workspaceIds, setWorkspaceIds] = useState(new Set());
+  const [workspaceNotice, setWorkspaceNotice] = useState(null);
+  const [workspacePanelOpen, setWorkspacePanelOpen] = useState(false);
+  const [workspaceQuickOpen, setWorkspaceQuickOpen] = useState(false);
+  const [quickExportOpen, setQuickExportOpen] = useState(false);
+  const [quickExportIncludeInstr, setQuickExportIncludeInstr] = useState(true);
 
   // Smart lock: live reverse-lookup of dependencies
   const lockedExtensions = React.useMemo(() => {
@@ -1768,6 +1778,7 @@ const RISCVExplorer = () => {
     const isSelected = selectedExt?.id === data.id;
     const highlighted = isHighlighted(data.id) || matchesSearch || isSelected;
     const dimmed = isDimmed(data.id) && !matchesSearch && !isSelected;
+    const inWorkspace = workspaceIds.has(data.id);
 
     return (
       <div
@@ -2087,6 +2098,192 @@ const RISCVExplorer = () => {
                 <div className="relative inline-flex items-stretch rounded-xl">
 
                   {/* Active glow ring */}
+                  {workspaceIds.size > 0 && (
+                    <span className="absolute -inset-px rounded-xl animate-pulse bg-amber-400/20 pointer-events-none z-0" />
+                  )}
+
+                  {/* Main body — opens full panel */}
+                  <button
+                    type="button"
+                    onClick={() => setWorkspacePanelOpen(true)}
+                    className={[
+                      'relative z-10 inline-flex items-center gap-2 pl-3.5 pr-3 py-2 text-xs font-bold transition-all duration-300 whitespace-nowrap',
+                      workspaceIds.size > 0
+                        ? 'bg-gradient-to-b from-amber-400 to-amber-500 text-slate-900 hover:from-amber-300 hover:to-amber-400 rounded-l-xl'
+                        : 'bg-gradient-to-b from-[#ffc107] to-[#ffb300] text-[#1e1e1e] hover:from-[#ffca28] hover:to-[#ffc107] rounded-xl',
+                    ].join(' ')}
+                    style={{ boxShadow: workspaceIds.size > 0 ? '0 4px 18px rgba(251,191,36,0.4)' : '0 2px 10px rgba(0,0,0,0.2)' }}
+                    title={workspaceIds.size > 0 ? `Builder active — ${workspaceIds.size} extension${workspaceIds.size !== 1 ? 's' : ''}. Click to open panel.` : 'Open Custom ISA Builder'}
+                  >
+                    <Cpu size={14} className="opacity-80 flex-shrink-0" />
+                    <span className="whitespace-nowrap">Custom ISA Builder</span>
+                    {workspaceIds.size > 0 && (
+                      <span className="inline-flex items-center justify-center min-w-[18px] px-1 h-[18px] rounded-full text-[9px] font-black bg-slate-900/75 text-amber-400">
+                        {workspaceIds.size}
+                      </span>
+                    )}
+                  </button>
+
+                  {/* Fused action icons — only when config is active */}
+                  {workspaceIds.size > 0 && (<>
+                    {/* Hairline divider */}
+                    <div className="relative z-10 w-px self-stretch bg-amber-600/60" />
+
+                    {/* Clear */}
+                    <button
+                      type="button"
+                      title="Clear all extensions"
+                      onClick={() => setWorkspaceIds(new Set())}
+                      className="group relative z-10 inline-flex items-center justify-center px-3 bg-gradient-to-b from-amber-400 to-amber-500 text-slate-800 hover:from-rose-500 hover:to-rose-600 hover:text-white transition-all duration-300 hover:shadow-[0_0_14px_rgba(225,29,72,0.5)] z-20"
+                    >
+                      <Trash2 size={13} className="transition-transform group-hover:scale-110" />
+                    </button>
+
+                    {/* Hairline divider */}
+                    <div className="relative z-10 w-px self-stretch bg-amber-600/60" />
+
+                    {/* Export */}
+                    <div className="relative z-10 flex">
+                      <button
+                        type="button"
+                        title="Export configuration YAML"
+                        onClick={() => setQuickExportOpen(v => !v)}
+                        className={`group inline-flex items-center justify-center px-3 rounded-r-xl transition-all duration-300 z-20 ${
+                          quickExportOpen 
+                            ? 'bg-emerald-500 text-white shadow-inner' 
+                            : 'bg-gradient-to-b from-amber-400 to-amber-500 text-slate-800 hover:from-emerald-500 hover:to-emerald-600 hover:text-white hover:shadow-[0_0_14px_rgba(16,185,129,0.5)]'
+                        }`}
+                      >
+                        <Download size={13} className="transition-transform group-hover:scale-110" />
+                      </button>
+
+                      {quickExportOpen && (
+                        <div style={{
+                          position: 'absolute', top: 'calc(100% + 8px)', right: 0,
+                          zIndex: 50,
+                          display: 'flex', flexDirection: 'column', gap: 0,
+                          borderRadius: 10,
+                          background: 'linear-gradient(145deg, #1a1f2e 0%, #141824 100%)',
+                          border: '1px solid rgba(245,197,66,0.25)',
+                          boxShadow: '0 12px 32px rgba(0,0,0,0.55), 0 0 0 1px rgba(255,255,255,0.03) inset',
+                          minWidth: 280, overflow: 'hidden',
+                        }}>
+                          {/* Header strip */}
+                          <div style={{
+                            display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                            padding: '10px 14px',
+                            borderBottom: '1px solid rgba(255,255,255,0.06)',
+                            background: 'rgba(245,197,66,0.04)',
+                          }}>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+                              <Package size={12} style={{ color: 'var(--riscv-gold)', opacity: 0.85 }} />
+                              <span style={{ fontSize: 11, color: '#f1f5f9', fontWeight: 700, letterSpacing: '0.01em' }}>
+                                Export Configuration YAML
+                              </span>
+                            </div>
+                            <button
+                              onClick={() => setQuickExportOpen(false)}
+                              style={{ background: 'none', border: 'none', color: '#475569', cursor: 'pointer', padding: 2, lineHeight: 0, borderRadius: 4 }}
+                              onMouseEnter={e => e.currentTarget.style.color = '#94a3b8'}
+                              onMouseLeave={e => e.currentTarget.style.color = '#475569'}
+                            ><X size={13} /></button>
+                          </div>
+
+                          {/* Toggle card */}
+                          <div style={{ padding: '12px 14px' }}>
+                            <div
+                              onClick={() => setQuickExportIncludeInstr(v => !v)}
+                              style={{
+                                display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12,
+                                padding: '10px 12px', borderRadius: 8, cursor: 'pointer',
+                                background: quickExportIncludeInstr ? 'rgba(245,197,66,0.07)' : 'rgba(255,255,255,0.03)',
+                                border: `1px solid ${quickExportIncludeInstr ? 'rgba(245,197,66,0.2)' : 'rgba(255,255,255,0.07)'}`,
+                                transition: 'all 0.2s',
+                                userSelect: 'none',
+                              }}
+                            >
+                              <div style={{ flex: 1 }}>
+                                <span style={{
+                                  fontSize: 11.5, fontWeight: 600,
+                                  color: quickExportIncludeInstr ? '#f1f5f9' : '#94a3b8',
+                                  display: 'block', lineHeight: 1.35, transition: 'color 0.2s',
+                                }}>
+                                  Include instruction catalog
+                                </span>
+                                <span style={{
+                                  fontSize: 10, marginTop: 2, display: 'block',
+                                  color: workspaceTotalInstr > 100 ? '#f59e0b' : '#64748b',
+                                  fontVariantNumeric: 'tabular-nums',
+                                }}>
+                                  {workspaceTotalInstr.toLocaleString()} instructions{workspaceTotalInstr > 100 ? ' · large export' : ''}
+                                </span>
+                              </div>
+
+                              {/* Premium toggle track */}
+                              <div style={{
+                                width: 38, height: 21, borderRadius: 11, flexShrink: 0,
+                                background: quickExportIncludeInstr
+                                  ? 'linear-gradient(135deg, #f5c542 0%, #fde68a 100%)'
+                                  : 'rgba(255,255,255,0.08)',
+                                boxShadow: quickExportIncludeInstr ? '0 0 8px rgba(245,197,66,0.4)' : 'none',
+                                position: 'relative', transition: 'all 0.25s',
+                                border: `1px solid ${quickExportIncludeInstr ? 'rgba(245,197,66,0.7)' : 'rgba(255,255,255,0.12)'}`,
+                              }}>
+                                <div style={{
+                                  width: 15, height: 15, borderRadius: '50%',
+                                  background: quickExportIncludeInstr ? '#1a1206' : '#475569',
+                                  position: 'absolute', top: 2,
+                                  left: quickExportIncludeInstr ? 19 : 2,
+                                  transition: 'all 0.25s',
+                                  boxShadow: '0 1px 3px rgba(0,0,0,0.4)',
+                                }} />
+                              </div>
+                            </div>
+                          </div>
+
+                          {/* Download button */}
+                          <div style={{ padding: '0 14px 13px' }}>
+                            <button
+                              onClick={() => {
+                                const { yaml } = buildIsaConfigYaml(Array.from(workspaceIds), allExtsList, quickExportIncludeInstr);
+                                const blob = new Blob([yaml], { type: 'text/yaml' });
+                                const url = URL.createObjectURL(blob);
+                                const a = document.createElement('a');
+                                a.href = url;
+                                const marchRes = buildMarchString(Array.from(workspaceIds), allExtsList);
+                                const base = marchRes.march ? marchRes.march.split('_')[0] : 'core';
+                                a.download = `riscv_${base}_config.yaml`;
+                                a.click();
+                                URL.revokeObjectURL(url);
+                                setQuickExportOpen(false);
+                              }}
+                              style={{
+                                width: '100%', padding: '9px 14px', borderRadius: 7,
+                                background: 'linear-gradient(135deg, rgba(245,197,66,0.22) 0%, rgba(245,197,66,0.12) 100%)',
+                                color: 'var(--riscv-gold)',
+                                border: '1px solid rgba(245,197,66,0.4)',
+                                fontSize: 11.5, fontWeight: 700,
+                                cursor: 'pointer', transition: 'all 0.18s',
+                                letterSpacing: '0.02em',
+                                display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+                              }}
+                              onMouseEnter={e => {
+                                e.currentTarget.style.background = 'linear-gradient(135deg, rgba(245,197,66,0.35) 0%, rgba(245,197,66,0.22) 100%)';
+                                e.currentTarget.style.boxShadow = '0 0 12px rgba(245,197,66,0.2)';
+                              }}
+                              onMouseLeave={e => {
+                                e.currentTarget.style.background = 'linear-gradient(135deg, rgba(245,197,66,0.22) 0%, rgba(245,197,66,0.12) 100%)';
+                                e.currentTarget.style.boxShadow = 'none';
+                              }}
+                            >
+                              <Package size={11} />
+                              Download .yaml
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </>)}
                 </div>
               </div>
             </div>

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -9,6 +9,36 @@ import {
   Copy,
   ChevronLeft,
   ChevronRight,
+  Search,
+  Cpu,
+  Shield,
+  Zap,
+  Lock,
+  Database,
+  Settings2,
+  Layers,
+  Braces,
+  FlaskConical,
+  Network,
+  Activity,
+  BookOpen,
+  Gem,
+  AlertTriangle,
+  CheckCircle2,
+  XCircle,
+  AlertCircle,
+  Package,
+  Binary,
+  MemoryStick,
+  CircuitBoard,
+  Shuffle,
+  Timer,
+  ServerCrash,
+  KeyRound,
+  Plus,
+  Trash2,
+  Download,
+  ChevronDown,
 } from 'lucide-react';
 import extensions from './riscv_extensions.json';
 
@@ -374,11 +404,47 @@ const EncodingDiagram = ({ encoding }) => {
   const normalized = String(encoding || '').replace(/\s+/g, '');
   if (normalized.length !== 32) {
     return (
-      <div className="font-mono text-[11px] text-slate-100 bg-slate-800/70 border border-slate-700 rounded px-2 py-1 break-all">
+      <div className="font-mono text-[11px] bg-[var(--riscv-surface-2)] border border-[var(--riscv-border-2)] rounded px-2 py-1 break-all" style={{ color: 'var(--riscv-text-2)' }}>
         {encoding}
       </div>
     );
   }
+
+  // RISC-V standard R-type field ranges (bit index from MSB=0):
+  // bit 31..25 → funct7 (i=0..6)
+  // bit 24..20 → rs2    (i=7..11)
+  // bit 19..15 → rs1    (i=12..16)
+  // bit 14..12 → funct3 (i=17..19)
+  // bit 11..7  → rd     (i=20..24)
+  // bit 6..0   → opcode (i=25..31)
+  const getFieldClass = (i, isVar) => {
+    if (isVar) return 'enc-var';
+    if (i <= 6) return 'enc-funct7';
+    if (i <= 11) return 'enc-rs2';
+    if (i <= 16) return 'enc-rs1';
+    if (i <= 19) return 'enc-funct3';
+    if (i <= 24) return 'enc-rd';
+    return 'enc-opcode';
+  };
+
+  const getFieldName = (i) => {
+    if (i <= 6) return 'funct7';
+    if (i <= 11) return 'rs2';
+    if (i <= 16) return 'rs1';
+    if (i <= 19) return 'funct3';
+    if (i <= 24) return 'rd';
+    return 'opcode';
+  };
+
+  // Build field label spans for the legend row
+  const FIELD_LABELS = [
+    { name: 'funct7', from: 0, to: 6, cls: 'enc-funct7' },
+    { name: 'rs2', from: 7, to: 11, cls: 'enc-rs2' },
+    { name: 'rs1', from: 12, to: 16, cls: 'enc-rs1' },
+    { name: 'funct3', from: 17, to: 19, cls: 'enc-funct3' },
+    { name: 'rd', from: 20, to: 24, cls: 'enc-rd' },
+    { name: 'opcode', from: 25, to: 31, cls: 'enc-opcode' },
+  ];
 
   const updateScrollState = React.useCallback(() => {
     const el = scrollRef.current;
@@ -437,11 +503,12 @@ const EncodingDiagram = ({ encoding }) => {
   return (
     <div>
       <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2 text-[10px] uppercase tracking-wider text-slate-500 font-bold">
-          <span>Bits</span>
+        <div className="flex items-center gap-2 text-[10px] uppercase tracking-wider font-semibold" style={{ color: 'var(--riscv-text-3)' }}>
+          <Binary size={11} />
+          <span>Bit Fields</span>
           {canScroll && (
-            <span className="inline-flex items-center gap-1 text-yellow-200/80 font-mono normal-case tracking-normal">
-              scroll <ArrowRight size={12} />
+            <span className="inline-flex items-center gap-1 normal-case tracking-normal" style={{ color: 'var(--riscv-gold)' }}>
+              scroll <ArrowRight size={11} />
             </span>
           )}
         </div>
@@ -449,49 +516,44 @@ const EncodingDiagram = ({ encoding }) => {
         <div className="flex items-center gap-1">
           <button
             type="button"
-            className="p-1 rounded border border-slate-600 bg-slate-800 text-slate-100 disabled:opacity-30"
+            className="riscv-btn p-1 disabled:opacity-30"
             onClick={() => scrollRef.current?.scrollBy({ left: -220, behavior: 'smooth' })}
             disabled={!canScroll || atLeft}
             title="Scroll left"
           >
-            <ChevronLeft size={14} />
+            <ChevronLeft size={13} />
           </button>
           <button
             type="button"
-            className="p-1 rounded border border-slate-600 bg-slate-800 text-slate-100 disabled:opacity-30"
+            className="riscv-btn p-1 disabled:opacity-30"
             onClick={() => scrollRef.current?.scrollBy({ left: 220, behavior: 'smooth' })}
             disabled={!canScroll || atRight}
             title="Scroll right"
           >
-            <ChevronRight size={14} />
+            <ChevronRight size={13} />
           </button>
         </div>
       </div>
 
       <div ref={scrollRef} className="overflow-x-auto">
         <div className="inline-block pr-2">
-          <div className="inline-grid grid-flow-col auto-cols-[18px] rounded border border-slate-700 bg-slate-900/40">
+          {/* Bit cells */}
+          <div className="inline-grid grid-flow-col auto-cols-[20px] rounded-md border border-[var(--riscv-border-2)] overflow-hidden">
             {normalized.split('').map((bit, i) => {
               const isVar = bit === '-';
               const isGroupEnd = (i + 1) % 4 === 0 && i !== 31;
               const value = isVar ? 'x' : bit;
+              const fieldCls = getFieldClass(i, isVar);
+              const fieldName = getFieldName(i);
               return (
                 <div
                   key={`${i}-${bit}`}
                   className={[
-                    'h-7 flex items-center justify-center font-mono text-[11px]',
-                    i === 0 ? 'rounded-l' : '',
-                    i === 31 ? 'rounded-r' : '',
-                    isVar
-                      ? 'bg-slate-800/60 text-purple-100'
-                      : 'bg-slate-700/40 text-slate-100',
-                    i === 31
-                      ? ''
-                      : isGroupEnd
-                          ? 'border-r-2 border-slate-600'
-                          : 'border-r border-slate-700',
+                    'h-7 flex items-center justify-center font-mono text-[11px] font-medium border-r',
+                    fieldCls,
+                    i === 31 ? 'border-r-0' : isGroupEnd ? 'border-r-2' : '',
                   ].join(' ')}
-                  title={`bit ${31 - i}`}
+                  title={`bit[${31 - i}] — ${fieldName}`}
                 >
                   {value}
                 </div>
@@ -499,16 +561,30 @@ const EncodingDiagram = ({ encoding }) => {
             })}
           </div>
 
-          <div className="mt-1 flex justify-between text-[10px] font-mono text-slate-500 px-0.5">
+          {/* Bit number labels */}
+          <div className="mt-1 flex justify-between text-[9px] font-mono px-0.5" style={{ color: 'var(--riscv-text-3)' }}>
             <span>31</span>
             <span>0</span>
+          </div>
+
+          {/* Field legend row */}
+          <div className="mt-2 flex gap-1.5 flex-wrap">
+            {FIELD_LABELS.map(({ name, cls }) => (
+              <span
+                key={name}
+                className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[9px] font-mono font-bold border ${cls}`}
+              >
+                {name}
+              </span>
+            ))}
           </div>
         </div>
       </div>
 
       {canScroll && (
         <div
-          className="mt-2 h-2 rounded bg-purple-300/15 border border-purple-300/20 relative cursor-pointer"
+          className="mt-2 h-1.5 rounded-full relative cursor-pointer"
+          style={{ background: 'var(--riscv-border)', border: '1px solid var(--riscv-border-2)' }}
           onClick={(e) => {
             const el = scrollRef.current;
             if (!el) return;
@@ -521,8 +597,13 @@ const EncodingDiagram = ({ encoding }) => {
           title="Click to scroll"
         >
           <div
-            className="absolute top-0 bottom-0 rounded bg-purple-200/40 border border-purple-200/30 cursor-grab active:cursor-grabbing"
-            style={{ left: `${thumbLeftPct}%`, width: `${thumbWidthPct}%` }}
+            className="absolute top-0 bottom-0 rounded-full cursor-grab active:cursor-grabbing"
+            style={{
+              left: `${thumbLeftPct}%`,
+              width: `${thumbWidthPct}%`,
+              background: 'var(--riscv-gold)',
+              opacity: 0.5,
+            }}
             onPointerDown={(e) => {
               const el = scrollRef.current;
               if (!el) return;
@@ -564,6 +645,7 @@ const EncodingDiagram = ({ encoding }) => {
 };
 
 const RISCVExplorer = () => {
+
   const [activeProfile, setActiveProfile] = useState(null);
   const [activeVolume, setActiveVolume] = useState(null);
   const [selectedExt, setSelectedExt] = useState(null);
@@ -580,7 +662,125 @@ const RISCVExplorer = () => {
   });
   const [encoderValidatorResult, setEncoderValidatorResult] = useState(null);
   const [encoderValidatorCopyStatus, setEncoderValidatorCopyStatus] = useState(null);
+
+  // Smart lock: live reverse-lookup of dependencies
+  const lockedExtensions = React.useMemo(() => {
+    const locked = new Map(); // ext -> [things requiring it]
+    const selected = Array.from(workspaceIds);
+    for (const ext of selected) {
+      const deps = SMART_DEPENDENCIES[ext] || [];
+      for (const dep of deps) {
+        if (workspaceIds.has(dep)) {
+          if (!locked.has(dep)) locked.set(dep, []);
+          locked.get(dep).push(ext);
+        }
+      }
+    }
+    return locked;
+  }, [workspaceIds]);
+
+  // Smart dependency and mutually-exclusive handler
+  const addWorkspaceIdsSmart = React.useCallback((idsToAdd, isToggle = false) => {
+    setWorkspaceIds(prev => {
+      const next = new Set(prev);
+      const autoAdded = [];
+      let baseChanged = false;
+
+      // Recompute lock state against current `prev` state to ensure up-to-date checks during batch updates
+      const currentLocked = new Map();
+      const currentSelected = Array.from(prev);
+      for (const ext of currentSelected) {
+        const deps = SMART_DEPENDENCIES[ext] || [];
+        for (const dep of deps) {
+          if (prev.has(dep)) {
+            if (!currentLocked.has(dep)) currentLocked.set(dep, []);
+            currentLocked.get(dep).push(ext);
+          }
+        }
+      }
+
+      const arrToAdd = Array.isArray(idsToAdd) ? idsToAdd : [idsToAdd];
+
+      for (const id of arrToAdd) {
+        if (isToggle && next.has(id)) {
+          // If locked, we cannot toggle it off
+          if (currentLocked.has(id)) {
+            setWorkspaceNotice(`Cannot remove ${id}: required by ${currentLocked.get(id).join(', ')}`);
+            setTimeout(() => setWorkspaceNotice(null), 4500);
+            continue; // block removal
+          }
+          next.delete(id);
+          continue;
+        }
+
+        // 1. Mutually Exclusive Base ISAs
+        if (BASE_ISA_IDS.has(id)) {
+          for (const baseId of BASE_ISA_IDS) {
+            if (baseId !== id && next.has(baseId)) {
+              // Note: Base ISAs aren't typically locked by other extensions in our SMART_DEPENDENCIES, 
+              // but if they were, we might need a lock check here too. Safe for now.
+              next.delete(baseId);
+              baseChanged = true;
+            }
+          }
+        }
+
+        next.add(id);
+
+        // 2. Smart Dependencies (e.g. D fundamentally requires F)
+        const deps = SMART_DEPENDENCIES[id];
+        if (deps) {
+          for (const dep of deps) {
+            if (!next.has(dep)) {
+              next.add(dep);
+              autoAdded.push(dep);
+            }
+          }
+        }
+      }
+
+      if (autoAdded.length > 0) {
+        setWorkspaceNotice(`Auto-added: ${autoAdded.join(', ')} (Required dependency)`);
+        setTimeout(() => setWorkspaceNotice(null), 4500);
+      } else if (baseChanged) {
+        setWorkspaceNotice('Base ISA is mutually exclusive. Previous base removed.');
+        setTimeout(() => setWorkspaceNotice(null), 4500);
+      }
+
+      return next;
+    });
+  }, []);
+
+  // Flat list of all extensions — stable reference for workspace utilities
+  const allExtsList = React.useMemo(
+    () => Object.values(extensions).flat().filter(Boolean),
+    []
+  );
+
+  const workspaceTotalInstr = React.useMemo(() => {
+    if (workspaceIds.size === 0) return 0;
+    return buildCombinedCatalog(Array.from(workspaceIds), allExtsList).length;
+  }, [workspaceIds, allExtsList]);
+
+  React.useEffect(() => {
+    setQuickExportIncludeInstr(workspaceTotalInstr <= 100);
+  }, [workspaceTotalInstr]);
+  // --------------------------------------------------------------------------
   const lastScrolledKeyRef = React.useRef(null);
+  const searchInputRef = React.useRef(null);
+
+  // Ctrl+K / Cmd+K → focus search
+  React.useEffect(() => {
+    const handler = (e) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   // ---------------------------------------------------------------------------
   // Extension Catalog – loaded from `src/riscv_extensions.json`
@@ -1241,8 +1441,8 @@ const RISCVExplorer = () => {
     Boolean(standardEquivalentMnemonic) && instructionIndex.get(standardEquivalentMnemonic)?.length;
   const compressedEquivalents = selectedInstruction
     ? (COMPRESSED_BY_STANDARD[normalizeMnemonicKey(selectedInstruction.mnemonic)] || []).filter((entry) =>
-        instructionIndex.has(normalizeMnemonicKey(entry.mnemonic))
-      )
+      instructionIndex.has(normalizeMnemonicKey(entry.mnemonic))
+    )
     : [];
 
   const formatInstructionForClipboard = React.useCallback((ext, instr) => {
@@ -1565,1198 +1765,1481 @@ const RISCVExplorer = () => {
     const matchesSearch = q.length ? searchIndex.includes(q) : false;
 
     const isDiscontinued = data.discontinued === 1;
-
     const isSelected = selectedExt?.id === data.id;
     const highlighted = isHighlighted(data.id) || matchesSearch || isSelected;
-    const baseColor = isDiscontinued
-      ? 'bg-slate-700 border-slate-500 text-slate-200'
-      : colorClass;
+    const dimmed = isDimmed(data.id) && !matchesSearch && !isSelected;
 
-	    return (
-	      <div
-	        id={`ext-${data.id}`}
-	        onClick={() =>
-	          setSelectedExt((current) => {
-	            const next = current?.id === data.id ? null : data;
-	            setSelectedInstruction(null);
-	            setSearchMatches(null);
-	            return next;
-	          })
-	        }
-	        className={`
-	          relative p-2 rounded border cursor-pointer transition-all duration-200
-	          ${
-            highlighted
-              ? 'ring-2 ring-yellow-400 bg-slate-800 scale-105 shadow-lg shadow-yellow-900/20'
-              : ''
-          }
-          ${
-            isDimmed(data.id) && !matchesSearch && !isSelected
-              ? 'opacity-20 grayscale'
-              : `${baseColor} hover:brightness-110`
-          }
-          ${isSelected ? 'z-20 shadow-xl shadow-yellow-900/40' : 'z-10'}
-	        `}
-	      >
-	        {isDiscontinued && (
-	          <span className="absolute top-1 right-1 px-1.5 py-0.5 rounded border border-red-600/60 bg-red-950/40 text-[8px] font-mono uppercase tracking-tight text-red-200">
-	            Discontinued
-	          </span>
-	        )}
-	        <div className="flex items-center justify-between mb-0.5">
-	          <span className="font-bold text-xs">{data.name}</span>
-	        </div>
-        <div className="text-[9px] leading-tight opacity-80 truncate">
+    return (
+      <div
+        id={`ext-${data.id}`}
+        onClick={() =>
+          setSelectedExt((current) => {
+            const next = current?.id === data.id ? null : data;
+            setSelectedInstruction(null);
+            setSearchMatches(null);
+            return next;
+          })
+        }
+        className={[
+          'ext-tile group relative rounded-lg border cursor-pointer select-none',
+          isSelected ? 'ext-tile-active' : '',
+          highlighted && !isSelected ? 'ext-tile-highlighted' : '',
+          dimmed ? 'opacity-20 grayscale pointer-events-none' : '',
+          isDiscontinued && !dimmed
+            ? 'border-[var(--riscv-border-2)] bg-[var(--riscv-surface)]'
+            : !dimmed ? colorClass : '',
+        ].join(' ')}
+        style={{
+          padding: '10px',
+          // Amber glow ring when in workspace
+          ...(inWorkspace && !isDiscontinued ? {
+            borderColor: 'rgba(245,197,66,0.55)',
+            boxShadow: '0 0 0 1px rgba(245,197,66,0.2), inset 0 0 12px rgba(245,197,66,0.04)',
+          } : {}),
+          transition: 'border-color 0.2s, box-shadow 0.2s',
+        }}
+      >
+        {/* EOL badge */}
+        {isDiscontinued && (
+          <span
+            className="absolute top-1.5 right-1.5 px-1.5 py-0.5 rounded text-[8px] font-mono uppercase tracking-wider"
+            style={{
+              background: 'rgba(255,77,107,0.12)',
+              color: '#ff7a8a',
+              border: '1px solid rgba(255,77,107,0.25)',
+            }}
+          >
+            EOL
+          </span>
+        )}
+
+        {/* ── ISA Workspace badge ── */}
+        {!isDiscontinued && (() => {
+          const isLocked = inWorkspace && lockedExtensions.has(data.id);
+          const lockedBy = isLocked ? lockedExtensions.get(data.id) : [];
+
+          return (
+            <button
+              type="button"
+              data-in-workspace={inWorkspace ? 'true' : 'false'}
+              onClick={(e) => {
+                e.stopPropagation();
+                // addWorkspaceIdsSmart handles the lock rejection/toast internally for clicks
+                addWorkspaceIdsSmart(data.id, true);
+              }}
+              className="workspace-tile-btn absolute top-1.5 right-1.5"
+              style={{
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                width: 18, height: 18,
+                borderRadius: 5,
+                border: `1px solid ${inWorkspace ? (isLocked ? 'rgba(245,197,66,0.3)' : 'rgba(245,197,66,0.5)') : 'rgba(255,255,255,0.12)'}`,
+                background: inWorkspace
+                  ? (isLocked ? 'rgba(245,197,66,0.08)' : 'rgba(245,197,66,0.2)')
+                  : 'rgba(10,10,20,0.6)',
+                backdropFilter: 'blur(4px)',
+                color: inWorkspace ? (isLocked ? 'rgba(245,197,66,0.5)' : '#f5c542') : '#64748b',
+                cursor: isLocked ? 'not-allowed' : 'pointer',
+                transition: 'all 0.15s',
+                padding: 0,
+              }}
+              title={isLocked ? `Required by ${lockedBy.join(', ')} — remove dependent first` : (inWorkspace ? `Remove ${data.id} from Custom ISA Configuration Builder` : `Add ${data.id} to Custom ISA Configuration Builder`)}
+            >
+              {inWorkspace
+                ? (
+                  <svg width="9" height="9" viewBox="0 0 9 9" fill="none">
+                    <path d="M1.5 4.5L3.5 6.5L7.5 2.5" stroke="#f5c542" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                )
+                : <Plus size={9} />
+              }
+            </button>
+          );
+        })()}
+
+        <div className="flex items-start justify-between mb-1">
+          <span
+            className="font-mono font-semibold text-[11px] leading-tight"
+            style={{ letterSpacing: '0.02em' }}
+          >
+            {data.name}
+          </span>
+        </div>
+        <div
+          className="text-[10px] leading-snug line-clamp-2"
+          style={{ color: 'var(--riscv-text-2)' }}
+        >
           {data.desc}
         </div>
       </div>
     );
   };
 
+
+
+
   // Scroll to extension tile when search matches an extension ID or instruction mnemonic,
   // and automatically open the Selected Details panel. Use a ref to avoid re-scrolling
   // on every render while the query stays the same.
-	  React.useEffect(() => {
-	    const q = searchQuery.trim().toLowerCase();
+  React.useEffect(() => {
+    const q = searchQuery.trim().toLowerCase();
 
-	    if (!q) {
-	      // Reset tracking when query is cleared
-	      lastScrolledKeyRef.current = null;
-	      setSearchMatches(null);
-	      return;
-	    }
+    if (!q) {
+      // Reset tracking when query is cleared
+      lastScrolledKeyRef.current = null;
+      setSearchMatches(null);
+      return;
+    }
 
-	    const allExts = Object.values(extensions).flat();
-	    let matchedMnemonic = null;
-	    let matchedDetails = null;
+    const allExts = Object.values(extensions).flat();
+    let matchedMnemonic = null;
+    let matchedDetails = null;
 
-	    // First, try an exact extension ID match
-	    let targetExt = allExts.find((ext) => ext.id.toLowerCase() === q);
+    // First, try an exact extension ID match
+    let targetExt = allExts.find((ext) => ext.id.toLowerCase() === q);
 
-	    // If no exact extension ID match, try to match an instruction mnemonic
-	    if (!targetExt) {
-	      for (const ext of allExts) {
-	        const mnemonics = Object.keys(ext.instructions || {});
-	        const found = mnemonics.find((m) => m.toLowerCase() === q);
-	        if (found) {
-	          targetExt = ext;
-	          matchedMnemonic = found;
-	          matchedDetails = ext.instructions[found] || null;
-	          break;
-	        }
-	      }
-	    }
+    // If no exact extension ID match, try to match an instruction mnemonic
+    if (!targetExt) {
+      for (const ext of allExts) {
+        const mnemonics = Object.keys(ext.instructions || {});
+        const found = mnemonics.find((m) => m.toLowerCase() === q);
+        if (found) {
+          targetExt = ext;
+          matchedMnemonic = found;
+          matchedDetails = ext.instructions[found] || null;
+          break;
+        }
+      }
+    }
 
-	    // If still no match, try a deep search against indexed extension+instruction details
-	    if (!targetExt) {
-	      targetExt =
-	        allExts.find((ext) => (extensionSearchIndexById.get(ext.id) || '').includes(q)) ||
-	        null;
-	    }
+    // If still no match, try a deep search against indexed extension+instruction details
+    if (!targetExt) {
+      targetExt =
+        allExts.find((ext) => (extensionSearchIndexById.get(ext.id) || '').includes(q)) ||
+        null;
+    }
 
-	    if (targetExt) {
-	      const hits = [];
-	      if (targetExt.instructions && typeof targetExt.instructions === 'object') {
-	        for (const [mnemonic, details] of Object.entries(targetExt.instructions)) {
-	          if (instructionMatchesQuery(mnemonic, details, q)) {
-	            hits.push(mnemonic);
-	          }
-	        }
-	      }
+    if (targetExt) {
+      const hits = [];
+      if (targetExt.instructions && typeof targetExt.instructions === 'object') {
+        for (const [mnemonic, details] of Object.entries(targetExt.instructions)) {
+          if (instructionMatchesQuery(mnemonic, details, q)) {
+            hits.push(mnemonic);
+          }
+        }
+      }
 
-	      if (matchedMnemonic && !hits.includes(matchedMnemonic)) hits.unshift(matchedMnemonic);
-	      if (!matchedMnemonic && hits.length) matchedMnemonic = hits[0];
-	      matchedDetails = matchedMnemonic ? targetExt?.instructions?.[matchedMnemonic] : null;
+      if (matchedMnemonic && !hits.includes(matchedMnemonic)) hits.unshift(matchedMnemonic);
+      if (!matchedMnemonic && hits.length) matchedMnemonic = hits[0];
+      matchedDetails = matchedMnemonic ? targetExt?.instructions?.[matchedMnemonic] : null;
 
-	      // Always open/update the Selected Details panel for the matched extension
-	      setSelectedExt(targetExt);
-	      setSearchMatches(hits.length ? { extId: targetExt.id, query: q, mnemonics: hits, index: 0 } : null);
-	      setSelectedInstruction(matchedMnemonic && matchedDetails ? { mnemonic: matchedMnemonic, ...matchedDetails } : null);
+      // Always open/update the Selected Details panel for the matched extension
+      setSelectedExt(targetExt);
+      setSearchMatches(hits.length ? { extId: targetExt.id, query: q, mnemonics: hits, index: 0 } : null);
+      setSelectedInstruction(matchedMnemonic && matchedDetails ? { mnemonic: matchedMnemonic, ...matchedDetails } : null);
 
-	      const key = `${targetExt.id}:${q}`;
+      const key = `${targetExt.id}:${q}`;
 
-	      // Only auto-scroll once per unique (extension, query) pair
-	      if (lastScrolledKeyRef.current !== key) {
+      // Only auto-scroll once per unique (extension, query) pair
+      if (lastScrolledKeyRef.current !== key) {
         const el = document.getElementById(`ext-${targetExt.id}`);
         if (el) {
           el.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
-	        lastScrolledKeyRef.current = key;
-	      }
-	    }
-	  }, [searchQuery, extensionSearchIndexById]);
+        lastScrolledKeyRef.current = key;
+      }
+    }
+  }, [searchQuery, extensionSearchIndexById]);
+
+  // Compute stat bar numbers from loaded JSON
+  const totalExtensions = React.useMemo(() => Object.values(extensions).flat().filter(Boolean).length, []);
+  const totalInstructions = React.useMemo(() => {
+    let c = 0;
+    for (const ext of Object.values(extensions).flat().filter(Boolean)) {
+      c += Object.keys(ext.instructions || {}).length;
+    }
+    return c;
+  }, []);
 
   return (
-    <div className="min-h-screen bg-slate-900 text-slate-50 p-2 md:p-6 font-sans">
-	      <div className="max-w-[1600px] mx-auto grid grid-cols-1 lg:grid-cols-12 gap-6">
-	        {/* Header */}
-	        <div className="lg:col-span-12 flex flex-col md:flex-row justify-between items-start md:items-end border-b border-slate-700 pb-4 mb-2">
-	          <div>
-            <h1 className="text-2xl md:text-3xl font-black text-transparent bg-clip-text bg-gradient-to-r from-yellow-300 via-amber-400 to-yellow-500">
-              RISC-V Extension Landscape
-            </h1>
-            <p className="text-slate-500 text-xs md:text-sm mt-1">
-              Interactive breakdown of RISC-V Extensions.
-            </p>
-          </div>
+    <div className="min-h-screen text-slate-50" style={{ background: 'var(--riscv-bg)' }}>
+      {/* Gradient top border */}
+      <div className="riscv-top-border" />
+      <div className="px-3 md:px-6 py-4 md:py-6 max-w-[1700px] mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
+          {/* ─── Header ───────────────────────────────────────────────────── */}
+          <div className="lg:col-span-12 pb-5 mb-2" style={{ borderBottom: '1px solid var(--riscv-border)' }}>
+            {/* Title row */}
+            <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+              <div>
+                <div className="flex items-center gap-3 mb-1">
+                  <CircuitBoard size={22} style={{ color: 'var(--riscv-gold)' }} />
+                  <h1
+                    className="text-2xl md:text-3xl font-black tracking-tight"
+                    style={{
+                      background: 'linear-gradient(90deg, #f5c542 0%, #fde68a 50%, #f5c542 100%)',
+                      WebkitBackgroundClip: 'text',
+                      WebkitTextFillColor: 'transparent',
+                    }}
+                  >
+                    RISC-V Extension Landscape
+                  </h1>
+                </div>
+                <p className="text-xs ml-9 whitespace-nowrap" style={{ color: 'var(--riscv-text-2)' }}>
+                  Authoritative reference for extensions, profiles &amp; per-instruction encoding.
+                </p>
+                {/* Stat bar */}
+                <div className="flex items-center gap-4 mt-3 ml-9">
+                  {[
+                    { label: 'Extensions', value: totalExtensions },
+                    { label: 'Profiles', value: Object.keys(profiles).length },
+                    { label: 'Instructions', value: `${(totalInstructions / 1000).toFixed(1)}k+` },
+                    { label: 'Volumes', value: 2 },
+                  ].map(({ label, value }) => (
+                    <div key={label} className="flex items-baseline gap-1.5">
+                      <span className="text-base font-black" style={{ color: 'var(--riscv-gold)' }}>{value}</span>
+                      <span className="text-[10px] uppercase tracking-wider" style={{ color: 'var(--riscv-text-3)' }}>{label}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
 
-	          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 mt-4 md:mt-0">
-	            <div className="flex items-center gap-2">
-	              <span className="text-[10px] uppercase tracking-wider text-slate-500 font-bold">
-	                Profiles
-	              </span>
-	              <div className="flex gap-2">
-	                {Object.keys(profiles).map((profile) => (
-	                  <button
-	                    key={profile}
-	                    onClick={() =>
-	                      setActiveProfile((current) => {
-	                        setSelectedExt(null);
-	                        setSelectedInstruction(null);
-	                        setSearchMatches(null);
-	                        return current === profile ? null : profile;
-	                      })
-	                    }
-	                    className={`
-	                      px-3 py-1 rounded text-xs font-bold border transition-all
-	                      ${
-		                        activeProfile === profile
-		                          ? 'bg-yellow-500/20 border-yellow-500 text-yellow-200'
-		                          : 'bg-slate-800 border-slate-600 text-slate-200 hover:border-slate-500'
-	                      }
-	                    `}
-	                  >
-	                    {profile}
-	                  </button>
-	                ))}
-	              </div>
-	            </div>
+              {/* Controls - Single Row Design 1 */}
+              <div className="flex flex-wrap xl:flex-nowrap items-center justify-start lg:justify-end gap-x-3 gap-y-3 shrink-0">
+                {/* Grouped Filters Container */}
+                <div className="flex items-center gap-3 px-3.5 py-2 rounded-xl border shadow-lg backdrop-blur-md" style={{ background: 'rgba(15,23,42,0.4)', borderColor: 'rgba(255,255,255,0.08)' }}>
+                  
+                  {/* Profiles */}
+                  <div className="flex items-center gap-2">
+                    <span className="text-[10px] uppercase tracking-widest font-semibold" style={{ color: 'var(--riscv-text-3)' }}>Profile</span>
+                    <div className="flex gap-1.5">
+                      {Object.keys(profiles).map((profile) => (
+                        <button
+                          key={profile}
+                          onClick={() =>
+                            setActiveProfile((current) => {
+                              setSelectedExt(null);
+                              setSelectedInstruction(null);
+                              setSearchMatches(null);
+                              return current === profile ? null : profile;
+                            })
+                          }
+                          className={[
+                            'px-3 py-1.5 text-[11px] rounded-lg transition-all duration-200 font-medium',
+                            activeProfile === profile 
+                              ? 'bg-slate-700/80 text-white shadow-inner border border-slate-500/50' 
+                              : 'text-slate-300 hover:text-white hover:bg-slate-700/40 border border-transparent hover:border-slate-600/30',
+                          ].join(' ')}
+                        >
+                          {profile}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
 
-	            <div className="hidden md:block h-7 w-px bg-slate-800" />
+                  {/* Vertical Divider */}
+                  <div className="h-5 w-px bg-slate-700/60 mx-1" />
 
-		            <div className="flex items-center gap-2">
-		              <span className="text-[10px] uppercase tracking-wider text-slate-500 font-bold">
-		                Volumes
-		              </span>
-	              <div className="flex gap-2">
-	                {['I', 'II'].map((vol) => (
-	                  <button
-	                    key={vol}
-	                    onClick={() =>
-	                      setActiveVolume((current) => {
-	                        setSelectedExt(null);
-	                        setSelectedInstruction(null);
-	                        setSearchMatches(null);
-	                        return current === vol ? null : vol;
-	                      })
-	                    }
-	                    className={`
-	                      px-3 py-1 rounded text-xs font-bold border transition-all
-	                      ${
-		                        activeVolume === vol
-		                          ? 'bg-yellow-500/20 border-yellow-500 text-yellow-200'
-		                          : 'bg-slate-800 border-slate-600 text-slate-200 hover:border-slate-500'
-	                      }
-	                    `}
-	                  >
-	                    Vol {vol}
-	                  </button>
-	                ))}
-		              </div>
-		            </div>
+                  {/* Volumes */}
+                  <div className="flex items-center gap-2">
+                    <span className="text-[10px] uppercase tracking-widest font-semibold" style={{ color: 'var(--riscv-text-3)' }}>Volume</span>
+                    <div className="flex gap-1.5">
+                      {['I', 'II'].map((vol) => (
+                        <button
+                          key={vol}
+                          onClick={() =>
+                            setActiveVolume((current) => {
+                              setSelectedExt(null);
+                              setSelectedInstruction(null);
+                              setSearchMatches(null);
+                              return current === vol ? null : vol;
+                            })
+                          }
+                          className={[
+                            'px-3 py-1.5 text-[11px] rounded-lg transition-all duration-200 font-medium',
+                            activeVolume === vol 
+                              ? 'bg-slate-700/80 text-white shadow-inner border border-slate-500/50' 
+                              : 'text-slate-300 hover:text-white hover:bg-slate-700/40 border border-transparent hover:border-slate-600/30',
+                          ].join(' ')}
+                        >
+                          Vol {vol}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
 
-		            <div className="hidden md:block h-7 w-px bg-slate-700" />
+                {/* Encoder Validator - Sleek Outline Button */}
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEncoderValidatorOpen(true);
+                    setEncoderValidatorResult(null);
+                    setEncoderValidatorCopyStatus(null);
+                  }}
+                  className="group inline-flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold transition-all duration-300 whitespace-nowrap border border-indigo-500/40 text-indigo-300 hover:bg-indigo-500/15 hover:border-indigo-400 hover:shadow-[0_0_15px_rgba(99,102,241,0.2)]"
+                  title="Validate a proposed instruction encoding against the existing instruction set"
+                >
+                  <ScanSearch size={14} className="text-indigo-400/80 group-hover:text-indigo-300 transition-colors" />
+                  <span className="whitespace-nowrap">Encoder Validator</span>
+                </button>
 
-		            <button
-		              type="button"
-		              onClick={() => {
-		                setEncoderValidatorOpen(true);
-		                setEncoderValidatorResult(null);
-		                setEncoderValidatorCopyStatus(null);
-		              }}
-		              className="inline-flex items-center gap-2 px-3 py-1 rounded text-xs font-bold border transition-all bg-slate-800 border-slate-600 text-slate-100 hover:border-slate-500"
-		              title="Validate a proposed instruction encoding against existing instructions"
-		            >
-		              <ScanSearch size={16} />
-		              Encoder Validator
-		            </button>
-		          </div>
-		        </div>
+                {/* Custom ISA Configuration Builder — fused action group */}
+                <div className="relative inline-flex items-stretch rounded-xl">
 
-	        {/* Main Grid */}
-	        <div className="lg:col-span-9 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 auto-rows-min">
-	          {/* Search Bar – centered, before Base Architectures */}
-		          <div className="col-span-full flex justify-center mb-3 -mt-1">
-		            <div className="w-full max-w-lg">
-		              <input
-		                type="text"
-		                value={searchQuery}
-		                onChange={(e) => setSearchQuery(e.target.value)}
-		                placeholder="Search extensions by ID, name, or description..."
-		                className="w-full px-4 py-2.5 rounded-lg bg-slate-800 border border-yellow-200/40 text-sm text-slate-100 placeholder-slate-400 shadow-sm shadow-yellow-900/10 focus:outline-none focus:ring-2 focus:ring-yellow-400/60 focus:border-yellow-300"
-		              />
-		              <p className="mt-1 text-[10px] text-center text-slate-500">
-		                Typing here will highlight matching tiles in yellow (case-insensitive).
-		              </p>
-		            </div>
-		          </div>
-
-          {/* 1. Base */}
-          <div className="space-y-2 col-span-full">
-            <h3 className="text-blue-400 text-xs font-bold uppercase flex items-center gap-2">
-              Base ISA
-            </h3>
-            <div className="grid grid-cols-2 md:grid-cols-5 gap-2">
-              {extensions.base.map((item) => (
-                <ExtensionBlock
-                  key={item.id}
-                  data={item}
-                  searchQuery={searchQuery}
-                  colorClass="bg-blue-950 border-blue-800 text-blue-100"
-                />
-              ))}
+                  {/* Active glow ring */}
+                </div>
+              </div>
             </div>
           </div>
-
-	          {/* 2. Single-Letter Extensions */}
-	          <div className="space-y-2 col-span-full">
-	            <h3 className="text-emerald-400 text-xs font-bold uppercase flex items-center gap-2">
-	              Single-Letter Extensions
-	            </h3>
-	            <div className="grid grid-cols-4 md:grid-cols-8 gap-2">
-	              {extensions.standard.map((item) => (
-	                <ExtensionBlock
-                  key={item.id}
-                  data={item}
-                  searchQuery={searchQuery}
-                  colorClass="bg-emerald-950 border-emerald-800 text-emerald-100"
+          {/* ─── Main Grid ───────────────────────────────────────────────── */}
+          <div className="lg:col-span-9 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 auto-rows-min">
+            {/* Search Bar */}
+            <div className="col-span-full mb-2">
+              <div className="relative">
+                <Search size={15} className="absolute left-3.5 top-1/2 -translate-y-1/2 pointer-events-none" style={{ color: 'var(--riscv-text-3)' }} />
+                <input
+                  ref={searchInputRef}
+                  type="text"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search extensions, instructions, encodings…"
+                  className="riscv-input w-full pl-10 pr-24 py-2.5 text-sm"
                 />
-              ))}
+                <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2">
+                  {searchQuery && (
+                    <button
+                      type="button"
+                      onClick={() => setSearchQuery('')}
+                      className="p-0.5 rounded hover:opacity-80"
+                      style={{ color: 'var(--riscv-text-3)' }}
+                      title="Clear search"
+                    >
+                      <X size={13} />
+                    </button>
+                  )}
+                  <kbd
+                    className="hidden sm:flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-mono"
+                    style={{ background: 'var(--riscv-muted)', color: 'var(--riscv-text-3)', border: '1px solid var(--riscv-border-2)' }}
+                  >
+                    <span className="text-[9px]">⌘</span>K
+                  </kbd>
+                </div>
+              </div>
             </div>
-          </div>
 
-          {/* 3. Z-Extensions (User Mode) */}
-	          <div className="col-span-full grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 pt-4 border-t border-slate-700">
-	            <div className="space-y-2">
-	              <h3 className="text-purple-400 text-xs font-bold uppercase flex items-center gap-2">
-	                Bit Manipulation (Zb)
-	              </h3>
-	              <div className="grid grid-cols-2 gap-2">
-	                {extensions.z_bit.map((item) => (
-	                  <ExtensionBlock
-                    key={item.id}
-                    data={item}
-                    searchQuery={searchQuery}
-                    colorClass="bg-purple-950/50 border-purple-800/50 text-purple-100"
-                  />
-                ))}
-	              </div>
-	            </div>
-
-	            <div className="space-y-2">
-	              <h3 className="text-amber-400 text-xs font-bold uppercase flex items-center gap-2">
-	                Atomics (Za/Zic*)
-	              </h3>
-	              <div className="grid grid-cols-2 gap-2">
-	                {extensions.z_atomics.map((item) => (
-	                  <ExtensionBlock
-	                    key={item.id}
-	                    data={item}
-	                    searchQuery={searchQuery}
-	                    colorClass="bg-amber-950/40 border-amber-800/50 text-amber-100"
-	                  />
-	                ))}
-	              </div>
-	            </div>
-
-		            <div className="space-y-2">
-		              <h3 className="text-indigo-400 text-xs font-bold uppercase flex items-center gap-2">
-		                Compressed Instructions (Zc)
-		              </h3>
-		              <div className="grid grid-cols-2 gap-2">
-	                {extensions.z_compress.map((item) => (
-	                  <ExtensionBlock
-	                    key={item.id}
-                    data={item}
-                    searchQuery={searchQuery}
-                    colorClass="bg-indigo-950/50 border-indigo-800/50 text-indigo-100"
-                  />
-                ))}
-	              </div>
-	            </div>
-
-	            <div className="space-y-2">
-	              <h3 className="text-pink-400 text-xs font-bold uppercase flex items-center gap-2">
-	                Float & Numerics (Zf/Za)
-              </h3>
-              <div className="grid grid-cols-2 gap-2">
-                {extensions.z_float.map((item) => (
+            {/* 1. Base ISA */}
+            <div className="space-y-2.5 col-span-full">
+              <div className="flex items-center gap-2">
+                <CircuitBoard size={13} style={{ color: '#60a5fa' }} />
+                <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#60a5fa' }}>Base ISA</h3>
+                <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.base.length} isa</span>
+              </div>
+              <div className="grid grid-cols-2 md:grid-cols-5 gap-2">
+                {extensions.base.map((item) => (
                   <ExtensionBlock
                     key={item.id}
                     data={item}
                     searchQuery={searchQuery}
-                    colorClass="bg-pink-950/50 border-pink-800/50 text-pink-100"
+                    colorClass="border-blue-900/60 bg-blue-950/40 text-blue-100"
                   />
                 ))}
-	              </div>
-	            </div>
+              </div>
+            </div>
 
-		            <div className="space-y-2">
-		              <h3 className="text-sky-400 text-xs font-bold uppercase flex items-center gap-2">
-		                Load/Store
-		              </h3>
-		              <div className="grid grid-cols-2 gap-2">
-		                {extensions.z_load_store.map((item) => (
-		                  <ExtensionBlock
-		                    key={item.id}
-		                    data={item}
-		                    searchQuery={searchQuery}
-		                    colorClass="bg-sky-950/40 border-sky-800/40 text-sky-100"
-		                  />
-		                ))}
-		              </div>
-		            </div>
-
-		            <div className="space-y-2">
-		              <h3 className="text-fuchsia-300 text-xs font-bold uppercase flex items-center gap-2">
-		                Integer
-		              </h3>
-		              <div className="grid grid-cols-2 gap-2">
-		                {extensions.z_integer.map((item) => (
-		                  <ExtensionBlock
-		                    key={item.id}
-		                    data={item}
-		                    searchQuery={searchQuery}
-		                    colorClass="bg-fuchsia-950/40 border-fuchsia-800/40 text-fuchsia-100"
-		                  />
-		                ))}
-		              </div>
-		            </div>
-
-	            <div className="space-y-2">
-	              <h3 className="text-teal-400 text-xs font-bold uppercase flex items-center gap-2">
-	                Vector Subsets (Zv/Zve)
-	              </h3>
-              <div className="grid grid-cols-2 gap-2">
-                {extensions.z_vector.map((item) => (
+            {/* 2. Single-Letter Extensions */}
+            <div className="space-y-2.5 col-span-full">
+              <div className="flex items-center gap-2">
+                <Braces size={13} style={{ color: '#34d399' }} />
+                <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#34d399' }}>Single-Letter Extensions</h3>
+                <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.standard.length} ext</span>
+              </div>
+              <div className="grid grid-cols-4 md:grid-cols-8 gap-2">
+                {extensions.standard.map((item) => (
                   <ExtensionBlock
                     key={item.id}
                     data={item}
                     searchQuery={searchQuery}
-                    colorClass="bg-teal-950/50 border-teal-800/50 text-teal-100"
+                    colorClass="border-emerald-900/60 bg-emerald-950/40 text-emerald-100"
                   />
                 ))}
               </div>
             </div>
 
-	            <div className="space-y-2">
-	              <h3 className="text-red-400 text-xs font-bold uppercase flex items-center gap-2">
-	                Security (Zi)
-	              </h3>
-	              <div className="grid grid-cols-2 gap-2">
-	                {extensions.z_security.map((item) => (
-	                  <ExtensionBlock
-                    key={item.id}
-                    data={item}
-                    searchQuery={searchQuery}
-                    colorClass="bg-red-950/50 border-red-800/50 text-red-100"
-                  />
-                ))}
+            {/* 3. Z-Extensions */}
+            <div
+              className="col-span-full grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 pt-5"
+              style={{ borderTop: '1px solid var(--riscv-border)' }}
+            >
+              <div className="space-y-2.5">
+                <div className="flex items-center gap-2">
+                  <Binary size={12} style={{ color: '#a78bfa' }} />
+                  <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#a78bfa' }}>Bit Manipulation (Zb*)</h3>
+                  <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.z_bit.length}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  {extensions.z_bit.map((item) => (
+                    <ExtensionBlock
+                      key={item.id}
+                      data={item}
+                      searchQuery={searchQuery}
+                      colorClass="border-purple-900/60 bg-purple-950/30 text-purple-100"
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2.5">
+                <div className="flex items-center gap-2">
+                  <Shuffle size={12} style={{ color: '#fbbf24' }} />
+                  <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#fbbf24' }}>Atomics (Za/Zic*)</h3>
+                  <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.z_atomics.length}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  {extensions.z_atomics.map((item) => (
+                    <ExtensionBlock
+                      key={item.id}
+                      data={item}
+                      searchQuery={searchQuery}
+                      colorClass="border-amber-900/60 bg-amber-950/30 text-amber-100"
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2.5">
+                <div className="flex items-center gap-2">
+                  <Layers size={12} style={{ color: '#818cf8' }} />
+                  <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#818cf8' }}>Compressed (Zc*)</h3>
+                  <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.z_compress.length}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  {extensions.z_compress.map((item) => (
+                    <ExtensionBlock
+                      key={item.id}
+                      data={item}
+                      searchQuery={searchQuery}
+                      colorClass="border-indigo-900/60 bg-indigo-950/30 text-indigo-100"
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2.5">
+                <div className="flex items-center gap-2">
+                  <FlaskConical size={12} style={{ color: '#f472b6' }} />
+                  <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#f472b6' }}>Float & Numerics (Zf*)</h3>
+                  <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.z_float.length}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  {extensions.z_float.map((item) => (
+                    <ExtensionBlock
+                      key={item.id}
+                      data={item}
+                      searchQuery={searchQuery}
+                      colorClass="border-pink-900/60 bg-pink-950/30 text-pink-100"
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2.5">
+                <div className="flex items-center gap-2">
+                  <Database size={12} style={{ color: '#38bdf8' }} />
+                  <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#38bdf8' }}>Load / Store</h3>
+                  <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.z_load_store.length}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  {extensions.z_load_store.map((item) => (
+                    <ExtensionBlock
+                      key={item.id}
+                      data={item}
+                      searchQuery={searchQuery}
+                      colorClass="border-sky-900/60 bg-sky-950/30 text-sky-100"
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2.5">
+                <div className="flex items-center gap-2">
+                  <Activity size={12} style={{ color: '#e879f9' }} />
+                  <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#e879f9' }}>Integer</h3>
+                  <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.z_integer.length}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  {extensions.z_integer.map((item) => (
+                    <ExtensionBlock
+                      key={item.id}
+                      data={item}
+                      searchQuery={searchQuery}
+                      colorClass="border-fuchsia-900/60 bg-fuchsia-950/30 text-fuchsia-100"
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2.5">
+                <div className="flex items-center gap-2">
+                  <Zap size={12} style={{ color: '#2dd4bf' }} />
+                  <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#2dd4bf' }}>Vector Subsets (Zv/Zve)</h3>
+                  <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.z_vector.length}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  {extensions.z_vector.map((item) => (
+                    <ExtensionBlock
+                      key={item.id}
+                      data={item}
+                      searchQuery={searchQuery}
+                      colorClass="border-teal-900/60 bg-teal-950/30 text-teal-100"
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2.5">
+                <div className="flex items-center gap-2">
+                  <Shield size={12} style={{ color: '#f87171' }} />
+                  <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#f87171' }}>Security & CFI (Zi*)</h3>
+                  <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.z_security.length}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  {extensions.z_security.map((item) => (
+                    <ExtensionBlock
+                      key={item.id}
+                      data={item}
+                      searchQuery={searchQuery}
+                      colorClass="border-red-900/60 bg-red-950/30 text-red-100"
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2.5">
+                <div className="flex items-center gap-2">
+                  <KeyRound size={12} style={{ color: '#94a3b8' }} />
+                  <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#94a3b8' }}>Cryptography (Zk*)</h3>
+                  <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.z_crypto.length}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  {extensions.z_crypto.map((item) => (
+                    <ExtensionBlock
+                      key={item.id}
+                      data={item}
+                      searchQuery={searchQuery}
+                      colorClass="border-[var(--riscv-border-2)] bg-[var(--riscv-surface-2)] text-slate-300"
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2.5">
+                <div className="flex items-center gap-2">
+                  <Lock size={12} style={{ color: '#c4b5fd' }} />
+                  <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#c4b5fd' }}>Vector Cryptography (Zvk*)</h3>
+                  <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.z_vector_crypto.length}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  {extensions.z_vector_crypto.map((item) => (
+                    <ExtensionBlock
+                      key={item.id}
+                      data={item}
+                      searchQuery={searchQuery}
+                      colorClass="border-violet-900/60 bg-violet-950/30 text-violet-100"
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2.5">
+                <div className="flex items-center gap-2">
+                  <Settings2 size={12} style={{ color: '#fb923c' }} />
+                  <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#fb923c' }}>System</h3>
+                  <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.z_system.length}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  {extensions.z_system.map((item) => (
+                    <ExtensionBlock
+                      key={item.id}
+                      data={item}
+                      searchQuery={searchQuery}
+                      colorClass="border-orange-900/60 bg-orange-950/30 text-orange-100"
+                    />
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2.5">
+                <div className="flex items-center gap-2">
+                  <MemoryStick size={12} style={{ color: '#fdba74' }} />
+                  <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#fdba74' }}>Caches</h3>
+                  <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.z_caches.length}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2">
+                  {extensions.z_caches.map((item) => (
+                    <ExtensionBlock
+                      key={item.id}
+                      data={item}
+                      searchQuery={searchQuery}
+                      colorClass="border-orange-900/40 bg-orange-950/20 text-orange-100"
+                    />
+                  ))}
+                </div>
               </div>
             </div>
 
-	            <div className="space-y-2">
-	              <h3 className="text-slate-400 text-xs font-bold uppercase flex items-center gap-2">
-	                Cryptography (Zk)
-	              </h3>
-	              <div className="grid grid-cols-2 gap-2">
-	                {extensions.z_crypto.map((item) => (
-	                  <ExtensionBlock
-                    key={item.id}
-                    data={item}
-                    searchQuery={searchQuery}
-                    colorClass="bg-slate-800 border-slate-600 text-slate-300"
-                  />
-                ))}
-	              </div>
-	            </div>
-
-	            <div className="space-y-2">
-	              <h3 className="text-violet-300 text-xs font-bold uppercase flex items-center gap-2">
-	                Vector Cryptography (Zvk)
-	              </h3>
-	              <div className="grid grid-cols-2 gap-2">
-	                {extensions.z_vector_crypto.map((item) => (
-	                  <ExtensionBlock
-	                    key={item.id}
-	                    data={item}
-	                    searchQuery={searchQuery}
-	                    colorClass="bg-violet-950/40 border-violet-800/40 text-violet-100"
-	                  />
-	                ))}
-	              </div>
-	            </div>
-
-	            <div className="space-y-2">
-	              <h3 className="text-orange-400 text-xs font-bold uppercase flex items-center gap-2">
-	                System
-	              </h3>
-	              <div className="grid grid-cols-2 gap-2">
-	                {extensions.z_system.map((item) => (
-	                  <ExtensionBlock
-	                    key={item.id}
-	                    data={item}
-	                    searchQuery={searchQuery}
-	                    colorClass="bg-orange-950/50 border-orange-800/50 text-orange-100"
-	                  />
-	                ))}
-	              </div>
-	            </div>
-
-	            <div className="space-y-2">
-	              <h3 className="text-orange-200 text-xs font-bold uppercase flex items-center gap-2">
-	                Caches
-	              </h3>
-	              <div className="grid grid-cols-2 gap-2">
-	                {extensions.z_caches.map((item) => (
-	                  <ExtensionBlock
-	                    key={item.id}
-	                    data={item}
-	                    searchQuery={searchQuery}
-	                    colorClass="bg-orange-950/30 border-orange-700/30 text-orange-100"
-	                  />
-	                ))}
-	              </div>
-	            </div>
-	          </div>
-
-          {/* 4. S-Extensions (Privileged) */}
-	          <div className="col-span-full pt-4 border-t border-slate-700">
-            <h3 className="text-cyan-400 text-xs font-bold uppercase flex items-center gap-2 mb-3">
-              S & Sv Extensions (Privileged)
-            </h3>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              <div className="space-y-2">
-                <h4 className="text-[10px] uppercase text-slate-500 font-bold">Memory (Sv)</h4>
-                <div className="grid grid-cols-2 gap-2">
-                  {extensions.s_mem.map((item) => (
-                    <ExtensionBlock
-                      key={item.id}
-                      data={item}
-                      searchQuery={searchQuery}
-                      colorClass="bg-cyan-950/30 border-cyan-800/30 text-cyan-100"
-                    />
-                  ))}
+            {/* 4. S-Extensions (Privileged) */}
+            <div
+              className="col-span-full pt-5"
+              style={{ borderTop: '1px solid var(--riscv-border)' }}
+            >
+              <div className="flex items-center gap-2 mb-4">
+                <Network size={13} style={{ color: '#22d3ee' }} />
+                <h3 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: '#22d3ee' }}>S &amp; Sv Extensions — Privileged ISA</h3>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+                <div className="space-y-2.5">
+                  <div className="flex items-center gap-1.5">
+                    <Layers size={11} style={{ color: 'var(--riscv-text-3)' }} />
+                    <h4 className="text-[10px] uppercase tracking-widest font-semibold" style={{ color: 'var(--riscv-text-3)' }}>Memory (Sv)</h4>
+                    <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.s_mem.length}</span>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    {extensions.s_mem.map((item) => (
+                      <ExtensionBlock
+                        key={item.id}
+                        data={item}
+                        searchQuery={searchQuery}
+                        colorClass="border-cyan-900/50 bg-cyan-950/20 text-cyan-100"
+                      />
+                    ))}
+                  </div>
+                </div>
+                <div className="space-y-2.5">
+                  <div className="flex items-center gap-1.5">
+                    <Timer size={11} style={{ color: 'var(--riscv-text-3)' }} />
+                    <h4 className="text-[10px] uppercase tracking-widest font-semibold" style={{ color: 'var(--riscv-text-3)' }}>Interrupts (Sm/Ss)</h4>
+                    <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.s_interrupt.length}</span>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    {extensions.s_interrupt.map((item) => (
+                      <ExtensionBlock
+                        key={item.id}
+                        data={item}
+                        searchQuery={searchQuery}
+                        colorClass="border-cyan-900/50 bg-cyan-950/20 text-cyan-100"
+                      />
+                    ))}
+                  </div>
+                </div>
+                <div className="space-y-2.5">
+                  <div className="flex items-center gap-1.5">
+                    <ServerCrash size={11} style={{ color: 'var(--riscv-text-3)' }} />
+                    <h4 className="text-[10px] uppercase tracking-widest font-semibold" style={{ color: 'var(--riscv-text-3)' }}>Trap, Debug &amp; Hypervisor</h4>
+                    <span className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>{extensions.s_trap.length}</span>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    {extensions.s_trap.map((item) => (
+                      <ExtensionBlock
+                        key={item.id}
+                        data={item}
+                        searchQuery={searchQuery}
+                        colorClass="border-cyan-900/50 bg-cyan-950/20 text-cyan-100"
+                      />
+                    ))}
+                  </div>
                 </div>
               </div>
-              <div className="space-y-2">
-                <h4 className="text-[10px] uppercase text-slate-500 font-bold">Interrupts (Sm/Ss)</h4>
-                <div className="grid grid-cols-2 gap-2">
-                  {extensions.s_interrupt.map((item) => (
-                    <ExtensionBlock
-                      key={item.id}
-                      data={item}
-                      searchQuery={searchQuery}
-                      colorClass="bg-cyan-950/30 border-cyan-800/30 text-cyan-100"
-                    />
-                  ))}
-                </div>
+            </div>
+          </div>
+
+          {/* ─── Sidebar ─────────────────────────────────────────────────── */}
+          <div className="lg:col-span-3 mt-6 lg:mt-0">
+            <div
+              className="sticky top-6 riscv-card backdrop-blur-sm min-h-[400px] max-h-[calc(100vh-3rem)] flex flex-col overflow-hidden"
+              style={{ boxShadow: '0 20px 60px rgba(0,0,0,0.6)' }}
+            >
+              <div className="p-4 pb-3 flex items-center gap-2" style={{ borderBottom: '1px solid var(--riscv-border)' }}>
+                <Info size={14} style={{ color: 'var(--riscv-text-3)' }} />
+                <h2 className="text-[11px] font-semibold uppercase tracking-widest" style={{ color: 'var(--riscv-text-3)' }}>Selected Details</h2>
               </div>
-              <div className="space-y-2">
-                <h4 className="text-[10px] uppercase text-slate-500 font-bold">
-                  Trap, Debug & Hypervisor Aux
-                </h4>
-                <div className="grid grid-cols-2 gap-2">
-                  {extensions.s_trap.map((item) => (
-                    <ExtensionBlock
-                      key={item.id}
-                      data={item}
-                      searchQuery={searchQuery}
-                      colorClass="bg-cyan-950/30 border-cyan-800/30 text-cyan-100"
-                    />
-                  ))}
-                </div>
+
+              <div className="flex-1 overflow-y-auto overscroll-contain p-4 pt-3">
+                {selectedExt ? (
+                  <div className="animate-in fade-in slide-in-from-right-4 duration-300">
+                    <div className="mb-6 flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <a
+                          href={selectedExt.url || 'https://github.com/riscv/riscv-isa-manual'}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex items-start gap-1 font-black tracking-tight break-words hover:opacity-80"
+                          style={{ fontSize: '1.5rem', lineHeight: 1.2, color: 'var(--riscv-gold)' }}
+                          title="Open reference link"
+                        >
+                          <span>{selectedExt.name}</span>
+                          <ArrowUpRight size={15} className="mt-1 shrink-0 opacity-70" />
+                        </a>
+                      </div>
+
+                      {selectedExt.discontinued === 1 && (
+                        <span className="shrink-0 px-2 py-1 rounded-md text-[10px] font-mono uppercase tracking-wide border bg-red-950/40 text-red-200 border-red-600/60">
+                          Discontinued
+                        </span>
+                      )}
+                    </div>
+
+                    <div className="space-y-6">
+                      <div>
+                        <h4 className="text-[10px] uppercase tracking-widest font-semibold mb-1.5" style={{ color: 'var(--riscv-text-3)' }}>Description</h4>
+                        <p className="text-sm leading-relaxed" style={{ color: 'var(--riscv-text)' }}>{selectedExt.desc}</p>
+                      </div>
+
+                      <div className="riscv-card-2 p-3 rounded-lg">
+                        <h4 className="text-[10px] uppercase tracking-widest font-semibold mb-2 flex items-center gap-1" style={{ color: 'var(--riscv-violet)' }}>
+                          <ArrowRight size={10} /> Use Case
+                        </h4>
+                        <p className="text-sm italic" style={{ color: 'var(--riscv-text-2)' }}>{selectedExt.use}</p>
+                      </div>
+
+                      {/* Instruction list, when available */}
+                      {searchMatches &&
+                        searchMatches.extId === selectedExt.id &&
+                        searchMatches.query === searchQuery.trim().toLowerCase() &&
+                        searchMatches.mnemonics.length > 0 && (
+                          <div className="bg-slate-900 p-3 rounded border border-slate-700">
+                            <div className="flex items-center justify-between gap-3">
+                              <div className="min-w-0">
+                                <div className="text-[10px] uppercase tracking-wider text-yellow-300 font-bold mb-0.5">
+                                  Search Hits ({searchMatches.mnemonics.length})
+                                </div>
+                                <div className="text-[11px] font-mono text-slate-200 truncate">
+                                  {searchMatches.mnemonics[searchMatches.index] || ''}
+                                  <span className="ml-2 text-slate-500">
+                                    ({searchMatches.index + 1}/{searchMatches.mnemonics.length})
+                                  </span>
+                                </div>
+                              </div>
+
+                              <div className="flex items-center gap-2 shrink-0">
+                                <button
+                                  type="button"
+                                  className="px-2 py-1 rounded border border-slate-600 bg-slate-800 text-[10px] font-mono text-slate-100 disabled:opacity-40"
+                                  onClick={() => {
+                                    setSearchMatches((current) => {
+                                      if (!current || current.extId !== selectedExt.id) return current;
+                                      const nextIndex =
+                                        (current.index - 1 + current.mnemonics.length) % current.mnemonics.length;
+                                      const mnemonic = current.mnemonics[nextIndex];
+                                      selectInstructionByMnemonic(selectedExt, mnemonic);
+                                      return { ...current, index: nextIndex };
+                                    });
+                                  }}
+                                  disabled={searchMatches.mnemonics.length < 2}
+                                >
+                                  Prev
+                                </button>
+                                <button
+                                  type="button"
+                                  className="px-2 py-1 rounded border border-slate-600 bg-slate-800 text-[10px] font-mono text-slate-100 disabled:opacity-40"
+                                  onClick={() => {
+                                    setSearchMatches((current) => {
+                                      if (!current || current.extId !== selectedExt.id) return current;
+                                      const nextIndex = (current.index + 1) % current.mnemonics.length;
+                                      const mnemonic = current.mnemonics[nextIndex];
+                                      selectInstructionByMnemonic(selectedExt, mnemonic);
+                                      return { ...current, index: nextIndex };
+                                    });
+                                  }}
+                                  disabled={searchMatches.mnemonics.length < 2}
+                                >
+                                  Next
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        )}
+
+                      {Object.keys(selectedExt.instructions || {}).length > 0 && (
+                        <div className="bg-slate-900 p-3 rounded border border-slate-700">
+                          <h4 className="text-[10px] uppercase tracking-wider text-emerald-400 font-bold mb-2">
+                            Instruction Set Snapshot ({Object.keys(selectedExt.instructions || {}).length})
+                          </h4>
+                          <div className="flex flex-wrap gap-1">
+                            {Object.keys(selectedExt.instructions || {}).map((mnemonic) => {
+                              const q = searchQuery.trim().toLowerCase();
+                              const instructionDetails = selectedExt.instructions?.[mnemonic];
+                              const isHit =
+                                q.length &&
+                                (mnemonic.toLowerCase().includes(q) ||
+                                  instructionMatchesQuery(mnemonic, instructionDetails, q));
+                              const isActive = selectedInstruction?.mnemonic === mnemonic;
+                              const isClickable = Boolean(instructionDetails);
+                              const isDeprecated = Boolean(instructionDetails?.deprecated);
+                              return (
+                                <button
+                                  key={mnemonic}
+                                  type="button"
+                                  onClick={() => {
+                                    if (!isClickable) return;
+                                    setSelectedInstruction(
+                                      isActive ? null : { mnemonic, ...instructionDetails }
+                                    );
+                                    setSearchMatches((current) => {
+                                      if (
+                                        !current ||
+                                        current.extId !== selectedExt.id ||
+                                        current.query !== searchQuery.trim().toLowerCase()
+                                      ) {
+                                        return current;
+                                      }
+                                      const idx = current.mnemonics.indexOf(mnemonic);
+                                      if (idx === -1) return current;
+                                      return { ...current, index: idx };
+                                    });
+                                  }}
+                                  className={`px-1.5 py-0.5 rounded border text-[10px] font-mono tracking-tight ${isActive
+                                    ? isDeprecated
+                                      ? 'border-red-400 bg-red-500/10 text-red-200'
+                                      : 'border-emerald-400 bg-emerald-500/10 text-emerald-200'
+                                    : isHit
+                                      ? 'border-yellow-400 bg-yellow-500/10 text-yellow-200'
+                                      : isDeprecated
+                                        ? 'border-red-500/60 bg-red-500/5 text-red-200'
+                                        : 'border-slate-700 bg-slate-800/70'
+                                    }`}
+                                  title={
+                                    isClickable
+                                      ? `View details for ${mnemonic}`
+                                      : `${mnemonic} (no details yet)`
+                                  }
+                                  disabled={!isClickable}
+                                >
+                                  {mnemonic}
+                                </button>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      )}
+
+                      {extensionCsrs[selectedExt.id] && (
+                        <div className="bg-slate-900 p-3 rounded border border-slate-700">
+                          <h4 className="text-[10px] uppercase tracking-wider text-sky-300 font-bold mb-2">
+                            {(extensionCsrLabels[selectedExt.id] || 'CSRs')}{' '}
+                            ({extensionCsrs[selectedExt.id].length})
+                          </h4>
+                          <div className="flex flex-wrap gap-1">
+                            {extensionCsrs[selectedExt.id].map((csr) => (
+                              <span
+                                key={csr}
+                                className="px-1.5 py-0.5 rounded border border-slate-700 bg-slate-800/70 text-[10px] font-mono text-slate-200"
+                              >
+                                {csr}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {selectedInstruction && (
+                        <div className="bg-slate-900 p-3 rounded border border-slate-700">
+                          <div className="flex items-start justify-between gap-3 mb-2">
+                            <h4 className="text-[10px] uppercase tracking-wider text-purple-300 font-bold flex items-center gap-1">
+                              <ArrowRight size={10} /> Instruction Details
+                            </h4>
+                            <div className="flex items-center gap-2">
+                              <button
+                                type="button"
+                                className="inline-flex items-center gap-1 px-2 py-1 rounded border border-slate-600 bg-slate-800 text-[10px] font-mono text-slate-100 hover:border-slate-500"
+                                onClick={async () => {
+                                  const text = formatInstructionForClipboard(selectedExt, selectedInstruction);
+                                  const ok = await copyTextToClipboard(text);
+                                  setCopyStatus(ok ? 'copied' : 'failed');
+                                  window.setTimeout(() => setCopyStatus(null), 1500);
+                                }}
+                                title="Copy extension + instruction details"
+                              >
+                                <Copy size={12} />
+                                {copyStatus === 'copied'
+                                  ? 'Copied'
+                                  : copyStatus === 'failed'
+                                    ? 'Copy failed'
+                                    : 'Copy'}
+                              </button>
+                              <button
+                                type="button"
+                                className="text-[10px] font-mono text-slate-500 hover:text-slate-300"
+                                onClick={() => setSelectedInstruction(null)}
+                              >
+                                Close
+                              </button>
+                            </div>
+                          </div>
+
+                          <div className="mb-3 flex items-start justify-between gap-2">
+                            <div className="text-white font-black tracking-tight text-xl">
+                              {selectedInstruction.mnemonic}
+                            </div>
+                            {selectedInstruction.deprecated && (
+                              <span className="shrink-0 px-2 py-1 rounded-md text-[10px] font-mono uppercase tracking-wide border bg-red-950/40 text-red-200 border-red-600/60">
+                                Discontinued
+                              </span>
+                            )}
+                          </div>
+
+                          <div className="space-y-3">
+                            <div>
+                              <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
+                                Encoding
+                              </div>
+                              <EncodingDiagram encoding={selectedInstruction.encoding} />
+                              <div className="mt-1 text-[10px] text-slate-500">
+                                Fixed bits are <span className="font-mono">0/1</span>, variable bits are{' '}
+                                <span className="font-mono">x</span>.
+                              </div>
+                            </div>
+
+                            <div>
+                              <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
+                                Variable Fields
+                              </div>
+                              <div className="flex flex-wrap gap-1">
+                                {(selectedInstruction.variable_fields || []).map((field) => (
+                                  <span
+                                    key={field}
+                                    className="px-1.5 py-0.5 rounded border border-slate-700 bg-slate-800/70 text-[10px] font-mono text-slate-200"
+                                  >
+                                    {field}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+
+                            <div className="grid grid-cols-2 gap-2">
+                              <div>
+                                <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
+                                  Match
+                                </div>
+                                <div
+                                  className={`font-mono text-[11px] text-slate-100 bg-slate-800/70 border rounded px-2 py-1 ${searchQuery.trim().length &&
+                                    String(selectedInstruction.match || '')
+                                      .toLowerCase()
+                                      .includes(searchQuery.trim().toLowerCase())
+                                    ? 'border-yellow-400 bg-yellow-500/10'
+                                    : 'border-slate-700'
+                                    }`}
+                                >
+                                  {selectedInstruction.match}
+                                </div>
+                              </div>
+                              <div>
+                                <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
+                                  Mask
+                                </div>
+                                <div
+                                  className={`font-mono text-[11px] text-slate-100 bg-slate-800/70 border rounded px-2 py-1 ${searchQuery.trim().length &&
+                                    String(selectedInstruction.mask || '')
+                                      .toLowerCase()
+                                      .includes(searchQuery.trim().toLowerCase())
+                                    ? 'border-yellow-400 bg-yellow-500/10'
+                                    : 'border-slate-700'
+                                    }`}
+                                >
+                                  {selectedInstruction.mask}
+                                </div>
+                              </div>
+                            </div>
+
+                            {compressedMapping && (
+                              <div className="rounded border border-slate-700 bg-slate-950/50 p-3">
+                                <div className="text-[10px] uppercase tracking-wider text-cyan-300 font-bold mb-2">
+                                  Compressed Mapping
+                                </div>
+                                <div className="space-y-2">
+                                  <div>
+                                    <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
+                                      Compressed
+                                    </div>
+                                    <div className="font-mono text-[11px] text-slate-100 bg-slate-800/70 border border-slate-700 rounded px-2 py-1">
+                                      {compressedMapping.compressed}
+                                    </div>
+                                  </div>
+                                  <div>
+                                    <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
+                                      Standard Equivalent
+                                    </div>
+                                    {hasStandardEquivalent ? (
+                                      <button
+                                        type="button"
+                                        className="w-full text-left font-mono text-[11px] text-slate-100 bg-slate-800/70 border border-slate-700 rounded px-2 py-1 hover:border-cyan-400/60"
+                                        onClick={() => selectStandardEquivalent(standardEquivalentMnemonic)}
+                                        title="Open standard instruction details"
+                                      >
+                                        <span className="inline-flex items-center gap-1">
+                                          {compressedMapping.standard}
+                                          <ArrowUpRight size={12} className="opacity-70" />
+                                        </span>
+                                      </button>
+                                    ) : (
+                                      <div className="font-mono text-[11px] text-slate-100 bg-slate-800/70 border border-slate-700 rounded px-2 py-1">
+                                        {compressedMapping.standard}
+                                      </div>
+                                    )}
+                                  </div>
+                                  <div>
+                                    <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
+                                      Equivalent Instruction
+                                    </div>
+                                    {standardEquivalentMnemonic ? (
+                                      hasStandardEquivalent ? (
+                                        <button
+                                          type="button"
+                                          className="inline-flex items-center gap-1 text-[11px] font-mono text-cyan-200 hover:text-cyan-100 underline"
+                                          onClick={() => selectStandardEquivalent(standardEquivalentMnemonic)}
+                                          title="Open standard instruction details"
+                                        >
+                                          {standardEquivalentMnemonic}
+                                          <ArrowUpRight size={12} className="opacity-70" />
+                                        </button>
+                                      ) : (
+                                        <div className="text-[11px] text-slate-500 font-mono">
+                                          {standardEquivalentMnemonic}
+                                        </div>
+                                      )
+                                    ) : (
+                                      <div className="text-[11px] text-slate-500">Unavailable</div>
+                                    )}
+                                  </div>
+                                  <div>
+                                    <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
+                                      Description
+                                    </div>
+                                    <div className="text-[11px] text-slate-200">{compressedMapping.description}</div>
+                                  </div>
+                                </div>
+                              </div>
+                            )}
+
+                            {compressedEquivalents.length > 0 && (
+                              <div className="rounded border border-slate-700 bg-slate-950/40 p-3">
+                                <div className="text-[10px] uppercase tracking-wider text-emerald-300 font-bold mb-2">
+                                  Compressed Equivalents
+                                </div>
+                                <div className="space-y-2">
+                                  {compressedEquivalents.map((entry) => (
+                                    <button
+                                      key={entry.mnemonic}
+                                      type="button"
+                                      className="w-full text-left rounded border border-slate-700 bg-slate-900/60 px-2 py-1.5 hover:border-emerald-400/60"
+                                      onClick={() => selectCompressedEquivalent(entry.mnemonic)}
+                                      title={`Open ${entry.mnemonic} details`}
+                                    >
+                                      <div className="flex items-center gap-1 text-[11px] font-mono text-emerald-200">
+                                        {normalizeMnemonicKey(entry.mnemonic)}
+                                        <ArrowUpRight size={12} className="opacity-70" />
+                                      </div>
+                                      <div className="text-[10px] font-mono text-slate-400">{entry.compressed}</div>
+                                    </button>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
+
+                          </div>
+                        </div>
+                      )}
+
+                      {activeProfile && (
+                        <div
+                          className={`
+                      mt-4 p-3 rounded text-xs flex items-center gap-2 border
+                      ${isHighlighted(selectedExt.id)
+                              ? 'bg-yellow-900/20 border-yellow-700/30 text-yellow-200'
+                              : 'bg-slate-800 border-slate-700 text-slate-500'
+                            }
+                    `}
+                        >
+                          {isHighlighted(selectedExt.id) ? (
+                            <>
+                              <div className="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse" />
+                              Required in <strong>{activeProfile}</strong>
+                            </>
+                          ) : (
+                            <>
+                              <div className="w-1.5 h-1.5 rounded-full bg-slate-600" />
+                              Not required in {activeProfile}
+                            </>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="h-[300px] flex flex-col items-center justify-center text-center space-y-3" style={{ color: 'var(--riscv-text-3)' }}>
+                    <div className="p-4 rounded-full" style={{ background: 'var(--riscv-surface-2)', border: '1px solid var(--riscv-border-2)' }}>
+                      <CircuitBoard size={28} style={{ color: 'var(--riscv-muted)' }} />
+                    </div>
+                    <div>
+                      <p className="text-xs font-medium mb-1" style={{ color: 'var(--riscv-text-2)' }}>No Extension Selected</p>
+                      <p className="text-[11px] max-w-[160px] mx-auto" style={{ color: 'var(--riscv-text-3)' }}>
+                        Click any tile to explore specifications, encodings &amp; profiles.
+                      </p>
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
           </div>
         </div>
 
-	        {/* Sidebar Info Panel */}
-		        <div className="lg:col-span-3 mt-6 lg:mt-0">
-		          <div className="sticky top-6 bg-slate-800/80 border border-slate-700 backdrop-blur-sm rounded-xl shadow-2xl min-h-[400px] max-h-[calc(100vh-3rem)] flex flex-col overflow-hidden">
-		            <div className="p-4 pb-3 border-b border-slate-700/60">
-	              <h2 className="text-sm font-bold text-slate-400 flex items-center gap-2 uppercase tracking-wide">
-	                <Info size={16} /> Selected Details
-	              </h2>
-	            </div>
+        {/* ─── Footer ─────────────────────────────────────────────────── */}
+        <footer
+          className="mt-10 pb-8 flex flex-col sm:flex-row items-center justify-between gap-3 text-[11px]"
+          style={{ borderTop: '1px solid var(--riscv-border)', paddingTop: '1.5rem', color: 'var(--riscv-text-3)' }}
+        >
+          <div className="flex items-center gap-2">
+            <CircuitBoard size={14} style={{ color: 'var(--riscv-gold)' }} />
+            <span className="font-semibold" style={{ color: 'var(--riscv-text-2)' }}>RISC-V Extension Landscape</span>
+            <span style={{ color: 'var(--riscv-border-2)' }}>·</span>
+            <span>Data sourced from <a href="https://github.com/riscv/riscv-isa-manual" target="_blank" rel="noreferrer" className="hover:underline" style={{ color: 'var(--riscv-violet)' }}>riscv/riscv-isa-manual</a></span>
+          </div>
+          <div className="flex items-center gap-3">
+            <a
+              href="https://github.com/riscv/riscv-isa-manual"
+              target="_blank"
+              rel="noreferrer"
+              className="hover:opacity-80"
+              style={{ color: 'var(--riscv-text-2)' }}
+              title="View on GitHub"
+            >
+              <BookOpen size={14} />
+            </a>
+          </div>
+        </footer>
+      </div>
 
-	            <div className="flex-1 overflow-y-auto overscroll-contain p-4 pt-3">
-	              {selectedExt ? (
-	                <div className="animate-in fade-in slide-in-from-right-4 duration-300">
-	                <div className="mb-6 flex items-start justify-between gap-3">
-	                  <div className="min-w-0">
-	                    <a
-	                      href={selectedExt.url || 'https://github.com/riscv/riscv-isa-manual'}
-	                      target="_blank"
-	                      rel="noreferrer"
-	                      className="inline-flex items-start gap-1 text-3xl font-black text-white tracking-tight break-words hover:text-purple-300"
-	                      title="Open reference link"
-	                    >
-	                      <span>{selectedExt.name}</span>
-	                      <ArrowUpRight size={18} className="mt-1 shrink-0 opacity-80" />
-	                    </a>
-                  </div>
+      {encoderValidatorOpen && (
+        <div className="fixed inset-0 z-50">
+          <div
+            className="absolute inset-0"
+            style={{ background: 'rgba(7,7,14,0.85)', backdropFilter: 'blur(4px)' }}
+            onClick={() => setEncoderValidatorOpen(false)}
+            role="presentation"
+          />
 
-                  {selectedExt.discontinued === 1 && (
-                    <span className="shrink-0 px-2 py-1 rounded-md text-[10px] font-mono uppercase tracking-wide border bg-red-950/40 text-red-200 border-red-600/60">
-                      Discontinued
-                    </span>
-                  )}
+          <div className="absolute inset-0 p-3 md:p-8 flex items-start justify-center overflow-y-auto">
+            <div className="animate-scale-in w-full max-w-3xl riscv-card overflow-hidden" style={{ boxShadow: '0 0 60px rgba(0,0,0,0.8), 0 0 0 1px rgba(139,124,248,0.15)' }}>
+              <div className="p-4 flex items-start justify-between gap-3" style={{ borderBottom: '1px solid var(--riscv-border)' }}>
+                <div className="min-w-0">
+                  <h3 className="font-bold flex items-center gap-2" style={{ color: 'var(--riscv-text)', fontSize: '14px' }}>
+                    <ScanSearch size={15} style={{ color: 'var(--riscv-violet)' }} />
+                    <span>Encoder Validator</span>
+                  </h3>
+                  <p className="text-[11px] mt-1" style={{ color: 'var(--riscv-text-3)' }}>
+                    Enter a 32-bit encoding (0/1/-) or Match+Mask (hex). Detects overlaps against the full ISA database.
+                  </p>
                 </div>
 
-                <div className="space-y-6">
+                <button
+                  type="button"
+                  className="riscv-btn p-1.5"
+                  onClick={() => setEncoderValidatorOpen(false)}
+                  title="Close"
+                >
+                  <X size={15} />
+                </button>
+              </div>
+
+              <div className="p-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-3">
                   <div>
-                    <h4 className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
-                      Description
-                    </h4>
-                    <p className="text-slate-200 leading-snug">{selectedExt.desc}</p>
-                  </div>
-
-                  <div className="bg-slate-900 p-3 rounded border border-slate-700">
-                    <h4 className="text-[10px] uppercase tracking-wider text-blue-400 font-bold mb-2 flex items-center gap-1">
-                      <ArrowRight size={10} /> Use Case
-                    </h4>
-                    <p className="text-slate-400 text-sm italic">{selectedExt.use}</p>
-                  </div>
-
-	                  {/* Instruction list, when available */}
-	                  {searchMatches &&
-	                    searchMatches.extId === selectedExt.id &&
-	                    searchMatches.query === searchQuery.trim().toLowerCase() &&
-	                    searchMatches.mnemonics.length > 0 && (
-	                      <div className="bg-slate-900 p-3 rounded border border-slate-700">
-	                        <div className="flex items-center justify-between gap-3">
-	                          <div className="min-w-0">
-	                            <div className="text-[10px] uppercase tracking-wider text-yellow-300 font-bold mb-0.5">
-	                              Search Hits ({searchMatches.mnemonics.length})
-	                            </div>
-	                            <div className="text-[11px] font-mono text-slate-200 truncate">
-	                              {searchMatches.mnemonics[searchMatches.index] || ''}
-	                              <span className="ml-2 text-slate-500">
-	                                ({searchMatches.index + 1}/{searchMatches.mnemonics.length})
-	                              </span>
-	                            </div>
-	                          </div>
-
-	                          <div className="flex items-center gap-2 shrink-0">
-	                            <button
-	                              type="button"
-	                              className="px-2 py-1 rounded border border-slate-600 bg-slate-800 text-[10px] font-mono text-slate-100 disabled:opacity-40"
-	                              onClick={() => {
-	                                setSearchMatches((current) => {
-	                                  if (!current || current.extId !== selectedExt.id) return current;
-	                                  const nextIndex =
-	                                    (current.index - 1 + current.mnemonics.length) % current.mnemonics.length;
-	                                  const mnemonic = current.mnemonics[nextIndex];
-	                                  selectInstructionByMnemonic(selectedExt, mnemonic);
-	                                  return { ...current, index: nextIndex };
-	                                });
-	                              }}
-	                              disabled={searchMatches.mnemonics.length < 2}
-	                            >
-	                              Prev
-	                            </button>
-	                            <button
-	                              type="button"
-	                              className="px-2 py-1 rounded border border-slate-600 bg-slate-800 text-[10px] font-mono text-slate-100 disabled:opacity-40"
-	                              onClick={() => {
-	                                setSearchMatches((current) => {
-	                                  if (!current || current.extId !== selectedExt.id) return current;
-	                                  const nextIndex = (current.index + 1) % current.mnemonics.length;
-	                                  const mnemonic = current.mnemonics[nextIndex];
-	                                  selectInstructionByMnemonic(selectedExt, mnemonic);
-	                                  return { ...current, index: nextIndex };
-	                                });
-	                              }}
-	                              disabled={searchMatches.mnemonics.length < 2}
-	                            >
-	                              Next
-	                            </button>
-	                          </div>
-	                        </div>
-	                      </div>
-	                    )}
-
-	                  {Object.keys(selectedExt.instructions || {}).length > 0 && (
-	                    <div className="bg-slate-900 p-3 rounded border border-slate-700">
-	                      <h4 className="text-[10px] uppercase tracking-wider text-emerald-400 font-bold mb-2">
-	                        Instruction Set Snapshot ({Object.keys(selectedExt.instructions || {}).length})
-	                      </h4>
-	                      <div className="flex flex-wrap gap-1">
-		                        {Object.keys(selectedExt.instructions || {}).map((mnemonic) => {
-		                          const q = searchQuery.trim().toLowerCase();
-		                          const instructionDetails = selectedExt.instructions?.[mnemonic];
-		                          const isHit =
-		                            q.length &&
-		                            (mnemonic.toLowerCase().includes(q) ||
-		                              instructionMatchesQuery(mnemonic, instructionDetails, q));
-		                          const isActive = selectedInstruction?.mnemonic === mnemonic;
-		                          const isClickable = Boolean(instructionDetails);
-		                          const isDeprecated = Boolean(instructionDetails?.deprecated);
-		                          return (
-	                            <button
-	                              key={mnemonic}
-	                              type="button"
-		                              onClick={() => {
-		                                if (!isClickable) return;
-		                                setSelectedInstruction(
-		                                  isActive ? null : { mnemonic, ...instructionDetails }
-		                                );
-		                                setSearchMatches((current) => {
-		                                  if (
-		                                    !current ||
-		                                    current.extId !== selectedExt.id ||
-		                                    current.query !== searchQuery.trim().toLowerCase()
-		                                  ) {
-		                                    return current;
-		                                  }
-		                                  const idx = current.mnemonics.indexOf(mnemonic);
-		                                  if (idx === -1) return current;
-		                                  return { ...current, index: idx };
-		                                });
-		                              }}
-	                              className={`px-1.5 py-0.5 rounded border text-[10px] font-mono tracking-tight ${
-	                                isActive
-	                                  ? isDeprecated
-	                                      ? 'border-red-400 bg-red-500/10 text-red-200'
-	                                      : 'border-emerald-400 bg-emerald-500/10 text-emerald-200'
-	                                  : isHit
-	                                      ? 'border-yellow-400 bg-yellow-500/10 text-yellow-200'
-	                                      : isDeprecated
-	                                          ? 'border-red-500/60 bg-red-500/5 text-red-200'
-	                                          : 'border-slate-700 bg-slate-800/70'
-	                              }`}
-	                              title={
-	                                isClickable
-	                                  ? `View details for ${mnemonic}`
-	                                  : `${mnemonic} (no details yet)`
-	                              }
-	                              disabled={!isClickable}
-	                            >
-	                              {mnemonic}
-	                            </button>
-	                          );
-	                        })}
-	                      </div>
-	                    </div>
-	                  )}
-
-                    {extensionCsrs[selectedExt.id] && (
-                      <div className="bg-slate-900 p-3 rounded border border-slate-700">
-                        <h4 className="text-[10px] uppercase tracking-wider text-sky-300 font-bold mb-2">
-                          {(extensionCsrLabels[selectedExt.id] || 'CSRs')}{' '}
-                          ({extensionCsrs[selectedExt.id].length})
-                        </h4>
-                        <div className="flex flex-wrap gap-1">
-                          {extensionCsrs[selectedExt.id].map((csr) => (
-                            <span
-                              key={csr}
-                              className="px-1.5 py-0.5 rounded border border-slate-700 bg-slate-800/70 text-[10px] font-mono text-slate-200"
-                            >
-                              {csr}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-
-		                  {selectedInstruction && (
-		                    <div className="bg-slate-900 p-3 rounded border border-slate-700">
-		                      <div className="flex items-start justify-between gap-3 mb-2">
-		                        <h4 className="text-[10px] uppercase tracking-wider text-purple-300 font-bold flex items-center gap-1">
-		                          <ArrowRight size={10} /> Instruction Details
-		                        </h4>
-		                        <div className="flex items-center gap-2">
-		                          <button
-		                            type="button"
-		                            className="inline-flex items-center gap-1 px-2 py-1 rounded border border-slate-600 bg-slate-800 text-[10px] font-mono text-slate-100 hover:border-slate-500"
-		                            onClick={async () => {
-		                              const text = formatInstructionForClipboard(selectedExt, selectedInstruction);
-		                              const ok = await copyTextToClipboard(text);
-		                              setCopyStatus(ok ? 'copied' : 'failed');
-		                              window.setTimeout(() => setCopyStatus(null), 1500);
-		                            }}
-		                            title="Copy extension + instruction details"
-		                          >
-		                            <Copy size={12} />
-		                            {copyStatus === 'copied'
-		                              ? 'Copied'
-		                              : copyStatus === 'failed'
-		                                  ? 'Copy failed'
-		                                  : 'Copy'}
-		                          </button>
-		                          <button
-		                            type="button"
-		                            className="text-[10px] font-mono text-slate-500 hover:text-slate-300"
-		                            onClick={() => setSelectedInstruction(null)}
-		                          >
-		                            Close
-		                          </button>
-		                        </div>
-		                      </div>
-
-	                      <div className="mb-3 flex items-start justify-between gap-2">
-	                        <div className="text-white font-black tracking-tight text-xl">
-	                          {selectedInstruction.mnemonic}
-	                        </div>
-	                        {selectedInstruction.deprecated && (
-	                          <span className="shrink-0 px-2 py-1 rounded-md text-[10px] font-mono uppercase tracking-wide border bg-red-950/40 text-red-200 border-red-600/60">
-	                            Discontinued
-	                          </span>
-	                        )}
-	                      </div>
-
-	                      <div className="space-y-3">
-	                        <div>
-	                          <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
-	                            Encoding
-	                          </div>
-	                          <EncodingDiagram encoding={selectedInstruction.encoding} />
-	                          <div className="mt-1 text-[10px] text-slate-500">
-	                            Fixed bits are <span className="font-mono">0/1</span>, variable bits are{' '}
-	                            <span className="font-mono">x</span>.
-	                          </div>
-	                        </div>
-
-	                        <div>
-	                          <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
-	                            Variable Fields
-	                          </div>
-	                          <div className="flex flex-wrap gap-1">
-	                            {(selectedInstruction.variable_fields || []).map((field) => (
-	                              <span
-	                                key={field}
-	                                className="px-1.5 py-0.5 rounded border border-slate-700 bg-slate-800/70 text-[10px] font-mono text-slate-200"
-	                              >
-	                                {field}
-	                              </span>
-	                            ))}
-	                          </div>
-	                        </div>
-
-		                        <div className="grid grid-cols-2 gap-2">
-		                          <div>
-		                            <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
-		                              Match
-		                            </div>
-		                            <div
-		                              className={`font-mono text-[11px] text-slate-100 bg-slate-800/70 border rounded px-2 py-1 ${
-		                                searchQuery.trim().length &&
-		                                String(selectedInstruction.match || '')
-		                                  .toLowerCase()
-		                                  .includes(searchQuery.trim().toLowerCase())
-		                                  ? 'border-yellow-400 bg-yellow-500/10'
-		                                  : 'border-slate-700'
-		                              }`}
-		                            >
-		                              {selectedInstruction.match}
-		                            </div>
-		                          </div>
-		                          <div>
-		                            <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
-		                              Mask
-		                            </div>
-		                            <div
-		                              className={`font-mono text-[11px] text-slate-100 bg-slate-800/70 border rounded px-2 py-1 ${
-		                                searchQuery.trim().length &&
-		                                String(selectedInstruction.mask || '')
-		                                  .toLowerCase()
-		                                  .includes(searchQuery.trim().toLowerCase())
-		                                  ? 'border-yellow-400 bg-yellow-500/10'
-		                                  : 'border-slate-700'
-		                              }`}
-		                            >
-		                              {selectedInstruction.mask}
-		                            </div>
-		                          </div>
-		                        </div>
-
-                        {compressedMapping && (
-                          <div className="rounded border border-slate-700 bg-slate-950/50 p-3">
-                            <div className="text-[10px] uppercase tracking-wider text-cyan-300 font-bold mb-2">
-                              Compressed Mapping
-                            </div>
-                            <div className="space-y-2">
-                              <div>
-                                <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
-                                  Compressed
-                                </div>
-                                <div className="font-mono text-[11px] text-slate-100 bg-slate-800/70 border border-slate-700 rounded px-2 py-1">
-                                  {compressedMapping.compressed}
-                                </div>
-                              </div>
-                              <div>
-                                <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
-                                  Standard Equivalent
-                                </div>
-                                {hasStandardEquivalent ? (
-                                  <button
-                                    type="button"
-                                    className="w-full text-left font-mono text-[11px] text-slate-100 bg-slate-800/70 border border-slate-700 rounded px-2 py-1 hover:border-cyan-400/60"
-                                    onClick={() => selectStandardEquivalent(standardEquivalentMnemonic)}
-                                    title="Open standard instruction details"
-                                  >
-                                    <span className="inline-flex items-center gap-1">
-                                      {compressedMapping.standard}
-                                      <ArrowUpRight size={12} className="opacity-70" />
-                                    </span>
-                                  </button>
-                                ) : (
-                                  <div className="font-mono text-[11px] text-slate-100 bg-slate-800/70 border border-slate-700 rounded px-2 py-1">
-                                    {compressedMapping.standard}
-                                  </div>
-                                )}
-                              </div>
-                              <div>
-                                <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
-                                  Equivalent Instruction
-                                </div>
-                                {standardEquivalentMnemonic ? (
-                                  hasStandardEquivalent ? (
-                                    <button
-                                      type="button"
-                                      className="inline-flex items-center gap-1 text-[11px] font-mono text-cyan-200 hover:text-cyan-100 underline"
-                                      onClick={() => selectStandardEquivalent(standardEquivalentMnemonic)}
-                                      title="Open standard instruction details"
-                                    >
-                                      {standardEquivalentMnemonic}
-                                      <ArrowUpRight size={12} className="opacity-70" />
-                                    </button>
-                                  ) : (
-                                    <div className="text-[11px] text-slate-500 font-mono">
-                                      {standardEquivalentMnemonic}
-                                    </div>
-                                  )
-                                ) : (
-                                  <div className="text-[11px] text-slate-500">Unavailable</div>
-                                )}
-                              </div>
-                              <div>
-                                <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
-                                  Description
-                                </div>
-                                <div className="text-[11px] text-slate-200">{compressedMapping.description}</div>
-                              </div>
-                            </div>
-                          </div>
-                        )}
-
-                        {compressedEquivalents.length > 0 && (
-                          <div className="rounded border border-slate-700 bg-slate-950/40 p-3">
-                            <div className="text-[10px] uppercase tracking-wider text-emerald-300 font-bold mb-2">
-                              Compressed Equivalents
-                            </div>
-                            <div className="space-y-2">
-                              {compressedEquivalents.map((entry) => (
-                                <button
-                                  key={entry.mnemonic}
-                                  type="button"
-                                  className="w-full text-left rounded border border-slate-700 bg-slate-900/60 px-2 py-1.5 hover:border-emerald-400/60"
-                                  onClick={() => selectCompressedEquivalent(entry.mnemonic)}
-                                  title={`Open ${entry.mnemonic} details`}
-                                >
-                                  <div className="flex items-center gap-1 text-[11px] font-mono text-emerald-200">
-                                    {normalizeMnemonicKey(entry.mnemonic)}
-                                    <ArrowUpRight size={12} className="opacity-70" />
-                                  </div>
-                                  <div className="text-[10px] font-mono text-slate-400">{entry.compressed}</div>
-                                </button>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-
-		                      </div>
-		                    </div>
-		                  )}
-
-                  {activeProfile && (
-                    <div
-                      className={`
-                      mt-4 p-3 rounded text-xs flex items-center gap-2 border
-                      ${
-                        isHighlighted(selectedExt.id)
-                          ? 'bg-yellow-900/20 border-yellow-700/30 text-yellow-200'
-                          : 'bg-slate-800 border-slate-700 text-slate-500'
+                    <div className="text-[10px] uppercase tracking-widest font-semibold mb-1.5" style={{ color: 'var(--riscv-text-3)' }}>Proposed Mnemonic <span style={{ fontWeight: 400 }}>(optional)</span></div>
+                    <input
+                      type="text"
+                      value={encoderValidatorInput.mnemonic}
+                      onChange={(e) =>
+                        setEncoderValidatorInput((prev) => ({ ...prev, mnemonic: e.target.value }))
                       }
-                    `}
+                      placeholder="e.g. MYOP"
+                      className="riscv-input w-full px-3 py-2 text-sm font-mono"
+                    />
+                  </div>
+
+                  <div>
+                    <div className="text-[10px] uppercase tracking-widest font-semibold mb-1.5" style={{ color: 'var(--riscv-text-3)' }}>Encoding <span style={{ fontWeight: 400 }}>(required if no match/mask)</span></div>
+                    <input
+                      type="text"
+                      value={encoderValidatorInput.encoding}
+                      onChange={(e) =>
+                        setEncoderValidatorInput((prev) => ({ ...prev, encoding: e.target.value }))
+                      }
+                      placeholder="-----------------000-----1100111"
+                      className="riscv-input w-full px-3 py-2 text-sm font-mono"
+                    />
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <div className="text-[10px] uppercase tracking-widest font-semibold mb-1.5" style={{ color: 'var(--riscv-text-3)' }}>Match (hex)</div>
+                      <input
+                        type="text"
+                        value={encoderValidatorInput.match}
+                        onChange={(e) =>
+                          setEncoderValidatorInput((prev) => ({ ...prev, match: e.target.value }))
+                        }
+                        placeholder="0x67"
+                        className="riscv-input w-full px-3 py-2 text-sm font-mono"
+                      />
+                    </div>
+                    <div>
+                      <div className="text-[10px] uppercase tracking-widest font-semibold mb-1.5" style={{ color: 'var(--riscv-text-3)' }}>Mask (hex)</div>
+                      <input
+                        type="text"
+                        value={encoderValidatorInput.mask}
+                        onChange={(e) =>
+                          setEncoderValidatorInput((prev) => ({ ...prev, mask: e.target.value }))
+                        }
+                        placeholder="0x707f"
+                        className="riscv-input w-full px-3 py-2 text-sm font-mono"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-2 pt-1">
+                    <button
+                      type="button"
+                      onClick={runEncoderValidation}
+                      className="riscv-btn riscv-btn-violet inline-flex items-center gap-2 px-4 py-2 text-[11px]"
                     >
-                      {isHighlighted(selectedExt.id) ? (
-                        <>
-                          <div className="w-1.5 h-1.5 rounded-full bg-yellow-400 animate-pulse" />
-                          Required in <strong>{activeProfile}</strong>
-                        </>
-                      ) : (
-                        <>
-                          <div className="w-1.5 h-1.5 rounded-full bg-slate-600" />
-                          Not required in {activeProfile}
-                        </>
-	                      )}
-	                    </div>
-	                  )}
-	                </div>
-	                </div>
-	              ) : (
-	                <div className="h-[300px] flex flex-col items-center justify-center text-slate-600 text-center space-y-4">
-	                  <LayoutGrid size={32} className="opacity-50" />
-	                  <p className="text-xs max-w-[150px]">
-	                    Click any block on the left to view technical specifications and use cases.
-	                  </p>
-	                </div>
-	              )}
-	            </div>
-		          </div>
-		        </div>
-	      </div>
+                      <ScanSearch size={14} />
+                      Validate
+                    </button>
 
-	      {encoderValidatorOpen && (
-	        <div className="fixed inset-0 z-50">
-	          <div
-	            className="absolute inset-0 bg-black/60"
-	            onClick={() => setEncoderValidatorOpen(false)}
-	            role="presentation"
-	          />
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setEncoderValidatorInput({ mnemonic: '', encoding: '', match: '', mask: '' });
+                        setEncoderValidatorResult(null);
+                        setEncoderValidatorCopyStatus(null);
+                      }}
+                      className="riscv-btn px-3 py-2 text-[11px]"
+                    >
+                      Reset
+                    </button>
+                  </div>
+                </div>
 
-	          <div className="absolute inset-0 p-3 md:p-8 flex items-start justify-center overflow-y-auto">
-	            <div className="w-full max-w-3xl bg-slate-900 border border-slate-700 rounded-xl shadow-2xl overflow-hidden">
-	              <div className="p-4 border-b border-slate-700 flex items-start justify-between gap-3">
-	                <div className="min-w-0">
-	                  <h3 className="text-sm font-bold text-slate-200 uppercase tracking-wide flex items-center gap-2">
-	                    <ScanSearch size={16} /> Encoder Validator
-	                  </h3>
-	                  <p className="text-xs text-slate-500 mt-1">
-	                    Provide either a 32-bit Encoding pattern (0/1/-), or Match+Mask (hex). The validator lists any
-	                    existing instructions that overlap.
-	                  </p>
-	                </div>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="text-[10px] uppercase tracking-widest font-semibold" style={{ color: 'var(--riscv-text-3)' }}>Results</div>
+                    <button
+                      type="button"
+                      disabled={!encoderValidatorResult?.proposed}
+                      onClick={async () => {
+                        if (!encoderValidatorResult?.proposed) return;
+                        const report = formatEncoderValidatorReport(
+                          encoderValidatorResult.proposed,
+                          encoderValidatorResult
+                        );
+                        const ok = await copyTextToClipboard(report);
+                        setEncoderValidatorCopyStatus(ok ? 'copied' : 'failed');
+                        window.setTimeout(() => setEncoderValidatorCopyStatus(null), 1500);
+                      }}
+                      className="riscv-btn inline-flex items-center gap-1.5 px-3 py-1.5 text-[11px] disabled:opacity-30"
+                      title="Copy validation report"
+                    >
+                      <Copy size={12} />
+                      {encoderValidatorCopyStatus === 'copied'
+                        ? 'Copied!'
+                        : encoderValidatorCopyStatus === 'failed'
+                          ? 'Failed'
+                          : 'Copy report'}
+                    </button>
+                  </div>
 
-	                <button
-	                  type="button"
-	                  className="p-2 rounded border border-slate-600 bg-slate-800 text-slate-100 hover:border-slate-500"
-	                  onClick={() => setEncoderValidatorOpen(false)}
-	                  title="Close"
-	                >
-	                  <X size={16} />
-	                </button>
-	              </div>
+                  {!encoderValidatorResult ? (
+                    <div
+                      className="text-[11px] rounded-lg p-3"
+                      style={{ background: 'var(--riscv-surface-2)', border: '1px solid var(--riscv-border-2)', color: 'var(--riscv-text-3)' }}
+                    >
+                      Enter a proposed encoding and click Validate.
+                    </div>
+                  ) : (
+                    <div className="space-y-3">
+                      {encoderValidatorResult.errors.length > 0 && (
+                        <div className="border border-red-800/40 bg-red-950/30 rounded p-3">
+                          <div className="text-[10px] uppercase tracking-wider text-red-200 font-bold mb-2">
+                            Errors
+                          </div>
+                          <ul className="text-xs text-red-100 space-y-1 list-disc pl-4">
+                            {encoderValidatorResult.errors.map((err) => (
+                              <li key={err}>{err}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
 
-	              <div className="p-4 grid grid-cols-1 md:grid-cols-2 gap-4">
-	                <div className="space-y-3">
-	                  <div>
-	                    <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
-	                      Proposed mnemonic (optional)
-	                    </div>
-	                    <input
-	                      type="text"
-	                      value={encoderValidatorInput.mnemonic}
-	                      onChange={(e) =>
-	                        setEncoderValidatorInput((prev) => ({ ...prev, mnemonic: e.target.value }))
-	                      }
-	                      placeholder="e.g. MYOP"
-	                      className="w-full px-3 py-2 rounded bg-slate-800 border border-slate-700 text-sm font-mono text-slate-100 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-yellow-400/60 focus:border-yellow-300"
-	                    />
-	                  </div>
+                      {encoderValidatorResult.proposed && (
+                        <div className="border border-slate-700 rounded p-3 bg-slate-800/50">
+                          <div className="text-[10px] uppercase tracking-wider text-slate-400 font-bold mb-2">
+                            Normalized Proposal
+                          </div>
+                          <div className="space-y-2">
+                            <div className="font-mono text-[11px] text-slate-200 break-all">
+                              Encoding: {encoderValidatorResult.proposed.encoding}
+                            </div>
+                            <div className="grid grid-cols-2 gap-2">
+                              <div className="font-mono text-[11px] text-slate-200">Match: {encoderValidatorResult.proposed.match}</div>
+                              <div className="font-mono text-[11px] text-slate-200">Mask: {encoderValidatorResult.proposed.mask}</div>
+                            </div>
+                          </div>
+                        </div>
+                      )}
 
-	                  <div>
-	                    <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
-	                      Encoding (required if no match/mask)
-	                    </div>
-	                    <input
-	                      type="text"
-	                      value={encoderValidatorInput.encoding}
-	                      onChange={(e) =>
-	                        setEncoderValidatorInput((prev) => ({ ...prev, encoding: e.target.value }))
-	                      }
-	                      placeholder="-----------------000-----1100111"
-	                      className="w-full px-3 py-2 rounded bg-slate-800 border border-slate-700 text-sm font-mono text-slate-100 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-yellow-400/60 focus:border-yellow-300"
-	                    />
-	                  </div>
+                      {encoderValidatorResult.proposed && (
+                        <div className="rounded-lg p-3" style={{ border: '1px solid var(--riscv-border-2)', background: 'var(--riscv-surface-2)' }}>
+                          <div className="text-[10px] uppercase tracking-widest font-semibold mb-2" style={{ color: 'var(--riscv-text-3)' }}>Conflicts ({encoderValidatorResult.conflicts.length})</div>
+                          {encoderValidatorResult.conflicts.length === 0 ? (
+                            <div className="conflict-none rounded-lg p-3 flex items-center gap-2 border">
+                              <CheckCircle2 size={15} style={{ color: 'var(--riscv-success)', flexShrink: 0 }} />
+                              <span className="text-[12px] font-medium" style={{ color: 'var(--riscv-success)' }}>No overlaps found in ISA database — safe to use.</span>
+                            </div>
+                          ) : (
+                            <div className="space-y-2 max-h-[340px] overflow-y-auto overscroll-contain pr-1">
+                              {encoderValidatorResult.conflicts.map((conflict) => {
+                                const severityCls =
+                                  conflict.type === 'identical' ? 'conflict-identical' :
+                                    conflict.type === 'proposed_subset_of_existing' ? 'conflict-subset-in' :
+                                      conflict.type === 'existing_subset_of_proposed' ? 'conflict-subset-out' :
+                                        'conflict-partial';
+                                const SeverityIcon =
+                                  conflict.type === 'identical' ? XCircle :
+                                    conflict.type === 'partial_overlap' ? AlertCircle : AlertTriangle;
+                                return (
+                                  <div
+                                    key={`${conflict.other.extId}:${conflict.other.mnemonic}:${conflict.type}`}
+                                    className={`rounded-lg p-2.5 border ${severityCls}`}
+                                  >
+                                    <div className="flex items-start justify-between gap-2">
+                                      <div className="min-w-0 flex items-start gap-1.5">
+                                        <SeverityIcon size={13} className="mt-0.5 shrink-0 opacity-80" />
+                                        <div>
+                                          <div className="font-mono text-[11px] font-medium break-words" style={{ color: 'var(--riscv-text)' }}>
+                                            {conflict.other.mnemonic}{' '}
+                                            <span style={{ color: 'var(--riscv-text-3)' }}>({conflict.other.extId})</span>
+                                          </div>
+                                          <div className="text-[10px] mt-0.5" style={{ color: 'var(--riscv-text-3)' }}>{conflict.other.extName}</div>
+                                        </div>
+                                      </div>
+                                      <span
+                                        className="shrink-0 px-1.5 py-0.5 rounded text-[9px] font-mono uppercase tracking-wider border"
+                                        style={{ background: 'rgba(0,0,0,0.2)', color: 'inherit' }}
+                                      >
+                                        {conflict.type.replace(/_/g, ' ')}
+                                      </span>
+                                    </div>
 
-	                  <div className="grid grid-cols-2 gap-3">
-	                    <div>
-	                      <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
-	                        Match (hex)
-	                      </div>
-	                      <input
-	                        type="text"
-	                        value={encoderValidatorInput.match}
-	                        onChange={(e) =>
-	                          setEncoderValidatorInput((prev) => ({ ...prev, match: e.target.value }))
-	                        }
-	                        placeholder="0x67"
-	                        className="w-full px-3 py-2 rounded bg-slate-800 border border-slate-700 text-sm font-mono text-slate-100 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-yellow-400/60 focus:border-yellow-300"
-	                      />
-	                    </div>
-	                    <div>
-	                      <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold mb-1">
-	                        Mask (hex)
-	                      </div>
-	                      <input
-	                        type="text"
-	                        value={encoderValidatorInput.mask}
-	                        onChange={(e) =>
-	                          setEncoderValidatorInput((prev) => ({ ...prev, mask: e.target.value }))
-	                        }
-	                        placeholder="0x707f"
-	                        className="w-full px-3 py-2 rounded bg-slate-800 border border-slate-700 text-sm font-mono text-slate-100 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-yellow-400/60 focus:border-yellow-300"
-	                      />
-	                    </div>
-	                  </div>
+                                    <div className="mt-1.5 text-[11px]" style={{ color: 'var(--riscv-text-2)' }}>{conflict.why}</div>
+                                    <div className="mt-1.5 grid grid-cols-2 gap-2">
+                                      <div className="font-mono text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>mask: {conflict.commonMask}</div>
+                                      <div className="font-mono text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>example: {conflict.exampleWord}</div>
+                                    </div>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
-	                  <div className="flex items-center gap-2 pt-1">
-	                    <button
-	                      type="button"
-	                      onClick={runEncoderValidation}
-	                      className="inline-flex items-center gap-2 px-3 py-2 rounded border border-yellow-500/50 bg-yellow-500/10 text-yellow-200 text-xs font-bold hover:border-yellow-400"
-	                    >
-	                      <ScanSearch size={16} />
-	                      Validate
-	                    </button>
+      {/* ── ISA Workspace Panel ────────────────────────────────────────── */}
+      <WorkspacePanel
+        open={workspacePanelOpen}
+        onClose={() => setWorkspacePanelOpen(false)}
+        workspaceIds={workspaceIds}
+        lockedExtensions={lockedExtensions}
+        allExts={allExtsList}
+        onAddId={(id) => addWorkspaceIdsSmart(id)}
+        onRemoveId={(id) =>
+          setWorkspaceIds((prev) => {
+            const next = new Set(prev);
+            // Lock check inside panel removal as well
+            const currentLocked = new Map();
+            for (const ext of Array.from(prev)) {
+              const deps = SMART_DEPENDENCIES[ext] || [];
+              for (const dep of deps) {
+                if (prev.has(dep)) {
+                  if (!currentLocked.has(dep)) currentLocked.set(dep, []);
+                  currentLocked.get(dep).push(ext);
+                }
+              }
+            }
+            if (currentLocked.has(id)) {
+              setWorkspaceNotice(`Cannot remove ${id}: required by ${currentLocked.get(id).join(', ')}`);
+              setTimeout(() => setWorkspaceNotice(null), 4500);
+              return next;
+            }
+            next.delete(id);
+            return next;
+          })
+        }
+        onClear={() => setWorkspaceIds(new Set())}
+        onLoadIds={(ids) => {
+          setWorkspaceIds(new Set()); // clear
+          addWorkspaceIdsSmart(ids);  // smartly add all
+        }}
+        onSelectInstruction={({ extId, mnemonic, encoding, variable_fields, match, mask }) => {
+          // Navigate the main view to the specified extension + instruction
+          const targetExt = allExtsList.find((e) => e.id === extId);
+          if (targetExt) {
+            setSelectedExt(targetExt);
+            setSelectedInstruction({ mnemonic, encoding, variable_fields, match, mask });
+            setWorkspacePanelOpen(false); // close panel to reveal main view
+            // Scroll tile into view
+            requestAnimationFrame(() => {
+              const el = document.getElementById(`ext-${extId}`);
+              if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            });
+          }
+        }}
+      />
 
-	                    <button
-	                      type="button"
-	                      onClick={() => {
-	                        setEncoderValidatorInput({ mnemonic: '', encoding: '', match: '', mask: '' });
-	                        setEncoderValidatorResult(null);
-	                        setEncoderValidatorCopyStatus(null);
-	                      }}
-	                      className="px-3 py-2 rounded border border-slate-600 bg-slate-800 text-xs font-bold text-slate-100 hover:border-slate-500"
-	                    >
-	                      Reset
-	                    </button>
-	                  </div>
-	                </div>
-
-	                <div className="space-y-3">
-	                  <div className="flex items-center justify-between gap-2">
-	                    <div className="text-[10px] uppercase tracking-wider text-slate-500 font-bold">
-	                      Results
-	                    </div>
-	                    <button
-	                      type="button"
-	                      disabled={!encoderValidatorResult?.proposed}
-	                      onClick={async () => {
-	                        if (!encoderValidatorResult?.proposed) return;
-	                        const report = formatEncoderValidatorReport(
-	                          encoderValidatorResult.proposed,
-	                          encoderValidatorResult
-	                        );
-	                        const ok = await copyTextToClipboard(report);
-	                        setEncoderValidatorCopyStatus(ok ? 'copied' : 'failed');
-	                        window.setTimeout(() => setEncoderValidatorCopyStatus(null), 1500);
-	                      }}
-	                      className="inline-flex items-center gap-2 px-3 py-2 rounded border border-slate-600 bg-slate-800 text-xs font-bold text-slate-100 hover:border-slate-500 disabled:opacity-30"
-	                      title="Copy validation report"
-	                    >
-	                      <Copy size={14} />
-	                      {encoderValidatorCopyStatus === 'copied'
-	                        ? 'Copied'
-	                        : encoderValidatorCopyStatus === 'failed'
-	                          ? 'Copy failed'
-	                          : 'Copy report'}
-	                    </button>
-	                  </div>
-
-	                  {!encoderValidatorResult ? (
-	                    <div className="text-xs text-slate-400 border border-slate-700 rounded p-3 bg-slate-800/50">
-	                      Enter a proposed encoding and click Validate.
-	                    </div>
-	                  ) : (
-	                    <div className="space-y-3">
-	                      {encoderValidatorResult.errors.length > 0 && (
-	                        <div className="border border-red-800/40 bg-red-950/30 rounded p-3">
-	                          <div className="text-[10px] uppercase tracking-wider text-red-200 font-bold mb-2">
-	                            Errors
-	                          </div>
-	                          <ul className="text-xs text-red-100 space-y-1 list-disc pl-4">
-	                            {encoderValidatorResult.errors.map((err) => (
-	                              <li key={err}>{err}</li>
-	                            ))}
-	                          </ul>
-	                        </div>
-	                      )}
-
-	                      {encoderValidatorResult.proposed && (
-	                        <div className="border border-slate-700 rounded p-3 bg-slate-800/50">
-	                          <div className="text-[10px] uppercase tracking-wider text-slate-400 font-bold mb-2">
-	                            Normalized Proposal
-	                          </div>
-	                          <div className="space-y-2">
-	                            <div className="font-mono text-[11px] text-slate-200 break-all">
-	                              Encoding: {encoderValidatorResult.proposed.encoding}
-	                            </div>
-	                            <div className="grid grid-cols-2 gap-2">
-	                              <div className="font-mono text-[11px] text-slate-200">Match: {encoderValidatorResult.proposed.match}</div>
-	                              <div className="font-mono text-[11px] text-slate-200">Mask: {encoderValidatorResult.proposed.mask}</div>
-	                            </div>
-	                          </div>
-	                        </div>
-	                      )}
-
-	                      {encoderValidatorResult.proposed && (
-	                        <div className="border border-slate-700 rounded p-3 bg-slate-800/50">
-	                          <div className="text-[10px] uppercase tracking-wider text-slate-400 font-bold mb-2">
-	                            Conflicts ({encoderValidatorResult.conflicts.length})
-	                          </div>
-	                          {encoderValidatorResult.conflicts.length === 0 ? (
-	                            <div className="text-xs text-emerald-200">
-	                              No overlaps found within the current instruction set database.
-	                            </div>
-	                          ) : (
-	                            <div className="space-y-2 max-h-[340px] overflow-y-auto overscroll-contain pr-1">
-	                              {encoderValidatorResult.conflicts.map((conflict) => (
-	                                <div
-	                                  key={`${conflict.other.extId}:${conflict.other.mnemonic}:${conflict.type}`}
-	                                  className="border border-slate-700 rounded p-2 bg-slate-900/50"
-	                                >
-	                                  <div className="flex items-start justify-between gap-2">
-	                                    <div className="min-w-0">
-	                                      <div className="font-mono text-xs text-slate-200 break-words">
-	                                        {conflict.other.mnemonic}{' '}
-	                                        <span className="text-slate-500">({conflict.other.extId})</span>
-	                                      </div>
-	                                      <div className="text-[11px] text-slate-500">{conflict.other.extName}</div>
-	                                    </div>
-	                                    <span className="shrink-0 px-2 py-1 rounded text-[10px] font-mono uppercase tracking-wide border bg-slate-800 text-slate-100 border-slate-600">
-	                                      {conflict.type}
-	                                    </span>
-	                                  </div>
-
-	                                  <div className="mt-2 text-xs text-slate-300">{conflict.why}</div>
-	                                  <div className="mt-2 grid grid-cols-2 gap-2">
-	                                    <div className="font-mono text-[10px] text-slate-400">
-	                                      Common mask: {conflict.commonMask}
-	                                    </div>
-	                                    <div className="font-mono text-[10px] text-slate-400">
-	                                      Example word: {conflict.exampleWord}
-	                                    </div>
-	                                  </div>
-	                                </div>
-	                              ))}
-	                            </div>
-	                          )}
-	                        </div>
-	                      )}
-	                    </div>
-	                  )}
-	                </div>
-	              </div>
-	            </div>
-	          </div>
-	        </div>
-	      )}
-	    </div>
-	  );
-	};
+      {/* ── Workspace Notices Toast ── */}
+      <div
+        style={{
+          position: 'fixed',
+          bottom: workspaceNotice ? '32px' : '-100px',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          background: 'var(--riscv-surface-2)',
+          border: '1px solid var(--riscv-border-2)',
+          color: 'var(--riscv-text)',
+          padding: '10px 16px',
+          borderRadius: '8px',
+          boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
+          transition: 'all 0.4s cubic-bezier(0.16, 1, 0.3, 1)',
+          zIndex: 9999,
+          display: 'flex',
+          alignItems: 'center',
+          gap: '10px',
+          opacity: workspaceNotice ? 1 : 0,
+          pointerEvents: workspaceNotice ? 'auto' : 'none',
+          backdropFilter: 'blur(8px)',
+        }}
+      >
+        <Info size={16} style={{ color: '#6366f1' }} />
+        <span style={{ fontSize: '13px', fontWeight: 500 }}>{workspaceNotice}</span>
+      </div>
+    </div>
+  );
+};
 
 export default RISCVExplorer;

--- a/tests/march.test.mjs
+++ b/tests/march.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for src/marchUtils.js — the -march generator and dependency table.
+ *
+ * These are pure-function tests: marchUtils imports no React and no JSON, and
+ * takes the flat extension array as a parameter, so it can be exercised
+ * directly with no DOM and no fixtures beyond the catalog itself.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  buildMarchString,
+  parseMarchString,
+  SMART_DEPENDENCIES,
+  INCOMPATIBLE_WITH,
+  NON_MARCH_IDS,
+} from '../src/marchUtils.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const catalog = JSON.parse(readFileSync(join(here, '..', 'src', 'riscv_extensions.json'), 'utf8'));
+const ALL = Object.values(catalog).flat();
+
+const march = (ids) => buildMarchString(ids, ALL);
+
+// ---------------------------------------------------------------------------
+// Canonical generation — these encode spec §27 rules and must always hold.
+// ---------------------------------------------------------------------------
+
+test('emits canonical single-letter order, base letter not repeated', () => {
+  const r = march(['RV64I', 'M', 'A', 'F', 'D', 'C']);
+  assert.equal(r.march, 'rv64imafdc');
+});
+
+test('multi-letter tokens are underscore-prefixed and alphabetical', () => {
+  const r = march(['RV64I', 'M', 'Zbb', 'Zba', 'Zicsr']);
+  assert.equal(r.march, 'rv64im_zba_zbb_zicsr');
+});
+
+test('never emits the g shorthand', () => {
+  const r = march(['RV64I', 'M', 'A', 'F', 'D', 'Zicsr', 'Zifencei']);
+  assert.ok(!/(^|[^a-z])g([^a-z]|$)/.test(r.march), `g leaked into ${r.march}`);
+});
+
+test('decoder expands g, encoder round-trips to explicit tokens', () => {
+  const p = parseMarchString('rv64gc', ALL);
+  assert.equal(p.xlen, 64);
+  assert.ok(p.gExpanded, 'g should be flagged as expanded');
+  const r = march(p.resolvedIds);
+  assert.ok(!r.march.includes('g'), `re-encoded string still contains g: ${r.march}`);
+});
+
+test('requires a base ISA', () => {
+  const r = march(['M', 'A']);
+  assert.equal(r.march, null);
+  assert.match(r.warnings.join(' '), /base ISA/i);
+});
+
+test('UI-only grouping tags are excluded, not emitted', () => {
+  for (const tag of NON_MARCH_IDS) {
+    const r = march(['RV64I', tag]);
+    assert.ok(
+      r.excluded.some((e) => e.id === tag),
+      `${tag} should appear in excluded[]`,
+    );
+    assert.ok(!r.march.includes(tag.toLowerCase()), `${tag} leaked into ${r.march}`);
+  }
+});
+
+test('privileged spec version tags are excluded', () => {
+  const r = march(['RV64I', 'Sm1p12']);
+  assert.ok(r.excluded.some((e) => e.id === 'Sm1p12'));
+});
+
+// ---------------------------------------------------------------------------
+// Dependency table integrity
+// ---------------------------------------------------------------------------
+
+test('every dependency target exists in the catalog', () => {
+  const ids = new Set(ALL.map((e) => e.id));
+  const missing = [];
+  for (const [ext, deps] of Object.entries(SMART_DEPENDENCIES)) {
+    for (const d of deps) if (!ids.has(d)) missing.push(`${ext} -> ${d}`);
+  }
+  assert.deepEqual(missing, [], `dependencies pointing at non-existent extensions:\n  ${missing.join('\n  ')}`);
+});
+
+// ---------------------------------------------------------------------------
+// Known defects — these are expected to FAIL until fixed.
+// Each corresponds to a review finding on PR #139.
+// ---------------------------------------------------------------------------
+
+test('[defect] E-base and F are rejected as incompatible', () => {
+  // INCOMPATIBLE_WITH declares RV32E/RV64E incompatible with F, but nothing
+  // consults the table, so an invalid string is produced silently.
+  assert.ok(INCOMPATIBLE_WITH.RV32E.includes('F'), 'table should declare the conflict');
+  const r = march(['RV32E', 'F']);
+  assert.ok(
+    r.march === null || r.excluded.some((e) => e.id === 'F') || r.warnings.length > 0,
+    `RV32E + F produced "${r.march}" with no warning or exclusion`,
+  );
+});
+
+test('[defect] I and E cannot both be selected', () => {
+  // buildMarchString filters only the base's own letter, so an E base with I
+  // also selected yields rv32ei..., which no toolchain accepts.
+  const r = march(['RV32E', 'I']);
+  assert.ok(
+    !/^rv32ei/.test(r.march ?? ''),
+    `produced mutually exclusive base letters: ${r.march}`,
+  );
+});
+
+test('[defect] F implies Zicsr', () => {
+  // F defines fcsr/frm/fflags, so it depends on Zicsr; GCC's riscv_ext_info
+  // encodes the same implication. Absent here, a config with F but no Zicsr
+  // resolves without complaint.
+  assert.ok(
+    SMART_DEPENDENCIES.F?.includes('Zicsr'),
+    'SMART_DEPENDENCIES has no F -> Zicsr entry',
+  );
+});


### PR DESCRIPTION
## feat: Custom ISA Configuration Builder

### The problem

Anyone who has tried to actually *build* a RISC-V configuration — rather than just read about one — runs into the same wall. The extensions landscape today is a reference: you can browse `Zicsr`, look up `Zve64d`, read what `Zks` covers. But going from "I want a config for this chip" to a config you can actually compile against is still a manual, error-prone exercise that lives in someone's head or a half-maintained spreadsheet.

Concretely, an engineer assembling a custom ISA profile has to answer, by hand, for every extension they touch:

- What does this extension actually *require*? Selecting `D` silently assumes `F`. Selecting `Zve64d` assumes both `D` and `F`. Nothing enforces that — you find out at compile time, or worse, at synthesis time.
- What is the correct canonical `-march` string for this exact combination? Ordering, casing, and separators are spec-defined, not stylistic, and getting them wrong produces a string that *looks* plausible but isn't accepted by real toolchains.
- What instructions does this configuration actually put on the table, once overlapping extensions are reconciled? Two extensions can define instructions that share a mnemonic but differ in encoding — a naive merge silently drops one of them.
- Can any of this be handed to a reviewer, a toolchain team, or a certification body without them having to re-derive it from scratch and trust it on faith?

This is arguably one of the most recurring pain points raised around the RISC-V extensions ecosystem: there's abundant reference material, but no workspace where you can actually *construct* a configuration and walk away with something verifiable. This PR builds that workspace.

### What this PR adds

The Custom ISA Configuration Builder turns the landscape from a browsing surface into an interactive builder. Users select extensions, the system resolves what those selections require, and the result can be exported as a self-describing, toolchain-ready configuration.

**1. Interactive workspace UI (`WorkspacePanel.jsx`)**
A persistent, collapsible workspace panel tracks the current selection across the whole landscape as the user browses. It shows live counters for selected extensions and resolved instructions, and exposes quick actions — clear workspace, export — without requiring the panel to be fully expanded. Two data views are available inline: the generated compiler flag, and the deduplicated instruction catalog for the current selection.

**2. Dependency engine (`marchUtils.js`)**
An extension cannot be selected without its architectural prerequisites also being satisfied — selecting `D` pulls in `F`; selecting `Zve64d` pulls in both `D` and `F`, automatically. Every dependency rule encoded here is traceable to a primary source (the RISC-V Unprivileged ISA Manual or the RISC-V Unified Database), not inferred or guessed.

**3. `-march` string generation**
Produces compiler flags that follow the canonical ordering, casing, and separator rules defined in the RISC-V Unprivileged ISA Specification (§27). Standard umbrella expansions are handled correctly (e.g., `G` expands to `IMAFDZicsr_Zifencei`), and internal UI/trace-only tags (`K`, `P`, `N`, `S`, `U`) are explicitly excluded so they never leak into a string a compiler would actually see.

**4. Instruction catalog with real deduplication**
Every instruction from every selected extension is merged into a single catalog. Deduplication uses a composite key of mnemonic *and* normalized encoding, not mnemonic alone — so two instructions that share a name but differ in encoding (e.g., a 32-bit vs. 64-bit mask width variant) are both preserved instead of one silently overwriting the other.

**5. Self-describing configuration export (`exportUtils.js`)**
Exports a two-part YAML: a header (base ISA, generated `-march` string, inferred spec versions, categorized extension lists) and, optionally, the full deduplicated instruction catalog (mnemonic, encoding, match/mask, `defined_by`). Configurations above 100 instructions default to excluding the catalog from the export to avoid bloat, with a toggle so the user can override that.

### Data provenance

Nothing in this feature is guessed. Every rule the builder enforces is backed by a primary source, and that source is exported alongside the data it produced:

- Canonical extension ordering — RISC-V Unprivileged ISA Specification, §27.11.
- Instruction encodings — `riscv/riscv-opcodes`.
- Compiler compatibility floors — tracked explicitly rather than assumed: scalar crypto verified back to roughly GCC 12 / LLVM 14, vector crypto to GCC 14 / LLVM 18 stable, with the exact `gcc -march=help`-style check commands exported directly into the YAML comments so a reviewer can re-verify them independently rather than take the tool's word for it.

### Also in this PR

Header layout has been redesigned: all header action buttons now share a cleaner, more consistent style, replacing the previous mixed layout.

### Future scope

- The current hardcoded `SMART_DEPENDENCIES` table is a deliberate placeholder — it's designed to be replaced by dynamic UDB payload fetching once the parallel UDB-syncing PR lands.
- Live CI cross-compiler validation against generated `-march` strings, so correctness is checked continuously rather than only at review time.