### PR TITLE
Add the Sh* augmented-hypervisor extensions

### DIFF
--- a/src/isa-dependency-graph.json
+++ b/src/isa-dependency-graph.json
@@ -183,6 +183,74 @@
       "requires": [],
       "verified": "none"
     },
+    "Sha": {
+      "requires": [
+        {
+          "ext": "H",
+          "src": "udb",
+          "ref": "Sha.yaml requirements.extension"
+        },
+        {
+          "ext": "Shcounterenw",
+          "src": "udb",
+          "ref": "Sha.yaml requirements.extension"
+        },
+        {
+          "ext": "Shgatpa",
+          "src": "udb",
+          "ref": "Sha.yaml requirements.extension"
+        },
+        {
+          "ext": "Shtvala",
+          "src": "udb",
+          "ref": "Sha.yaml requirements.extension"
+        },
+        {
+          "ext": "Shvsatpa",
+          "src": "udb",
+          "ref": "Sha.yaml requirements.extension"
+        },
+        {
+          "ext": "Shvstvala",
+          "src": "udb",
+          "ref": "Sha.yaml requirements.extension"
+        },
+        {
+          "ext": "Shvstvecd",
+          "src": "udb",
+          "ref": "Sha.yaml requirements.extension"
+        },
+        {
+          "ext": "Ssstateen",
+          "src": "udb",
+          "ref": "Sha.yaml requirements.extension"
+        }
+      ]
+    },
+    "Shcounterenw": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Shgatpa": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Shtvala": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Shvsatpa": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Shvstvala": {
+      "requires": [],
+      "verified": "udb"
+    },
+    "Shvstvecd": {
+      "requires": [],
+      "verified": "udb"
+    },
     "Sm": {
       "requires": [],
       "catalogued": false,

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -27171,6 +27171,69 @@
       "use": "Trace / instrumentation spec tag",
       "url": "https://github.com/riscv/riscv-isa-manual",
       "instructions": {}
+    },
+    {
+      "id": "Sha",
+      "name": "Sha",
+      "tags": [],
+      "desc": "Augmented hypervisor",
+      "use": "Bundle of hypervisor augmentation requirements (profiles)",
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {}
+    },
+    {
+      "id": "Shcounterenw",
+      "name": "Shcounterenw",
+      "tags": [],
+      "desc": "Hypervisor counter enable",
+      "use": "Writable hcounteren for all supported counters",
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {}
+    },
+    {
+      "id": "Shgatpa",
+      "name": "Shgatpa",
+      "tags": [],
+      "desc": "SvNNx4 guest translation for all supported S-mode modes, plus Bare",
+      "use": "Guest-physical address translation requirement",
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {}
+    },
+    {
+      "id": "Shtvala",
+      "name": "Shtvala",
+      "tags": [],
+      "desc": "Hypervisor Trap Value (htval) provides all needed values",
+      "use": "htval reporting requirement",
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {}
+    },
+    {
+      "id": "Shvsatpa",
+      "name": "Shvsatpa",
+      "tags": [],
+      "desc": "Virtual Supervisor address translation supports all supported S-mode modes",
+      "use": "VS-stage address translation requirement",
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {}
+    },
+    {
+      "id": "Shvstvala",
+      "name": "Shvstvala",
+      "tags": [],
+      "desc": "Virtual Supervisor Trap Value (vstval) provides all needed values",
+      "use": "vstval reporting requirement",
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {}
+    },
+    {
+      "id": "Shvstvecd",
+      "name": "Shvstvecd",
+      "tags": [],
+      "desc": "Virtual Supervisor Trap Vector (vstvec) supports Direct mode",
+      "use": "vstvec Direct mode requirement",
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {}
     }
   ]
 }


### PR DESCRIPTION
Adds the `Sh*` "augmented hypervisor" family, which exists in [riscv-unified-db](https://github.com/riscv/riscv-unified-db) but had no representation in the catalog. These are privileged extensions mandated by the application-processor profiles (RVA23 and friends), so their absence showed up as a profile-completeness gap.

**Replaces #136**, which predated the dependency graph (#145) and had gone stale against `main`.

## What's added

All seven land in `s_trap`, alongside their supervisor analogues (`Sstvala`, `Sstvecd`, `Ssstateen`). Descriptions follow UDB's `long_name`, verified file by file.

| Extension | Description |
|---|---|
| `Sha` | Augmented hypervisor (bundle) |
| `Shcounterenw` | Hypervisor counter enable |
| `Shgatpa` | SvNNx4 guest translation for all supported S-mode modes, plus Bare |
| `Shtvala` | Hypervisor Trap Value (`htval`) provides all needed values |
| `Shvsatpa` | Virtual Supervisor address translation supports all supported S-mode modes |
| `Shvstvala` | Virtual Supervisor Trap Value (`vstval`) provides all needed values |
| `Shvstvecd` | Virtual Supervisor Trap Vector (`vstvec`) supports Direct mode |

## `Sha` is a bundle, not a leaf

This is the part #136 missed. UDB gives `Sha` **eight** requirements — `H`, `Ssstateen`, and the other six `Sh*`. Without a graph node it would expand to nothing, so a user selecting the bundle would get the bundle and none of what it mandates. Seeded from UDB, it now resolves properly:

```
Sha on RV64I -> 12 extensions
  H, S, Sha, Shcounterenw, Shgatpa, Shtvala, Shvsatpa,
  Shvstvala, Shvstvecd, Sm, Ssstateen, U

  why Ssstateen:  Sha -> Ssstateen
  why S:          Sha -> H -> S
```

Every edge carries `src: udb` with a citation.

## Two corrections carried over from reviewing #136

- **`tags` are `[]`, not invented `rv_sh*` values.** Tags map catalog entries onto `riscv-opcodes` instruction groups. `rv_sha` and friends match **zero** entries in `instr_dict.json`, and 41 of 43 `s_trap` siblings use `[]`. A fabricated tag that looks real is worse than an empty one.
- **Entries carry `"instructions": {}`** to match every sibling in the category.

## On `Sm`

#136 deferred `Sm` as "a naming/granularity difference." That's now settled from the other direction: UDB's `S` requires `Sm`, so #145 already carries it as a **graph-only node** (`catalogued: false`) to keep the graph closed. Nothing to do here.

## Testing

The completeness gate from #145 caught this correctly — before reseeding, all seven failed with `Sha is in the catalog but has no graph node`. After `npm run graph:check`'s seed step: **42/42 tests pass**, build clean, 228 graph nodes / 69 with dependencies. Diff is +131/−0 with no reformatting of the catalog.