### PR TITLE
ci: publish to GitHub Pages on every push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,41 @@ jobs:
             fi
           done < <(node scripts/emit-march-matrix.mjs)
           exit $fail
+
+  # Publishes to the gh-pages branch, which is what Pages serves. Gated on
+  # build-and-test so only tested code reaches the live site, and restricted to
+  # pushes on main so pull requests never publish.
+  deploy:
+    needs: build-and-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: gh-pages
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Publish dist/ to gh-pages
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -d dist || { echo "dist/ was not produced by the build"; exit 1; }
+          touch dist/.nojekyll
+          cd dist
+          git init -q
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -q -m "deploy: ${GITHUB_SHA::8} from main"
+          git push -f "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:gh-pages
+          echo "published ${GITHUB_SHA::8} to gh-pages"


### PR DESCRIPTION
**The live site is seven months stale.**

```
gh-pages: b62df29a  2026-01-15  "Updates"
main:     a97df1f7  2026-08-17
```

Pages is configured and serving `gh-pages`, but nothing ever wrote to it — publishing depended on someone running `npm run deploy` by hand. So https://rpsene.github.io/riscv-extensions-landscape/ currently carries neither the UI overhaul (#140) nor the ISA Configuration Builder (#139).

Adds a `deploy` job to the existing CI workflow rather than a separate one, so the ordering is explicit and enforced:

- `needs: build-and-test` — only code that builds and passes all 19 tests is published
- `if: push && ref == main` — pull requests never deploy
- `concurrency: gh-pages, cancel-in-progress` — overlapping merges cannot interleave force-pushes to the published branch

Uses the built-in `GITHUB_TOKEN`, so no new secret. Adds `.nojekyll` so Jekyll does not strip underscore-prefixed files from the webpack output.

Merging this will publish the current `main` for the first time since January.