### PR TITLE
Model extension dependencies as a validated graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "style-loader": "^3.3.3",
         "tailwindcss": "^3.4.0",
         "webpack": "^5.89.0",
-        "webpack-cli": "^5.1.4"
+        "webpack-cli": "^5.1.4",
+        "yaml": "^2.9.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -73,7 +74,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -802,7 +802,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -829,7 +828,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1053,7 +1051,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -3002,7 +2999,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3306,7 +3302,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3929,7 +3924,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4059,7 +4053,6 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -4109,7 +4102,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -4214,6 +4206,22 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -4,31 +4,33 @@
   "description": "",
   "main": "index.js",
   "homepage": "https://rpsene.github.io/riscv-extensions-landscape/",
-"scripts": {
-  "build": "webpack",
-  "predeploy": "npm run build",
-  "deploy": "gh-pages -d dist --branch gh-pages --dotfiles",
-  "test": "node --test tests/*.test.mjs",
-  "sync:check": "npm run sync -- --strict",
-  "sync": "node scripts/sync_instructions.mjs"
-},
+  "scripts": {
+    "build": "webpack",
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist --branch gh-pages --dotfiles",
+    "test": "node --test tests/*.test.mjs",
+    "sync:check": "npm run sync -- --strict",
+    "sync": "node scripts/sync_instructions.mjs",
+    "graph:check": "node scripts/seed-dependency-graph.mjs --check --udb"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "gh-pages": "^6.0.0",
     "@babel/core": "^7.23.0",
     "@babel/preset-react": "^7.22.0",
     "autoprefixer": "^10.4.16",
     "babel-loader": "^9.1.3",
     "css-loader": "^6.8.1",
+    "gh-pages": "^6.0.0",
     "html-webpack-plugin": "^5.5.4",
     "postcss": "^8.4.32",
     "postcss-loader": "^7.3.4",
     "style-loader": "^3.3.3",
     "tailwindcss": "^3.4.0",
     "webpack": "^5.89.0",
-    "webpack-cli": "^5.1.4"
+    "webpack-cli": "^5.1.4",
+    "yaml": "^2.9.0"
   },
   "dependencies": {
     "lucide-react": "^0.294.0",

--- a/scripts/seed-dependency-graph.mjs
+++ b/scripts/seed-dependency-graph.mjs
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+/**
+ * Seeds src/isa-dependency-graph.json from riscv-unified-db.
+ *
+ * This is a bootstrap/reconcile tool, NOT part of the build. The committed
+ * graph is the source of truth and is maintained by hand; this script exists so
+ * a human can ask "has upstream moved?" and get a diff instead of guessing.
+ *
+ *   node scripts/seed-dependency-graph.mjs --udb <path-to-udb-checkout>          # write
+ *   node scripts/seed-dependency-graph.mjs --udb <path-to-udb-checkout> --check  # diff only
+ *
+ * UDB schema note (this cost us once already): extension requirements live in
+ * BOTH `requirements:` at the top level and `versions[].requirements:`, and the
+ * `extension:` node is either a bare `{name: X}` or a combinator
+ * (`allOf`/`anyOf`) containing `{name: X}` entries. Parsing only the top-level
+ * `allOf` shape silently loses D->F, Q->D, B->Zba/Zbb/Zbs and ~15 others, which
+ * reads as "UDB has gaps" when in fact the parser did.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { parse as parseYaml } from 'yaml';
+
+const args = process.argv.slice(2);
+const udbFlag = args.indexOf('--udb');
+const udbRoot = udbFlag === -1 ? null : args[udbFlag + 1];
+const checkOnly = args.includes('--check');
+if (!udbRoot || udbRoot.startsWith('--')) {
+  console.error('usage: seed-dependency-graph.mjs --udb <path-to-riscv-unified-db> [--check]');
+  process.exit(2);
+}
+
+const here = path.dirname(new URL(import.meta.url).pathname);
+const repoRoot = path.join(here, '..');
+const GRAPH_PATH = path.join(repoRoot, 'src', 'isa-dependency-graph.json');
+
+// ---------------------------------------------------------------------------
+// UDB extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extension requirements reachable from a `requirements:` node, any shape.
+ *
+ * `allOf` members are hard requirements. `anyOf`/`oneOf` members are a CHOICE
+ * and must not be flattened into the hard set — Svpbmt requires S and *one of*
+ * Sv39/Sv48/Sv57, and demanding all three would over-constrain every config
+ * that uses it.
+ */
+function extensionRequirements(requirements) {
+  const hard = [];
+  const choices = [];
+  const walk = (node) => {
+    if (Array.isArray(node)) return node.forEach(walk);
+    if (!node || typeof node !== 'object') return;
+    if (typeof node.name === 'string') return void hard.push(node.name);
+    if ('allOf' in node) walk(node.allOf);
+    for (const combinator of ['anyOf', 'oneOf']) {
+      if (combinator in node) {
+        const options = [];
+        const collect = (n) => {
+          if (Array.isArray(n)) return n.forEach(collect);
+          if (n && typeof n === 'object') {
+            if (typeof n.name === 'string') options.push(n.name);
+            else for (const c of ['allOf', 'anyOf', 'oneOf']) if (c in n) collect(n[c]);
+          }
+        };
+        collect(node[combinator]);
+        if (options.length) choices.push(options);
+      }
+    }
+  };
+  walk(requirements?.extension);
+  return { hard, choices };
+}
+
+function readUdb(root) {
+  const dir = path.join(root, 'spec', 'std', 'isa', 'ext');
+  const graph = {};
+  const known = new Set();
+  for (const file of fs.readdirSync(dir).filter((f) => f.endsWith('.yaml'))) {
+    const id = file.slice(0, -5);
+    known.add(id);
+    const doc = parseYaml(fs.readFileSync(path.join(dir, file), 'utf8'));
+    if (!doc || typeof doc !== 'object') continue;
+    const hard = new Set();
+    const choices = [];
+    for (const req of [doc.requirements, ...(doc.versions ?? []).map((v) => v?.requirements)]) {
+      if (!req) continue;
+      const found = extensionRequirements(req);
+      found.hard.forEach((n) => hard.add(n));
+      for (const options of found.choices) {
+        const key = options.slice().sort().join('|');
+        if (!choices.some((c) => c.slice().sort().join('|') === key)) choices.push(options);
+      }
+    }
+    hard.delete(id); // a few files name themselves via version constraints
+    if (hard.size || choices.length) {
+      graph[id] = { hard: [...hard].sort(), choices };
+    }
+  }
+  let commit = 'unknown';
+  try {
+    commit = execFileSync('git', ['-C', root, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+  } catch { /* not a git checkout — provenance degrades, extraction still works */ }
+  return { graph, known, commit };
+}
+
+/** Extension ids in the shipped catalog. */
+function readCatalogIds() {
+  const cat = JSON.parse(fs.readFileSync(path.join(repoRoot, 'src', 'riscv_extensions.json'), 'utf8'));
+  const ids = [];
+  for (const group of Object.values(cat)) {
+    if (Array.isArray(group)) group.forEach((e) => e?.id && ids.push(e.id));
+  }
+  return ids;
+}
+
+// ---------------------------------------------------------------------------
+// Edges we assert ourselves, where UDB is silent.
+// Every entry needs a citation — an uncited edge is a guess wearing a fact's
+// clothes, and this graph is meant to be auditable.
+// ---------------------------------------------------------------------------
+const LOCAL_EDGES = {
+  Zdinx:    [{ ext: 'Zicsr', src: 'isa-manual', ref: 'Vol.I §21 — Zdinx uses the fcsr/frm/fflags CSRs' }],
+  Zhinx:    [{ ext: 'Zicsr', src: 'isa-manual', ref: 'Vol.I §21 — Zhinx uses the fcsr/frm/fflags CSRs' }],
+  Zhinxmin: [{ ext: 'Zicsr', src: 'isa-manual', ref: 'Vol.I §21 — Zhinxmin uses the fcsr/frm/fflags CSRs' }],
+  Zfh:      [{ ext: 'Zfhmin', src: 'isa-manual', ref: 'Vol.I §16.2 — Zfh is a superset of Zfhmin' }],
+  // clang implies zvfhmin for Zvfh, and Zvfh is the full vector half-precision
+  // extension to Zvfhmin's conversion-only subset — the same superset relation
+  // UDB *does* record for the scalar pair (Zfh -> Zfhmin). UDB's Zvfh.yaml
+  // lists only Zve32f and Zfhmin, so this edge rests on clang plus the scalar
+  // analogue rather than on UDB. Marked src:clang so the weaker backing shows.
+  Zvfh:     [{ ext: 'Zvfhmin', src: 'clang', ref: 'clang -march=rv64i_zvfh implies +zvfhmin; UDB Zvfh.yaml is silent' }],
+};
+
+/** Base-ISA conflicts. Not dependencies, but they belong to the same graph. */
+const CONFLICTS = {
+  RV32E: [{ ext: 'F', ref: 'Vol.I §5 — RV32E has 16 GPRs and no F register file' }],
+  RV64E: [{ ext: 'F', ref: 'Vol.I §5 — RV64E has 16 GPRs and no F register file' }],
+};
+
+// ---------------------------------------------------------------------------
+// Build
+// ---------------------------------------------------------------------------
+const { graph: udb, known: udbKnown, commit } = readUdb(udbRoot);
+const catalogIds = readCatalogIds();
+
+/**
+ * Which option to auto-select when a choice group is unsatisfied. The weakest
+ * option is the honest default: it is the minimum that satisfies the
+ * requirement, so it never silently buys capability the user did not ask for.
+ * Ordered weakest-first; the first member present in the group wins.
+ */
+const WEAKEST_FIRST = ['Sv32', 'Sv39', 'Sv48', 'Sv57'];
+function pickDefault(options) {
+  for (const candidate of WEAKEST_FIRST) if (options.includes(candidate)) return candidate;
+  return options.slice().sort()[0];
+}
+
+const nodes = {};
+for (const id of catalogIds.slice().sort((a, b) => a.localeCompare(b))) {
+  const requires = [];
+  for (const dep of udb[id]?.hard ?? []) {
+    requires.push({ ext: dep, src: 'udb', ref: `${id}.yaml requirements.extension` });
+  }
+  for (const local of LOCAL_EDGES[id] ?? []) {
+    if (requires.some((r) => r.ext === local.ext)) continue; // UDB already covers it
+    requires.push({ ext: local.ext, src: local.src, ref: local.ref });
+  }
+  requires.sort((a, b) => a.ext.localeCompare(b.ext));
+
+  const node = { requires };
+
+  const choices = udb[id]?.choices ?? [];
+  if (choices.length) {
+    node.requiresOneOf = choices.map((options) => ({
+      options: options.slice().sort(),
+      default: pickDefault(options),
+      src: 'udb',
+      ref: `${id}.yaml requirements.extension.anyOf`,
+    }));
+  }
+
+  if (CONFLICTS[id]) {
+    node.conflicts = CONFLICTS[id].map((c) => ({ ext: c.ext, src: 'isa-manual', ref: c.ref }));
+  }
+  // How far to trust an empty `requires`. "udb" means UDB models this extension
+  // and records no extension requirements; "none" means nothing authoritative
+  // was consulted, so the emptiness is an assumption rather than a finding.
+  if (requires.length === 0 && !node.requiresOneOf) {
+    node.verified = udbKnown.has(id) ? 'udb' : 'none';
+  }
+  nodes[id] = node;
+}
+
+// Close the graph. UDB requires a few extensions our catalog does not carry
+// (S -> Sm, for one), and an edge pointing at nothing is a validation error, so
+// pull those in transitively. They are marked catalogued:false — they exist to
+// keep traversal total, not because the UI offers them.
+const pending = [];
+const collectTargets = (node) => {
+  for (const edge of node.requires ?? []) pending.push(edge.ext);
+  for (const choice of node.requiresOneOf ?? []) pending.push(...choice.options);
+};
+Object.values(nodes).forEach(collectTargets);
+
+while (pending.length) {
+  const id = pending.pop();
+  if (nodes[id]) continue;
+  const requires = (udb[id]?.hard ?? []).map((dep) => ({
+    ext: dep,
+    src: 'udb',
+    ref: `${id}.yaml requirements.extension`,
+  }));
+  const node = { requires, catalogued: false };
+  if (udb[id]?.choices?.length) {
+    node.requiresOneOf = udb[id].choices.map((options) => ({
+      options: options.slice().sort(),
+      default: pickDefault(options),
+      src: 'udb',
+      ref: `${id}.yaml requirements.extension.anyOf`,
+    }));
+  }
+  if (requires.length === 0 && !node.requiresOneOf) {
+    node.verified = udbKnown.has(id) ? 'udb' : 'none';
+  }
+  nodes[id] = node;
+  collectTargets(node);
+}
+
+const graph = {
+  $comment:
+    'Dependency graph for RISC-V extensions. Source of truth, maintained by hand. ' +
+    'Every catalog extension must appear here — tests/isa-graph.test.mjs enforces it. ' +
+    'Reconcile against upstream with scripts/seed-dependency-graph.mjs --check.',
+  version: 1,
+  sources: {
+    udb: { repo: 'riscv/riscv-unified-db', commit, path: 'spec/std/isa/ext' },
+    'isa-manual': { repo: 'riscv/riscv-isa-manual', note: 'section cited per edge' },
+  },
+  // Sorted so a regeneration produces a reviewable diff rather than a reshuffle.
+  nodes: Object.fromEntries(
+    Object.keys(nodes).sort((a, b) => a.localeCompare(b)).map((id) => [id, nodes[id]]),
+  ),
+};
+
+if (checkOnly) {
+  if (!fs.existsSync(GRAPH_PATH)) {
+    console.error(`no graph at ${GRAPH_PATH} — run without --check to seed it`);
+    process.exit(1);
+  }
+  const committed = JSON.parse(fs.readFileSync(GRAPH_PATH, 'utf8')).nodes ?? {};
+  const summarize = (node) => {
+    const hard = (node?.requires ?? []).map((r) => r.ext).sort();
+    const choices = (node?.requiresOneOf ?? [])
+      .map((c) => `one-of(${c.options.slice().sort().join('|')})`)
+      .sort();
+    return [...hard, ...choices].join(',');
+  };
+  const drift = [];
+  for (const id of [...new Set([...Object.keys(nodes), ...Object.keys(committed)])].sort()) {
+    const mine = summarize(committed[id]);
+    const theirs = summarize(nodes[id]);
+    if (mine !== theirs) drift.push(`  ${id}: committed [${mine || '-'}] vs upstream [${theirs || '-'}]`);
+  }
+  if (drift.length) {
+    console.error(`upstream drift in ${drift.length} node(s):\n${drift.join('\n')}`);
+    process.exit(1);
+  }
+  console.log(`no drift — ${Object.keys(nodes).length} nodes match UDB ${commit.slice(0, 8)}`);
+} else {
+  fs.writeFileSync(GRAPH_PATH, JSON.stringify(graph, null, 2) + '\n');
+  const withDeps = Object.values(nodes).filter((n) => n.requires.length).length;
+  const unverified = Object.values(nodes).filter((n) => n.verified === 'none').length;
+  console.log(`wrote ${path.relative(repoRoot, GRAPH_PATH)}`);
+  console.log(`  ${Object.keys(nodes).length} nodes, ${withDeps} with dependencies`);
+  console.log(`  ${unverified} with no dependencies and no authoritative source (verified: none)`);
+}

--- a/src/isa-dependency-graph.json
+++ b/src/isa-dependency-graph.json
@@ -1,0 +1,1493 @@
+{
+  "$comment": "Dependency graph for RISC-V extensions. Source of truth, maintained by hand. Every catalog extension must appear here — tests/isa-graph.test.mjs enforces it. Reconcile against upstream with scripts/seed-dependency-graph.mjs --check.",
+  "version": 1,
+  "sources": {
+    "udb": {
+      "repo": "riscv/riscv-unified-db",
+      "commit": "eb7b9357fbc554c31bc15467b8b6d897d66e4c42",
+      "path": "spec/std/isa/ext"
+    },
+    "isa-manual": {
+      "repo": "riscv/riscv-isa-manual",
+      "note": "section cited per edge"
+    }
+  },
+  "nodes": {
+    "A": {
+      "requires": [
+        {
+          "ext": "Zaamo",
+          "src": "udb",
+          "ref": "A.yaml requirements.extension"
+        },
+        {
+          "ext": "Zalrsc",
+          "src": "udb",
+          "ref": "A.yaml requirements.extension"
+        }
+      ]
+    },
+    "B": {
+      "requires": [
+        {
+          "ext": "Zba",
+          "src": "udb",
+          "ref": "B.yaml requirements.extension"
+        },
+        {
+          "ext": "Zbb",
+          "src": "udb",
+          "ref": "B.yaml requirements.extension"
+        },
+        {
+          "ext": "Zbs",
+          "src": "udb",
+          "ref": "B.yaml requirements.extension"
+        }
+      ]
+    },
+    "C": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "D": {
+      "requires": [
+        {
+          "ext": "F",
+          "src": "udb",
+          "ref": "D.yaml requirements.extension"
+        }
+      ]
+    },
+    "F": {
+      "requires": [
+        {
+          "ext": "Zicsr",
+          "src": "udb",
+          "ref": "F.yaml requirements.extension"
+        }
+      ]
+    },
+    "H": {
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "H.yaml requirements.extension"
+        }
+      ]
+    },
+    "HTI": {
+      "requires": [],
+      "verified": "none"
+    },
+    "K": {
+      "requires": [],
+      "verified": "none"
+    },
+    "M": {
+      "requires": [
+        {
+          "ext": "Zmmul",
+          "src": "udb",
+          "ref": "M.yaml requirements.extension"
+        }
+      ]
+    },
+    "N": {
+      "requires": [],
+      "verified": "none"
+    },
+    "P": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Q": {
+      "requires": [
+        {
+          "ext": "D",
+          "src": "udb",
+          "ref": "Q.yaml requirements.extension"
+        }
+      ]
+    },
+    "RERI": {
+      "requires": [],
+      "verified": "none"
+    },
+    "RV128I": {
+      "requires": [],
+      "verified": "none"
+    },
+    "RV32E": {
+      "requires": [],
+      "conflicts": [
+        {
+          "ext": "F",
+          "src": "isa-manual",
+          "ref": "Vol.I §5 — RV32E has 16 GPRs and no F register file"
+        }
+      ],
+      "verified": "none"
+    },
+    "RV32I": {
+      "requires": [],
+      "verified": "none"
+    },
+    "RV64E": {
+      "requires": [],
+      "conflicts": [
+        {
+          "ext": "F",
+          "src": "isa-manual",
+          "ref": "Vol.I §5 — RV64E has 16 GPRs and no F register file"
+        }
+      ],
+      "verified": "none"
+    },
+    "RV64I": {
+      "requires": [],
+      "verified": "none"
+    },
+    "S": {
+      "requires": [
+        {
+          "ext": "Sm",
+          "src": "udb",
+          "ref": "S.yaml requirements.extension"
+        },
+        {
+          "ext": "U",
+          "src": "udb",
+          "ref": "S.yaml requirements.extension"
+        }
+      ]
+    },
+    "Sddbltrp": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Sdext": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Sdtrig": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Sdtrigepm": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Sdtrigpend": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Sm": {
+      "requires": [],
+      "catalogued": false,
+      "verified": "udb"
+    },
+    "Sm1p11": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Sm1p12": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Sm1p13": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Smaia": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Smcdeleg": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Smcfiss": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Smclic": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Smclicconfig": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Smclicshv": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Smcntrpmf": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Smcsrind": {
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "Smcsrind.yaml requirements.extension"
+        }
+      ]
+    },
+    "Smctr": {
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "Smctr.yaml requirements.extension"
+        },
+        {
+          "ext": "Smcsrind",
+          "src": "udb",
+          "ref": "Smctr.yaml requirements.extension"
+        },
+        {
+          "ext": "Ssctr",
+          "src": "udb",
+          "ref": "Smctr.yaml requirements.extension"
+        }
+      ]
+    },
+    "Smdbltrp": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Smdid": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Smepmp": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Smmpm": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Smnpm": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Smpmpmt": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Smrnmi": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Smrnpt": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Smrntt": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Smsdia": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Smstateen": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Smtdeleg": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Smvatag": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Ss1p11": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Ss1p12": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Ss1p13": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Ssaia": {
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "Ssaia.yaml requirements.extension"
+        }
+      ]
+    },
+    "Ssccfg": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Ssccptr": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Ssclic": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Sscntrcfg": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Sscofpmf": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Sscounterenw": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Sscsrind": {
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "Sscsrind.yaml requirements.extension"
+        },
+        {
+          "ext": "Smcsrind",
+          "src": "udb",
+          "ref": "Sscsrind.yaml requirements.extension"
+        }
+      ]
+    },
+    "Ssctr": {
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "Ssctr.yaml requirements.extension"
+        },
+        {
+          "ext": "Sscsrind",
+          "src": "udb",
+          "ref": "Ssctr.yaml requirements.extension"
+        }
+      ]
+    },
+    "Ssdbltrp": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Ssdtso": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Sshpmcfg": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Ssnpm": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Sspm": {
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "Sspm.yaml requirements.extension"
+        },
+        {
+          "ext": "Smnpm",
+          "src": "udb",
+          "ref": "Sspm.yaml requirements.extension"
+        }
+      ]
+    },
+    "Ssptead": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Ssqosid": {
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "Ssqosid.yaml requirements.extension"
+        }
+      ]
+    },
+    "Ssstateen": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Ssstrict": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Sstc": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Sstcfg": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Sstvala": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Sstvecd": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Sstvecv": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Ssu32xl": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Ssu64xl": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Ssube": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Ssvxscr": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Suclic": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Supm": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Sv32": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Sv39": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Sv48": {
+      "requires": [
+        {
+          "ext": "Sv39",
+          "src": "udb",
+          "ref": "Sv48.yaml requirements.extension"
+        }
+      ]
+    },
+    "Sv57": {
+      "requires": [
+        {
+          "ext": "Sv48",
+          "src": "udb",
+          "ref": "Sv57.yaml requirements.extension"
+        }
+      ]
+    },
+    "Svade": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Svadu": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Svatag": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Svbare": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Svinval": {
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "Svinval.yaml requirements.extension"
+        }
+      ]
+    },
+    "Svnapot": {
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "Svnapot.yaml requirements.extension"
+        },
+        {
+          "ext": "Sv39",
+          "src": "udb",
+          "ref": "Svnapot.yaml requirements.extension"
+        }
+      ]
+    },
+    "Svpbmt": {
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "Svpbmt.yaml requirements.extension"
+        }
+      ],
+      "requiresOneOf": [
+        {
+          "options": [
+            "Sv39",
+            "Sv48",
+            "Sv57"
+          ],
+          "default": "Sv39",
+          "src": "udb",
+          "ref": "Svpbmt.yaml requirements.extension.anyOf"
+        }
+      ]
+    },
+    "Svrsw60t59b": {
+      "requires": [
+        {
+          "ext": "Sv39",
+          "src": "udb",
+          "ref": "Svrsw60t59b.yaml requirements.extension"
+        }
+      ]
+    },
+    "Svukte": {
+      "requires": [
+        {
+          "ext": "Sv39",
+          "src": "udb",
+          "ref": "Svukte.yaml requirements.extension"
+        }
+      ]
+    },
+    "Svvptc": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "U": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "V": {
+      "requires": [
+        {
+          "ext": "Zve64d",
+          "src": "udb",
+          "ref": "V.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvl128b",
+          "src": "udb",
+          "ref": "V.yaml requirements.extension"
+        }
+      ]
+    },
+    "Za128rs": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Za64rs": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zaamo": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zabha": {
+      "requires": [
+        {
+          "ext": "Zaamo",
+          "src": "udb",
+          "ref": "Zabha.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zacas": {
+      "requires": [
+        {
+          "ext": "Zaamo",
+          "src": "udb",
+          "ref": "Zacas.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zalasr": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zalrsc": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zama16b": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zawrs": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zba": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zbb": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zbc": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zbkb": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zbkc": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zbkx": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zbs": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zca": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zcb": {
+      "requires": [
+        {
+          "ext": "Zca",
+          "src": "udb",
+          "ref": "Zcb.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zccid": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zcd": {
+      "requires": [
+        {
+          "ext": "D",
+          "src": "udb",
+          "ref": "Zcd.yaml requirements.extension"
+        },
+        {
+          "ext": "Zca",
+          "src": "udb",
+          "ref": "Zcd.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zce": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zcf": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zclsd": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zcmlsd": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zcmop": {
+      "requires": [
+        {
+          "ext": "Zca",
+          "src": "udb",
+          "ref": "Zcmop.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zcmp": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zcmt": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zdinx": {
+      "requires": [
+        {
+          "ext": "Zfinx",
+          "src": "udb",
+          "ref": "Zdinx.yaml requirements.extension"
+        },
+        {
+          "ext": "Zicsr",
+          "src": "isa-manual",
+          "ref": "Vol.I §21 — Zdinx uses the fcsr/frm/fflags CSRs"
+        }
+      ]
+    },
+    "Zfa": {
+      "requires": [
+        {
+          "ext": "F",
+          "src": "udb",
+          "ref": "Zfa.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zfbfmin": {
+      "requires": [
+        {
+          "ext": "F",
+          "src": "udb",
+          "ref": "Zfbfmin.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zfh": {
+      "requires": [
+        {
+          "ext": "Zfhmin",
+          "src": "udb",
+          "ref": "Zfh.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zfhmin": {
+      "requires": [
+        {
+          "ext": "F",
+          "src": "udb",
+          "ref": "Zfhmin.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zfinx": {
+      "requires": [
+        {
+          "ext": "Zicsr",
+          "src": "udb",
+          "ref": "Zfinx.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zhinx": {
+      "requires": [
+        {
+          "ext": "Zhinxmin",
+          "src": "udb",
+          "ref": "Zhinx.yaml requirements.extension"
+        },
+        {
+          "ext": "Zicsr",
+          "src": "isa-manual",
+          "ref": "Vol.I §21 — Zhinx uses the fcsr/frm/fflags CSRs"
+        }
+      ]
+    },
+    "Zhinxmin": {
+      "requires": [
+        {
+          "ext": "Zfinx",
+          "src": "udb",
+          "ref": "Zhinxmin.yaml requirements.extension"
+        },
+        {
+          "ext": "Zicsr",
+          "src": "isa-manual",
+          "ref": "Vol.I §21 — Zhinxmin uses the fcsr/frm/fflags CSRs"
+        }
+      ]
+    },
+    "Zibi": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zic64b": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zicbom": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zicbop": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zicboz": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Ziccamoa": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Ziccamoc": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Ziccif": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zicclsm": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Ziccrse": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zicfilp": {
+      "requires": [
+        {
+          "ext": "Zicsr",
+          "src": "udb",
+          "ref": "Zicfilp.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zicfiss": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zicntr": {
+      "requires": [
+        {
+          "ext": "Zicsr",
+          "src": "udb",
+          "ref": "Zicntr.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zicntrpmf": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zicond": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zicsr": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zifencei": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zihintntl": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zihintpause": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zihpm": {
+      "requires": [
+        {
+          "ext": "Zicsr",
+          "src": "udb",
+          "ref": "Zihpm.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zilsd": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zilsm*": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zilsm<x>b": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zilsme": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zilsmea": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zilsp": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zimop": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zimt": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zitagelide": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zjid": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zjpm": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zk": {
+      "requires": [
+        {
+          "ext": "Zkn",
+          "src": "udb",
+          "ref": "Zk.yaml requirements.extension"
+        },
+        {
+          "ext": "Zkr",
+          "src": "udb",
+          "ref": "Zk.yaml requirements.extension"
+        },
+        {
+          "ext": "Zkt",
+          "src": "udb",
+          "ref": "Zk.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zkn": {
+      "requires": [
+        {
+          "ext": "Zbkb",
+          "src": "udb",
+          "ref": "Zkn.yaml requirements.extension"
+        },
+        {
+          "ext": "Zbkc",
+          "src": "udb",
+          "ref": "Zkn.yaml requirements.extension"
+        },
+        {
+          "ext": "Zbkx",
+          "src": "udb",
+          "ref": "Zkn.yaml requirements.extension"
+        },
+        {
+          "ext": "Zknd",
+          "src": "udb",
+          "ref": "Zkn.yaml requirements.extension"
+        },
+        {
+          "ext": "Zkne",
+          "src": "udb",
+          "ref": "Zkn.yaml requirements.extension"
+        },
+        {
+          "ext": "Zknh",
+          "src": "udb",
+          "ref": "Zkn.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zknd": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zkne": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zknh": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zkr": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zks": {
+      "requires": [
+        {
+          "ext": "Zbkb",
+          "src": "udb",
+          "ref": "Zks.yaml requirements.extension"
+        },
+        {
+          "ext": "Zbkc",
+          "src": "udb",
+          "ref": "Zks.yaml requirements.extension"
+        },
+        {
+          "ext": "Zbkx",
+          "src": "udb",
+          "ref": "Zks.yaml requirements.extension"
+        },
+        {
+          "ext": "Zksed",
+          "src": "udb",
+          "ref": "Zks.yaml requirements.extension"
+        },
+        {
+          "ext": "Zksh",
+          "src": "udb",
+          "ref": "Zks.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zksed": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zksh": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zkt": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zmmul": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Ztso": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zv": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zvabd": {
+      "requires": [
+        {
+          "ext": "Zve32x",
+          "src": "udb",
+          "ref": "Zvabd.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvbb": {
+      "requires": [
+        {
+          "ext": "Zvkb",
+          "src": "udb",
+          "ref": "Zvbb.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvbc": {
+      "requires": [
+        {
+          "ext": "Zve64x",
+          "src": "udb",
+          "ref": "Zvbc.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvbc32e": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zvbdota": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zvdot4a": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zvdota": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zve": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zve32f": {
+      "requires": [
+        {
+          "ext": "F",
+          "src": "udb",
+          "ref": "Zve32f.yaml requirements.extension"
+        },
+        {
+          "ext": "Zve32x",
+          "src": "udb",
+          "ref": "Zve32f.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zve32x": {
+      "requires": [
+        {
+          "ext": "Zicsr",
+          "src": "udb",
+          "ref": "Zve32x.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvl32b",
+          "src": "udb",
+          "ref": "Zve32x.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zve64d": {
+      "requires": [
+        {
+          "ext": "D",
+          "src": "udb",
+          "ref": "Zve64d.yaml requirements.extension"
+        },
+        {
+          "ext": "Zve64f",
+          "src": "udb",
+          "ref": "Zve64d.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zve64f": {
+      "requires": [
+        {
+          "ext": "Zve32f",
+          "src": "udb",
+          "ref": "Zve64f.yaml requirements.extension"
+        },
+        {
+          "ext": "Zve64x",
+          "src": "udb",
+          "ref": "Zve64f.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zve64x": {
+      "requires": [
+        {
+          "ext": "Zve32x",
+          "src": "udb",
+          "ref": "Zve64x.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvl64b",
+          "src": "udb",
+          "ref": "Zve64x.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvf": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zvfbfa": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zvfbfmin": {
+      "requires": [
+        {
+          "ext": "Zve32f",
+          "src": "udb",
+          "ref": "Zvfbfmin.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvfbfwma": {
+      "requires": [
+        {
+          "ext": "Zfbfmin",
+          "src": "udb",
+          "ref": "Zvfbfwma.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvfbfmin",
+          "src": "udb",
+          "ref": "Zvfbfwma.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvfh": {
+      "requires": [
+        {
+          "ext": "Zfhmin",
+          "src": "udb",
+          "ref": "Zvfh.yaml requirements.extension"
+        },
+        {
+          "ext": "Zve32f",
+          "src": "udb",
+          "ref": "Zvfh.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvfhmin",
+          "src": "clang",
+          "ref": "clang -march=rv64i_zvfh implies +zvfhmin; UDB Zvfh.yaml is silent"
+        }
+      ]
+    },
+    "Zvfhmin": {
+      "requires": [
+        {
+          "ext": "Zve32f",
+          "src": "udb",
+          "ref": "Zvfhmin.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvfofp8min": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zvk": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zvkb": {
+      "requires": [
+        {
+          "ext": "Zve32x",
+          "src": "udb",
+          "ref": "Zvkb.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvkg": {
+      "requires": [
+        {
+          "ext": "Zve32x",
+          "src": "udb",
+          "ref": "Zvkg.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvkgs": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zvkn": {
+      "requires": [
+        {
+          "ext": "Zvkb",
+          "src": "udb",
+          "ref": "Zvkn.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvkned",
+          "src": "udb",
+          "ref": "Zvkn.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvknhb",
+          "src": "udb",
+          "ref": "Zvkn.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvkt",
+          "src": "udb",
+          "ref": "Zvkn.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvknc": {
+      "requires": [
+        {
+          "ext": "Zvbc",
+          "src": "udb",
+          "ref": "Zvknc.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvkn",
+          "src": "udb",
+          "ref": "Zvknc.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvkned": {
+      "requires": [
+        {
+          "ext": "Zve32x",
+          "src": "udb",
+          "ref": "Zvkned.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvknf": {
+      "requires": [],
+      "verified": "none"
+    },
+    "Zvkng": {
+      "requires": [
+        {
+          "ext": "Zvkg",
+          "src": "udb",
+          "ref": "Zvkng.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvkn",
+          "src": "udb",
+          "ref": "Zvkng.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvknha": {
+      "requires": [
+        {
+          "ext": "Zve32x",
+          "src": "udb",
+          "ref": "Zvknha.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvknhb": {
+      "requires": [
+        {
+          "ext": "Zve64x",
+          "src": "udb",
+          "ref": "Zvknhb.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvknha",
+          "src": "udb",
+          "ref": "Zvknhb.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvks": {
+      "requires": [
+        {
+          "ext": "Zvkb",
+          "src": "udb",
+          "ref": "Zvks.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvksed",
+          "src": "udb",
+          "ref": "Zvks.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvksh",
+          "src": "udb",
+          "ref": "Zvks.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvkt",
+          "src": "udb",
+          "ref": "Zvks.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvksc": {
+      "requires": [
+        {
+          "ext": "Zvbc",
+          "src": "udb",
+          "ref": "Zvksc.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvks",
+          "src": "udb",
+          "ref": "Zvksc.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvksed": {
+      "requires": [
+        {
+          "ext": "Zve32x",
+          "src": "udb",
+          "ref": "Zvksed.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvksg": {
+      "requires": [
+        {
+          "ext": "Zvkg",
+          "src": "udb",
+          "ref": "Zvksg.yaml requirements.extension"
+        },
+        {
+          "ext": "Zvks",
+          "src": "udb",
+          "ref": "Zvksg.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvksh": {
+      "requires": [
+        {
+          "ext": "Zve32x",
+          "src": "udb",
+          "ref": "Zvksh.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvkt": {
+      "requires": [
+        {
+          "ext": "Zvl32b",
+          "src": "udb",
+          "ref": "Zvkt.yaml requirements.extension"
+        }
+      ]
+    },
+    "Zvl1024b": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zvl128b": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zvl256b": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zvl32b": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zvl512b": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zvl64b": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Zvw": {
+      "requires": [],
+      "verified": "none"
+    }
+  }
+}

--- a/src/isaGraph.js
+++ b/src/isaGraph.js
@@ -1,0 +1,338 @@
+/**
+ * isaGraph.js — the RISC-V extension dependency graph, and validated traversal.
+ *
+ * WHY THIS EXISTS
+ * The dependency data used to be a hand-written table of ~21 extensions inside
+ * marchUtils.js. Reconciling it against riscv-unified-db and clang showed the
+ * table was correct as far as it went but covered under a third of what UDB
+ * models, and drifted silently when it did not. The graph is now a data file
+ * with per-edge provenance (src/isa-dependency-graph.json), every catalog
+ * extension has a node, and CI fails if a new extension arrives without one.
+ *
+ * TWO KINDS OF CHECKING, AND WHY BOTH ARE NEEDED
+ *   validateGraph()    — structural, selection-independent. Dangling edges,
+ *                        cycles, self-edges, uncited edges, bad choice defaults.
+ *                        Runs in CI over the whole graph on every commit.
+ *   resolveSelection() — traversal-time, selection-dependent. A conflict that
+ *                        only exists for a particular base ISA, a choice group
+ *                        with nothing chosen, an extension made redundant by
+ *                        another selection. None of these are properties of the
+ *                        graph; they are properties of a walk through it, so no
+ *                        amount of static validation finds them.
+ *
+ * Traversal REPORTS rather than drops. The previous implementation returned a
+ * bare boolean from dependsOnIncompatible() and silently excluded the
+ * extension, so "Zve64d disappeared from my RV32E config" had no explanation.
+ * resolveSelection() returns the path that caused it.
+ *
+ * Note: unlike marchUtils.js this module does import its data file. The graph
+ * IS the model here, it is small, and splitting the two would reintroduce the
+ * second source of truth this replaces.
+ */
+import graphData from './isa-dependency-graph.json' with { type: 'json' };
+
+export const DEPENDENCY_GRAPH = graphData;
+
+/** Provenance values an edge may claim. An edge citing anything else is a bug. */
+export const EDGE_SOURCES = new Set(['udb', 'isa-manual', 'clang']);
+
+// ---------------------------------------------------------------------------
+// Derived views (same shape as the flat tables they replace)
+// ---------------------------------------------------------------------------
+
+/**
+ * A node the extension catalog actually offers. A few nodes exist only to keep
+ * the graph closed — UDB's S requires Sm, which our catalog does not carry — and
+ * those must not surface in views that feed the UI, since nothing downstream can
+ * resolve them. The graph itself keeps them; only these flat views filter.
+ */
+const isCatalogued = (id) => graphData.nodes[id]?.catalogued !== false;
+
+/** `{ D: ['F'], ... }` — hard requirements, catalogued extensions only. */
+export const SMART_DEPENDENCIES = Object.fromEntries(
+  Object.entries(graphData.nodes)
+    .filter(([id]) => isCatalogued(id))
+    .map(([id, node]) => [id, (node.requires ?? []).map((r) => r.ext).filter(isCatalogued)])
+    .filter(([, deps]) => deps.length > 0),
+);
+
+/** `{ RV32E: ['F'], ... }` — declared conflicts, catalogued extensions only. */
+export const INCOMPATIBLE_WITH = Object.fromEntries(
+  Object.entries(graphData.nodes)
+    .filter(([id]) => isCatalogued(id))
+    .map(([id, node]) => [id, (node.conflicts ?? []).map((c) => c.ext).filter(isCatalogued)])
+    .filter(([, conflicts]) => conflicts.length > 0),
+);
+
+// ---------------------------------------------------------------------------
+// Structural validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks the graph is well formed, independent of any selection.
+ *
+ * @param {object} graph the graph document ({ nodes: {...} })
+ * @param {string[]|null} catalogIds if given, enforces node-per-extension both ways
+ * @returns {{errors: string[], warnings: string[], stats: object}}
+ */
+export function validateGraph(graph = graphData, catalogIds = null) {
+  const errors = [];
+  const warnings = [];
+  const nodes = graph?.nodes ?? {};
+  const ids = Object.keys(nodes);
+  const has = (id) => Object.prototype.hasOwnProperty.call(nodes, id);
+
+  for (const [id, node] of Object.entries(nodes)) {
+    const requires = node.requires ?? [];
+    if (!Array.isArray(requires)) {
+      errors.push(`${id}: requires must be an array`);
+      continue;
+    }
+
+    const seenTargets = new Set();
+    for (const edge of requires) {
+      if (!edge || typeof edge.ext !== 'string') {
+        errors.push(`${id}: edge without an "ext"`);
+        continue;
+      }
+      if (edge.ext === id) errors.push(`${id}: requires itself`);
+      if (!has(edge.ext)) errors.push(`${id} -> ${edge.ext}: no such node (dangling edge)`);
+      if (seenTargets.has(edge.ext)) errors.push(`${id} -> ${edge.ext}: duplicate edge`);
+      seenTargets.add(edge.ext);
+      if (!EDGE_SOURCES.has(edge.src)) {
+        errors.push(`${id} -> ${edge.ext}: src "${edge.src}" is not one of ${[...EDGE_SOURCES].join(', ')}`);
+      }
+      // An uncited edge cannot be audited, and an unauditable graph is one
+      // nobody can safely change later.
+      if (!edge.ref || !String(edge.ref).trim()) {
+        errors.push(`${id} -> ${edge.ext}: missing "ref" citation`);
+      }
+    }
+
+    for (const choice of node.requiresOneOf ?? []) {
+      const options = choice.options ?? [];
+      if (options.length < 2) errors.push(`${id}: requiresOneOf group needs at least two options`);
+      for (const option of options) {
+        if (!has(option)) errors.push(`${id} -> one-of ${option}: no such node`);
+      }
+      if (!options.includes(choice.default)) {
+        errors.push(`${id}: requiresOneOf default "${choice.default}" is not among its options`);
+      }
+      if (!EDGE_SOURCES.has(choice.src)) {
+        errors.push(`${id}: requiresOneOf src "${choice.src}" is not a known source`);
+      }
+      if (!choice.ref || !String(choice.ref).trim()) {
+        errors.push(`${id}: requiresOneOf group missing "ref" citation`);
+      }
+    }
+
+    for (const conflict of node.conflicts ?? []) {
+      if (!has(conflict.ext)) errors.push(`${id} conflicts with ${conflict.ext}: no such node`);
+      if (conflict.ext === id) errors.push(`${id}: conflicts with itself`);
+      if (!conflict.ref || !String(conflict.ref).trim()) {
+        errors.push(`${id} conflicts with ${conflict.ext}: missing "ref" citation`);
+      }
+    }
+
+    if (requires.length === 0 && !node.requiresOneOf && !node.verified) {
+      warnings.push(`${id}: no dependencies and no "verified" marker — checked, or assumed?`);
+    }
+  }
+
+  errors.push(...findCycles(nodes));
+
+  if (catalogIds) {
+    const inGraph = new Set(ids);
+    for (const id of catalogIds) {
+      if (!inGraph.has(id)) {
+        errors.push(`${id} is in the catalog but has no graph node — add one to isa-dependency-graph.json`);
+      }
+    }
+    const inCatalog = new Set(catalogIds);
+    for (const id of ids) {
+      if (!inCatalog.has(id)) warnings.push(`${id} has a graph node but is not in the catalog`);
+    }
+  }
+
+  return {
+    errors,
+    warnings,
+    stats: {
+      nodes: ids.length,
+      withDependencies: ids.filter((id) => (nodes[id].requires ?? []).length > 0).length,
+      edges: ids.reduce((total, id) => total + (nodes[id].requires ?? []).length, 0),
+      unverified: ids.filter((id) => nodes[id].verified === 'none').length,
+    },
+  };
+}
+
+/** Every dependency cycle, reported once per cycle as a readable path. */
+function findCycles(nodes) {
+  const found = [];
+  const state = new Map(); // id -> 'visiting' | 'done'
+  const stack = [];
+
+  const walk = (id) => {
+    if (state.get(id) === 'done') return;
+    if (state.get(id) === 'visiting') {
+      const from = stack.indexOf(id);
+      found.push(`dependency cycle: ${[...stack.slice(from), id].join(' -> ')}`);
+      return;
+    }
+    state.set(id, 'visiting');
+    stack.push(id);
+    for (const edge of nodes[id]?.requires ?? []) {
+      if (nodes[edge.ext]) walk(edge.ext); // dangling edges are reported separately
+    }
+    stack.pop();
+    state.set(id, 'done');
+  };
+
+  for (const id of Object.keys(nodes)) walk(id);
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// Traversal
+// ---------------------------------------------------------------------------
+
+/**
+ * Transitive hard requirements of `id`, excluding `id` itself.
+ * Cycle-safe: a cycle yields a finite set rather than blowing the stack, so a
+ * malformed graph degrades instead of taking the UI down with it.
+ */
+export function closure(id, graph = graphData) {
+  const out = new Set();
+  const walk = (current) => {
+    for (const edge of graph.nodes?.[current]?.requires ?? []) {
+      if (out.has(edge.ext)) continue;
+      out.add(edge.ext);
+      walk(edge.ext);
+    }
+  };
+  walk(id);
+  out.delete(id);
+  return out;
+}
+
+/**
+ * Walks the graph for a selection, validating as it goes.
+ *
+ * @param {object}   options
+ * @param {string[]} options.selected  extension ids the user picked
+ * @param {string}   [options.base]    base ISA id, e.g. 'RV32E'
+ * @param {object}   [options.graph]
+ * @param {boolean}  [options.applyChoiceDefaults=true] auto-satisfy one-of groups
+ * @returns {{
+ *   resolved: string[],
+ *   implied: Array<{ext: string, path: string[]}>,
+ *   redundant: Array<{ext: string, impliedBy: string[]}>,
+ *   conflicts: Array<{ext: string, with: string, path: string[], ref: string}>,
+ *   choices: Array<{node: string, options: string[], satisfiedBy: string|null, applied: string|null}>,
+ *   unknown: Array<{ext: string, from: string|null}>
+ * }}
+ */
+export function resolveSelection({
+  selected = [],
+  base = null,
+  graph = graphData,
+  applyChoiceDefaults = true,
+} = {}) {
+  const nodes = graph?.nodes ?? {};
+  const resolved = new Set();
+  const implied = [];
+  const unknown = [];
+  const pathTo = new Map(); // ext -> shortest known path from a selected root
+
+  const seed = [...new Set(selected.filter(Boolean))];
+  for (const id of seed) if (!nodes[id]) unknown.push({ ext: id, from: null });
+  if (base && !nodes[base]) unknown.push({ ext: base, from: null });
+
+  // Breadth-first, so `path` is the shortest explanation rather than an
+  // arbitrary one — the path is shown to users, so it should be the clearest.
+  const queue = [];
+  for (const id of seed) {
+    if (!nodes[id]) continue;
+    resolved.add(id);
+    pathTo.set(id, [id]);
+    queue.push({ id, path: [id] });
+  }
+
+  while (queue.length) {
+    const { id, path } = queue.shift();
+    for (const edge of nodes[id]?.requires ?? []) {
+      if (!nodes[edge.ext]) {
+        if (!unknown.some((u) => u.ext === edge.ext && u.from === id)) {
+          unknown.push({ ext: edge.ext, from: id });
+        }
+        continue;
+      }
+      if (resolved.has(edge.ext)) continue; // already explained by a shorter path
+      const next = [...path, edge.ext];
+      resolved.add(edge.ext);
+      pathTo.set(edge.ext, next);
+      implied.push({ ext: edge.ext, path: next });
+      queue.push({ id: edge.ext, path: next });
+    }
+  }
+
+  // One-of groups. Selection-dependent by nature: whether a group is satisfied
+  // depends on what else the user picked, so it cannot be settled statically.
+  const choices = [];
+  for (const id of [...resolved]) {
+    for (const choice of nodes[id]?.requiresOneOf ?? []) {
+      // Prefer what the user actually picked. Options are often nested (Sv48
+      // requires Sv39), so resolving Sv48 also resolves Sv39 — reporting the
+      // latter as the satisfier would credit a choice the user never made.
+      const satisfiedBy =
+        choice.options.find((option) => seed.includes(option)) ??
+        choice.options.find((option) => resolved.has(option)) ??
+        null;
+      let applied = null;
+      if (!satisfiedBy && applyChoiceDefaults && nodes[choice.default]) {
+        applied = choice.default;
+        const basePath = pathTo.get(id) ?? [id];
+        for (const ext of [applied, ...closure(applied, graph)]) {
+          if (resolved.has(ext)) continue;
+          const next = ext === applied ? [...basePath, ext] : [...basePath, applied, ext];
+          resolved.add(ext);
+          pathTo.set(ext, next);
+          implied.push({ ext, path: next });
+        }
+      }
+      choices.push({ node: id, options: [...choice.options], satisfiedBy, applied });
+    }
+  }
+
+  // Conflicts, reported with the path that pulled the offending extension in —
+  // "D conflicts with RV32E" is useless when the user never picked D.
+  const conflicts = [];
+  const candidates = base ? [base, ...resolved] : [...resolved];
+  for (const holder of new Set(candidates)) {
+    for (const conflict of nodes[holder]?.conflicts ?? []) {
+      if (holder === conflict.ext) continue;
+      if (!resolved.has(conflict.ext) && conflict.ext !== base) continue;
+      conflicts.push({
+        ext: conflict.ext,
+        with: holder,
+        path: pathTo.get(conflict.ext) ?? [conflict.ext],
+        ref: conflict.ref ?? '',
+      });
+    }
+  }
+
+  // Redundancy: a selected extension another selection already implies.
+  const redundant = [];
+  for (const id of seed) {
+    const impliedBy = seed.filter((other) => other !== id && closure(other, graph).has(id));
+    if (impliedBy.length) redundant.push({ ext: id, impliedBy });
+  }
+
+  return { resolved: [...resolved], implied, redundant, conflicts, choices, unknown };
+}
+
+/** One-line explanation of why `ext` is in a resolution, for UI and errors. */
+export function explain(ext, result) {
+  const hit = result.implied.find((entry) => entry.ext === ext);
+  return hit ? hit.path.join(' -> ') : `${ext} was selected directly`;
+}

--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -1,8 +1,12 @@
 /**
  * marchUtils.js — RISC-V -march String Utilities
  *
- * Pure functions. No React. No JSON imports.
- * Callers pass the flat extension array from riscv_extensions.json.
+ * Pure functions. No React. Callers pass the flat extension array from
+ * riscv_extensions.json — the catalog is never imported here.
+ *
+ * Exception: dependency data now comes from ./isaGraph.js, which owns
+ * isa-dependency-graph.json. That table used to live in this file and drifted;
+ * see isaGraph.js for why it moved and how it is validated.
  *
  * DATA SOURCES (documented for every design decision):
  *   [SPEC]   RISC-V Unprivileged ISA Specification, Chapter 27
@@ -98,78 +102,22 @@ export const BASE_ISA_PREFIX_MAP = {
 };
 
 // ============================================================================
-// Smart Dependencies
+// Dependencies and conflicts
 // ============================================================================
 /**
- * This table is intentionally hardcoded until the automate syncing of dependecies gets merged.
- * Do not replace with live fetching until that piece merges. When it does, this table should be deleted 
- * and replaced by reading the dependencies array UDB sync writes into each extension object in riscv_extensions.json.
- * 
- * Core, undeniable architectural dependencies. 
- * We do not map the entire evolving RISC-V graph, but we auto-resolve 
- * obvious ones (e.g. D fundamentally requires F) to assist the user.
+ * These used to be hand-written tables here, covering ~21 extensions. They are
+ * now derived from src/isa-dependency-graph.json, which carries a node for every
+ * catalog extension and a citation on every edge.
+ *
+ * Re-exported in the flat `{id: [ext]}` shape the existing callers expect. New
+ * code should prefer resolveSelection() from ./isaGraph.js, which reports what
+ * it implied and why instead of returning a bare set.
  */
-export const SMART_DEPENDENCIES = {
-  // --- Floating-point family ---
-  // D → F  : UDB D.yaml requirements.extension: {name: F} — directly fetched
-  // Q → D,F: ISA Manual Vol.I §14.1 "Q depends on D (which depends on F)"
-  // Zfh, Zfhmin → F: ISA Manual Vol.I §12.2 "Zfh requires F"
-  // Zfbfmin → F: UDB Zfbfmin.yaml — BF16 converts operate on F registers
-  // Zdinx → Zfinx: ISA Manual "Zdinx uses integer regs for double; requires Zfinx"
-  // Zhinx, Zhinxmin → Zfinx: ISA Manual §12, parallel to Zdinx reasoning
-  // F → Zicsr: F defines the fcsr/frm/fflags CSRs, so it cannot be used without
-  // Zicsr. GCC's riscv_ext_info encodes the same implication.
-  'F': ['Zicsr'], // ISA Manual Vol.I §12
-  'D': ['F'], // UDB-confirmed
-  'Q': ['D', 'F'], // ISA Manual Vol.I §14.1
-  'Zfh': ['F', 'Zfhmin'], // ISA Manual Vol.I §12.2 — Zfh is a superset of Zfhmin
-  'Zfhmin': ['F'], // ISA Manual Vol.I §12.2
-  'Zfbfmin': ['F'], // UDB-confirmed
-  'Zdinx': ['Zfinx', 'Zicsr'], // ISA Manual Vol.I §12
-  'Zhinx': ['Zfinx', 'Zhinxmin', 'Zicsr'], // ISA Manual Vol.I §12 — superset of Zhinxmin
-  'Zhinxmin': ['Zfinx', 'Zicsr'], // ISA Manual Vol.I §12
+// Imported, not `export ... from`: a re-export creates no local binding, and
+// isIncompatible()/dependsOnIncompatible() below reference these directly.
+import { SMART_DEPENDENCIES, INCOMPATIBLE_WITH } from './isaGraph.js';
 
-  // --- Vector family ---
-  // Source: ISA Manual Vol.I §33.18.2 "Zve* profiles" + kernel dt-bindings
-  // Zve32x → Zicsr: all vector extensions require CSR state (vtype, vl, vstart)
-  // Zve32f → Zve32x + F: adds FP vector ops to the integer-only Zve32x base
-  // Zve64x → Zve32x: extends 32-bit integer vector to 64-bit elements
-  // Zve64f → Zve32f + Zve64x + F: 64-bit elements with FP; subsumes Zve32f
-  // Zve64d → Zve64f + D: adds double-precision FP vector; UDB Zve64d.yaml confirmed
-  // V → Zve64d + Zvl128b: ISA Manual §33.18.2 "V = Zve64d + min 128-bit VLEN"
-  'Zve32x': ['Zicsr'], // ISA Manual Vol.I §33.18.2
-  'Zve32f': ['Zve32x', 'F'], // ISA Manual Vol.I §33.18.2
-  'Zve64x': ['Zve32x'], // ISA Manual Vol.I §33.18.2
-  'Zve64f': ['Zve32f', 'Zve64x', 'F'], // ISA Manual Vol.I §33.18.2
-  'Zve64d': ['Zve64f', 'D'], // UDB-confirmed
-  'V': ['Zve64d', 'Zvl128b'], // ISA Manual Vol.I §33.18.2
-
-  // --- Scalar crypto bundles ---
-  // Zkn: UDB Zkn.yaml — "shorthand for Zbkb, Zbkc, Zbkx, Zkne, Zknd, Zknh"
-  // Zks: UDB Zks.yaml — "shorthand for Zbkb, Zbkc, Zbkx, Zksed, Zksh"
-  // Zk:  UDB Zk.yaml  — "shorthand for Zkn, Zkr, Zkt" — directly fetched
-  'Zkn': ['Zknd', 'Zkne', 'Zknh', 'Zbkb', 'Zbkc', 'Zbkx'], // UDB-confirmed
-  'Zks': ['Zksed', 'Zksh', 'Zbkb', 'Zbkc', 'Zbkx'], // UDB-confirmed
-  'Zk': ['Zkn', 'Zkr', 'Zkt'], // UDB-confirmed
-
-  // --- Performance counters ---
-  // Source: ISA Manual Vol.II §3.1 — counter extensions require Zicsr
-  'Zicntr': ['Zicsr'], // ISA Manual Vol.II §3.1
-  'Zihpm': ['Zicsr'], // ISA Manual Vol.II §3.1
-
-  // --- Bit-manipulation ---
-  // B: Meta-extension typically resolved to Zba, Zbb, and Zbs.
-  'B': ['Zba', 'Zbb', 'Zbs'], // ISA Manual
-};
-
-/**
- * Architecturally invalid combinations.
- * Evaluated bidirectionally: e.g. RV32E excludes F, and F excludes RV32E.
- */
-export const INCOMPATIBLE_WITH = {
-  'RV32E': ['F'], // E-base (16 integer regs) cannot support F (requires 32 float regs)
-  'RV64E': ['F']
-};
+export { SMART_DEPENDENCIES, INCOMPATIBLE_WITH };
 
 // ============================================================================
 // Architectural tags that are not -march ISA options

--- a/tests/dependency-closure.test.mjs
+++ b/tests/dependency-closure.test.mjs
@@ -22,21 +22,16 @@ import { SMART_DEPENDENCIES } from '../src/marchUtils.js';
 
 /**
  * Divergences we have looked at and accepted, with the reason.
- * Removing a gap from the table should also remove its entry here.
+ * Removing a gap from the graph should also remove its entry here — the test
+ * below fails on stale entries as well as on new ones.
+ *
+ * Empty as of the move to isa-dependency-graph.json. The six Zve*-and-V entries
+ * that lived here were the Zvl*b minimum-VLEN tokens, unresolved because we had
+ * only clang's word for them. riscv-unified-db records Zve32x -> Zvl32b and
+ * Zve64x -> Zvl64b directly, which agrees with clang and closes all six
+ * transitively, so they are now real edges rather than documented debt.
  */
-const KNOWN_DIVERGENCES = {
-  Zve32x:  ['zvl32b'],
-  Zve32f:  ['zvl32b'],
-  Zve64x:  ['zvl32b', 'zvl64b'],
-  Zve64f:  ['zvl32b', 'zvl64b'],
-  Zve64d:  ['zvl32b', 'zvl64b'],
-  V:       ['zvl32b', 'zvl64b'],
-};
-// Reason, shared by all of the above: clang implies a minimum-VLEN token (Zvl*b)
-// for every Zve* profile. Whether that is a normative architectural requirement
-// or clang's way of modelling VLEN is not settled here; it should be confirmed
-// against riscv-unified-db when the UDB sync lands (see #137). Until then the
-// tool does not emit Zvl*b, and that choice is recorded rather than hidden.
+const KNOWN_DIVERGENCES = {};
 
 function clangHasRiscv() {
   try {

--- a/tests/isa-graph.test.mjs
+++ b/tests/isa-graph.test.mjs
@@ -1,0 +1,241 @@
+/**
+ * The graph is checked on every commit, in two ways.
+ *
+ * Structural: the shipped graph must be well formed and must cover every
+ * extension in the catalog. That second half is the point — adding an extension
+ * without adding its node fails the build, so the graph cannot quietly rot into
+ * the stale table it replaced.
+ *
+ * Traversal: the walk must report what it did. Silent behaviour is the bug we
+ * are fixing, so each traversal test asserts on the diagnostics, not just the
+ * resulting set.
+ *
+ * Every validation rule also has a negative test built on a deliberately broken
+ * fixture. A checker nobody has watched fail is a checker nobody knows works.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  DEPENDENCY_GRAPH,
+  SMART_DEPENDENCIES,
+  INCOMPATIBLE_WITH,
+  validateGraph,
+  resolveSelection,
+  closure,
+  explain,
+} from '../src/isaGraph.js';
+
+const catalogIds = (() => {
+  const file = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'src', 'riscv_extensions.json');
+  const catalog = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const ids = [];
+  for (const group of Object.values(catalog)) {
+    if (Array.isArray(group)) group.forEach((entry) => entry?.id && ids.push(entry.id));
+  }
+  return ids;
+})();
+
+/** Minimal well-formed graph for negative tests to corrupt. */
+function fixture(nodes) {
+  return { version: 1, nodes };
+}
+const cite = (ext, ref = 'test fixture') => ({ ext, src: 'udb', ref });
+
+// ---------------------------------------------------------------------------
+// The shipped graph
+// ---------------------------------------------------------------------------
+
+test('shipped graph is structurally valid', () => {
+  const { errors, stats } = validateGraph(DEPENDENCY_GRAPH);
+  assert.deepEqual(errors, [], `graph has structural errors:\n  ${errors.join('\n  ')}`);
+  assert.ok(stats.nodes > 200, `expected the full catalog, got ${stats.nodes} nodes`);
+  assert.ok(stats.edges > 0, 'graph has no edges at all');
+});
+
+test('every catalog extension has a graph node', () => {
+  // The gate. A new extension without a node fails here, by design.
+  const { errors } = validateGraph(DEPENDENCY_GRAPH, catalogIds);
+  const missing = errors.filter((e) => e.includes('no graph node'));
+  assert.deepEqual(missing, [], `extensions missing from the graph:\n  ${missing.join('\n  ')}`);
+});
+
+test('every edge cites a source', () => {
+  for (const [id, node] of Object.entries(DEPENDENCY_GRAPH.nodes)) {
+    for (const edge of node.requires ?? []) {
+      assert.ok(edge.ref?.trim(), `${id} -> ${edge.ext} has no citation`);
+      assert.ok(['udb', 'isa-manual', 'clang'].includes(edge.src), `${id} -> ${edge.ext} has src "${edge.src}"`);
+    }
+  }
+});
+
+test('known dependencies survived the move off the hand-written table', () => {
+  // Spot-checks of edges the old table asserted, so a bad regeneration is loud.
+  assert.deepEqual(SMART_DEPENDENCIES.D, ['F']);
+  assert.ok(SMART_DEPENDENCIES.F.includes('Zicsr'), 'F -> Zicsr lost');
+  assert.ok(SMART_DEPENDENCIES.Zfh.includes('Zfhmin'), 'Zfh -> Zfhmin lost');
+  assert.ok(closure('Q').has('F'), 'Q should reach F transitively');
+  assert.ok(INCOMPATIBLE_WITH.RV32E.includes('F'), 'RV32E/F conflict lost');
+});
+
+test('the Zvl divergence against clang is closed in the graph', () => {
+  // clang and UDB both imply a minimum-VLEN token for the Zve* profiles; the
+  // old table did not, and carried the gap in a KNOWN_DIVERGENCES ratchet.
+  assert.ok(closure('Zve32x').has('Zvl32b'), 'Zve32x should require Zvl32b');
+  assert.ok(closure('Zve64x').has('Zvl64b'), 'Zve64x should require Zvl64b');
+  assert.ok(closure('V').has('Zvl32b'), 'V should reach Zvl32b transitively');
+});
+
+// ---------------------------------------------------------------------------
+// Structural validation — negative tests
+// ---------------------------------------------------------------------------
+
+test('validation catches a dangling edge', () => {
+  const { errors } = validateGraph(fixture({ A: { requires: [cite('Nope')] } }));
+  assert.ok(errors.some((e) => e.includes('dangling edge')), `expected a dangling-edge error, got: ${errors}`);
+});
+
+test('validation catches a self-edge', () => {
+  const { errors } = validateGraph(fixture({ A: { requires: [cite('A')] } }));
+  assert.ok(errors.some((e) => e.includes('requires itself')), `got: ${errors}`);
+});
+
+test('validation catches a cycle', () => {
+  const { errors } = validateGraph(fixture({
+    A: { requires: [cite('B')] },
+    B: { requires: [cite('C')] },
+    C: { requires: [cite('A')] },
+  }));
+  const cycles = errors.filter((e) => e.startsWith('dependency cycle'));
+  assert.equal(cycles.length, 1, `expected exactly one cycle, got: ${errors}`);
+  assert.match(cycles[0], /A -> B -> C -> A/);
+});
+
+test('validation catches an uncited edge', () => {
+  const { errors } = validateGraph(fixture({
+    A: { requires: [{ ext: 'B', src: 'udb' }] },
+    B: { requires: [], verified: 'udb' },
+  }));
+  assert.ok(errors.some((e) => e.includes('missing "ref"')), `got: ${errors}`);
+});
+
+test('validation catches an unknown provenance value', () => {
+  const { errors } = validateGraph(fixture({
+    A: { requires: [{ ext: 'B', src: 'vibes', ref: 'trust me' }] },
+    B: { requires: [], verified: 'udb' },
+  }));
+  assert.ok(errors.some((e) => e.includes('is not one of')), `got: ${errors}`);
+});
+
+test('validation catches a one-of default outside its own options', () => {
+  const { errors } = validateGraph(fixture({
+    A: { requires: [], requiresOneOf: [{ options: ['B', 'C'], default: 'D', src: 'udb', ref: 'x' }] },
+    B: { requires: [], verified: 'udb' },
+    C: { requires: [], verified: 'udb' },
+    D: { requires: [], verified: 'udb' },
+  }));
+  assert.ok(errors.some((e) => e.includes('is not among its options')), `got: ${errors}`);
+});
+
+test('validation catches a duplicate edge', () => {
+  const { errors } = validateGraph(fixture({
+    A: { requires: [cite('B'), cite('B')] },
+    B: { requires: [], verified: 'udb' },
+  }));
+  assert.ok(errors.some((e) => e.includes('duplicate edge')), `got: ${errors}`);
+});
+
+test('a node with no dependencies and no verified marker warns but does not fail', () => {
+  const { errors, warnings } = validateGraph(fixture({ A: { requires: [] } }));
+  assert.deepEqual(errors, []);
+  assert.ok(warnings.some((w) => w.includes('checked, or assumed')), `got: ${warnings}`);
+});
+
+// ---------------------------------------------------------------------------
+// Traversal
+// ---------------------------------------------------------------------------
+
+test('traversal reports what it implied, and why', () => {
+  const result = resolveSelection({ selected: ['D'] });
+  assert.ok(result.resolved.includes('F'), 'D should pull in F');
+  assert.ok(result.resolved.includes('Zicsr'), 'and Zicsr transitively through F');
+  assert.deepEqual(explain('F', result).split(' -> '), ['D', 'F']);
+  assert.deepEqual(explain('Zicsr', result).split(' -> '), ['D', 'F', 'Zicsr']);
+  assert.equal(explain('D', result), 'D was selected directly');
+});
+
+test('traversal explains a conflict with the path that caused it', () => {
+  // The case that used to vanish silently: nothing the user picked is F, but
+  // Zve64d reaches it through D, and RV32E has no F registers.
+  const result = resolveSelection({ selected: ['Zve64d'], base: 'RV32E' });
+  const conflict = result.conflicts.find((c) => c.ext === 'F');
+  assert.ok(conflict, `expected an F conflict, got ${JSON.stringify(result.conflicts)}`);
+  assert.equal(conflict.with, 'RV32E');
+  assert.deepEqual(conflict.path, ['Zve64d', 'D', 'F']);
+  assert.ok(conflict.ref.includes('GPR'), 'the conflict should carry its citation');
+});
+
+test('no conflict is reported when the base has no quarrel with the selection', () => {
+  const result = resolveSelection({ selected: ['Zve64d'], base: 'RV64I' });
+  assert.deepEqual(result.conflicts, []);
+});
+
+test('traversal flags a selection another selection already implies', () => {
+  const result = resolveSelection({ selected: ['D', 'F'] });
+  const redundant = result.redundant.find((r) => r.ext === 'F');
+  assert.ok(redundant, `expected F to be redundant, got ${JSON.stringify(result.redundant)}`);
+  assert.deepEqual(redundant.impliedBy, ['D']);
+  // D itself is not redundant — nothing else selected implies it.
+  assert.ok(!result.redundant.some((r) => r.ext === 'D'));
+});
+
+test('an unsatisfied one-of group applies its documented default', () => {
+  const result = resolveSelection({ selected: ['Svpbmt'] });
+  const choice = result.choices.find((c) => c.node === 'Svpbmt');
+  assert.ok(choice, 'Svpbmt should present a choice group');
+  assert.equal(choice.satisfiedBy, null, 'nothing in the selection satisfies it');
+  assert.equal(choice.applied, 'Sv39', 'the weakest option is the honest default');
+  assert.ok(result.resolved.includes('Sv39'));
+});
+
+test('a one-of group already satisfied does not add the default', () => {
+  const result = resolveSelection({ selected: ['Svpbmt', 'Sv48'] });
+  const choice = result.choices.find((c) => c.node === 'Svpbmt');
+  assert.equal(choice.satisfiedBy, 'Sv48');
+  assert.equal(choice.applied, null, 'must not pull in Sv39 when Sv48 already satisfies the group');
+});
+
+test('one-of defaults can be turned off for callers that want to prompt', () => {
+  const result = resolveSelection({ selected: ['Svpbmt'], applyChoiceDefaults: false });
+  const choice = result.choices.find((c) => c.node === 'Svpbmt');
+  assert.equal(choice.applied, null);
+  assert.ok(!result.resolved.includes('Sv39'), 'nothing should be auto-added');
+});
+
+test('an unknown extension is reported, not thrown', () => {
+  const result = resolveSelection({ selected: ['Znotreal', 'D'] });
+  assert.ok(result.unknown.some((u) => u.ext === 'Znotreal'));
+  assert.ok(result.resolved.includes('F'), 'the rest of the selection still resolves');
+});
+
+test('traversal survives a cyclic graph instead of hanging', () => {
+  const cyclic = fixture({
+    A: { requires: [cite('B')] },
+    B: { requires: [cite('A')] },
+  });
+  const result = resolveSelection({ selected: ['A'], graph: cyclic });
+  assert.deepEqual(result.resolved.sort(), ['A', 'B']);
+  assert.deepEqual([...closure('A', cyclic)].sort(), ['B']);
+});
+
+test('the implied path is the shortest one', () => {
+  // C is reachable as A->C and as A->B->C; the explanation should be the former.
+  const graph = fixture({
+    A: { requires: [cite('B'), cite('C')] },
+    B: { requires: [cite('C')] },
+    C: { requires: [], verified: 'udb' },
+  });
+  const result = resolveSelection({ selected: ['A'], graph });
+  assert.deepEqual(explain('C', result).split(' -> '), ['A', 'C']);
+});


### PR DESCRIPTION
Replaces the hand-written dependency table with a graph that is validated on every commit.

## Why

The table in `marchUtils.js` covered 21 extensions and was marked *"intentionally hardcoded until the automated syncing of dependencies gets merged."* Reconciling it against `riscv-unified-db` and clang showed it was **correct as far as it went** but covered under a third of what UDB models, with nothing to notice when it drifted.

## What changed

`src/isa-dependency-graph.json` — a node for **every** catalog extension (221), a citation on **every** edge, seeded from UDB and reconcilable against it with `npm run graph:check -- <udb-path>`. `marchUtils` re-exports the flat shape, so existing callers are untouched.

## Two kinds of validation, because they catch different things

| | catches |
|---|---|
| `validateGraph()` — structural, selection-independent | dangling edges, cycles, self-edges, uncited edges, bad choice defaults, and **the completeness gate: a catalog extension with no node fails the build** |
| `resolveSelection()` — traversal-time, selection-dependent | a conflict that only exists for one base ISA, a choice group nothing satisfies, an extension another selection already implies |

The second set are properties of a *walk*, not of the graph, so no amount of static checking finds them.

**Traversal reports instead of dropping.** `dependsOnIncompatible()` returned a bare boolean and the extension silently vanished. Now:

```
Zve64d on RV32E  ->  conflict: F, with RV32E, path Zve64d -> D -> F
                     ref: Vol.I §5 — RV32E has 16 GPRs and no F register file
```

## Three findings from building it

1. **The six `Zvl*b` divergences are real.** UDB records `Zve32x -> Zvl32b` and `Zve64x -> Zvl64b` directly, agreeing with clang, closing all six transitively. `KNOWN_DIVERGENCES` is now empty.
2. **UDB gap on `Zvfh`.** It requires `Zve32f` and `Zfhmin` but not `Zvfhmin` — though it records the same superset relation for the scalar pair (`Zfh -> Zfhmin`). clang implies it. Added with `src: clang` so the weaker backing stays visible. **Worth raising upstream.**
3. **`Svpbmt` needs a choice edge.** It requires `S` *and one of* Sv39/Sv48/Sv57. Flattening that `anyOf` into a conjunction would force all three paging modes, so the graph models choice groups and satisfies them with the weakest option.

## Testing

42 tests pass (23 new). Every validation rule has a negative test on a deliberately broken fixture, and **each was watched failing before being trusted** — deleting a node, injecting a cycle, and stripping a citation each fail the intended test and only that test. Build is clean and all 32 generated `-march` strings still pass clang.

## Follow-up

When #137 lands, the UDB sync should open an issue whenever upstream introduces an extension the graph does not cover — the CI gate fails the build, the issue says what to add.