### PR TITLE
Read every UDB requirement shape, and keep negations as conflicts

### DIFF
--- a/scripts/seed-dependency-graph.mjs
+++ b/scripts/seed-dependency-graph.mjs
@@ -39,44 +39,134 @@ const GRAPH_PATH = path.join(repoRoot, 'src', 'isa-dependency-graph.json');
 // ---------------------------------------------------------------------------
 
 /**
- * Extension requirements reachable from a `requirements:` node, any shape.
+ * Extension requirements reachable from a `requirements:` node.
  *
- * `allOf` members are hard requirements. `anyOf`/`oneOf` members are a CHOICE
- * and must not be flattened into the hard set — Svpbmt requires S and *one of*
- * Sv39/Sv48/Sv57, and demanding all three would over-constrain every config
- * that uses it.
+ * UDB puts `extension:` in two structurally different places, and reading only
+ * one of them loses ~44 blocks including the whole Zvl*b chain:
+ *
+ *   requirements:                 requirements:
+ *     extension:                    allOf:
+ *       name: F                       - extension: {name: Zvl32b}
+ *                                     - param: {name: VLEN, greaterThanOrEqual: 64}
+ *
+ * Three kinds of member, treated differently:
+ *
+ *   allOf   — hard requirements.
+ *   anyOf   — a CHOICE. Svpbmt requires S and *one of* Sv39/Sv48/Sv57; flattening
+ *             that into the hard set demands all three paging modes at once.
+ *   not:    — a NEGATION, and `xlen:`/`param:` are conditions, not extensions.
+ *             C.yaml reads "Zca, and (not F or xlen 64 or Zcf), and (not D or
+ *             Zcd)": C requires only Zca. Flattening yields "C requires F and D",
+ *             which is false — C is perfectly legal without either.
+ *
+ * Groups mixing negation or width conditions are therefore not hard edges and
+ * not clean choice groups. They are returned as `conditional` so the caller can
+ * report them rather than silently guess.
  */
 function extensionRequirements(requirements) {
   const hard = [];
   const choices = [];
-  const walk = (node) => {
-    if (Array.isArray(node)) return node.forEach(walk);
+  const conditional = [];
+  const excluded = [];
+
+  /**
+   * True when every member names an extension and nothing else. Two spellings
+   * occur, depending on whether the group sits under `requirements:` or already
+   * inside an `extension:` node:
+   *   {extension: {name: X}}   and   {name: X}
+   * A `version:` alongside the name is fine — it constrains, it does not add a
+   * condition on some other extension being absent.
+   */
+  const optionName = (member) => {
+    if (!member || typeof member !== 'object') return null;
+    const keys = Object.keys(member);
+    if (keys.length === 1 && member.extension && typeof member.extension.name === 'string') {
+      return member.extension.name;
+    }
+    if (typeof member.name === 'string' && keys.every((k) => k === 'name' || k === 'version')) {
+      return member.name;
+    }
+    return null;
+  };
+  const pureChoiceOptions = (members) => {
+    if (!Array.isArray(members) || members.length === 0) return null;
+    const names = members.map(optionName);
+    return names.every(Boolean) ? names : null;
+  };
+
+  // `negated` — inside a `not:`. `guarded` — inside anyOf/oneOf/if, where a
+  // negation is one branch of a condition rather than an absolute exclusion.
+  // Zfinx says allOf[not: F], an unconditional "must not have F". C says
+  // anyOf[not: F, xlen: 64, Zcf], which is "F absent OR 64-bit OR Zcf" and
+  // excludes nothing on its own.
+  const walk = (node, negated = false, guarded = false) => {
+    if (Array.isArray(node)) return node.forEach((child) => walk(child, negated, guarded));
     if (!node || typeof node !== 'object') return;
-    if (typeof node.name === 'string') return void hard.push(node.name);
-    if ('allOf' in node) walk(node.allOf);
-    for (const combinator of ['anyOf', 'oneOf']) {
-      if (combinator in node) {
-        const options = [];
-        const collect = (n) => {
-          if (Array.isArray(n)) return n.forEach(collect);
-          if (n && typeof n === 'object') {
-            if (typeof n.name === 'string') options.push(n.name);
-            else for (const c of ['allOf', 'anyOf', 'oneOf']) if (c in n) collect(n[c]);
+
+    for (const [key, value] of Object.entries(node)) {
+      switch (key) {
+        case 'extension':
+          if (negated) walk(value, true, guarded);
+          else if (typeof value?.name === 'string') hard.push(value.name);
+          else walk(value, negated, guarded);
+          break;
+        case 'name':
+          if (typeof value !== 'string') break;
+          if (!negated) hard.push(value);
+          else if (!guarded) excluded.push(value);
+          break;
+        case 'allOf':
+          walk(value, negated, guarded);
+          break;
+        case 'anyOf':
+        case 'oneOf': {
+          const options = negated ? null : pureChoiceOptions(value);
+          if (options) {
+            choices.push(options);
+            break;
           }
-        };
-        collect(node[combinator]);
-        if (options.length) choices.push(options);
+          conditional.push(key);
+          // A non-pure group is a condition, so its branch-specific parts are
+          // dropped. But whatever EVERY branch requires is required outright:
+          // Zce's three alternative configurations all demand Zca, Zcb, Zcmp
+          // and Zcmt, differing only in xlen and F. Taking the intersection
+          // recovers those without asserting anything a branch does not.
+          if (!negated && Array.isArray(value) && value.length > 0) {
+            const perBranch = value.map((branch) => new Set(extensionRequirements(branch).hard));
+            const common = [...perBranch[0]].filter((name) => perBranch.every((s) => s.has(name)));
+            hard.push(...common);
+          }
+          break;
+        }
+        case 'not':
+          walk(value, true, guarded);
+          break;
+        case 'if':
+          // `if: {extension: U} then: {extension: S}` — an implication, not a
+          // dependency. Supm and Zicfiss use this. Neither side is walked as a
+          // requirement: the antecedent is a test, and the consequent only
+          // holds when it passes.
+          conditional.push('if');
+          break;
+        case 'then':
+          break;
+        // param / xlen / version are conditions on an implementation, not
+        // extension dependencies.
+        default:
+          break;
       }
     }
   };
-  walk(requirements?.extension);
-  return { hard, choices };
+
+  walk(requirements);
+  return { hard, choices, conditional, excluded };
 }
 
 function readUdb(root) {
   const dir = path.join(root, 'spec', 'std', 'isa', 'ext');
   const graph = {};
   const known = new Set();
+  const conditionalNodes = [];
   for (const file of fs.readdirSync(dir).filter((f) => f.endsWith('.yaml'))) {
     const id = file.slice(0, -5);
     known.add(id);
@@ -84,25 +174,35 @@ function readUdb(root) {
     if (!doc || typeof doc !== 'object') continue;
     const hard = new Set();
     const choices = [];
+    const excluded = new Set();
+    let skipped = 0;
     for (const req of [doc.requirements, ...(doc.versions ?? []).map((v) => v?.requirements)]) {
       if (!req) continue;
       const found = extensionRequirements(req);
       found.hard.forEach((n) => hard.add(n));
+      found.excluded.forEach((n) => excluded.add(n));
+      skipped += found.conditional.length;
       for (const options of found.choices) {
         const key = options.slice().sort().join('|');
         if (!choices.some((c) => c.slice().sort().join('|') === key)) choices.push(options);
       }
     }
     hard.delete(id); // a few files name themselves via version constraints
-    if (hard.size || choices.length) {
-      graph[id] = { hard: [...hard].sort(), choices };
+    if (skipped) conditionalNodes.push(`${id} (${skipped} group${skipped > 1 ? 's' : ''})`);
+    if (hard.size || choices.length || excluded.size || skipped) {
+      graph[id] = {
+        hard: [...hard].sort(),
+        choices,
+        excluded: [...excluded].sort(),
+        conditional: skipped > 0,
+      };
     }
   }
   let commit = 'unknown';
   try {
     commit = execFileSync('git', ['-C', root, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
   } catch { /* not a git checkout — provenance degrades, extraction still works */ }
-  return { graph, known, commit };
+  return { graph, known, commit, conditionalNodes };
 }
 
 /** Extension ids in the shipped catalog. */
@@ -142,7 +242,7 @@ const CONFLICTS = {
 // ---------------------------------------------------------------------------
 // Build
 // ---------------------------------------------------------------------------
-const { graph: udb, known: udbKnown, commit } = readUdb(udbRoot);
+const { graph: udb, known: udbKnown, commit, conditionalNodes } = readUdb(udbRoot);
 const catalogIds = readCatalogIds();
 
 /**
@@ -181,13 +281,29 @@ for (const id of catalogIds.slice().sort((a, b) => a.localeCompare(b))) {
     }));
   }
 
-  if (CONFLICTS[id]) {
-    node.conflicts = CONFLICTS[id].map((c) => ({ ext: c.ext, src: 'isa-manual', ref: c.ref }));
+  // Conflicts come from two places: our own base-ISA rules, and UDB's
+  // unconditional `not:` clauses. The latter are real negative information —
+  // Zfinx declares "not F" because it replaces the F register file — and
+  // dropping them would leave nothing to stop an invalid pairing.
+  const conflicts = [];
+  for (const dep of udb[id]?.excluded ?? []) {
+    conflicts.push({ ext: dep, src: 'udb', ref: `${id}.yaml requirements … not: ${dep}` });
   }
+  for (const conflict of CONFLICTS[id] ?? []) {
+    if (conflicts.some((c) => c.ext === conflict.ext)) continue;
+    conflicts.push({ ext: conflict.ext, src: 'isa-manual', ref: conflict.ref });
+  }
+  if (conflicts.length) node.conflicts = conflicts;
   // How far to trust an empty `requires`. "udb" means UDB models this extension
   // and records no extension requirements; "none" means nothing authoritative
   // was consulted, so the emptiness is an assumption rather than a finding.
-  if (requires.length === 0 && !node.requiresOneOf) {
+  // UDB expresses some requirements as conditionals (negations, xlen guards)
+  // that this model does not represent. Record that, so an empty `requires` is
+  // never read as "UDB says this extension depends on nothing" when what UDB
+  // actually says is "it depends, conditionally".
+  if (udb[id]?.conditional) node.conditionalRequirements = true;
+
+  if (requires.length === 0 && !node.requiresOneOf && !node.conditionalRequirements) {
     node.verified = udbKnown.has(id) ? 'udb' : 'none';
   }
   nodes[id] = node;
@@ -275,4 +391,12 @@ if (checkOnly) {
   console.log(`wrote ${path.relative(repoRoot, GRAPH_PATH)}`);
   console.log(`  ${Object.keys(nodes).length} nodes, ${withDeps} with dependencies`);
   console.log(`  ${unverified} with no dependencies and no authoritative source (verified: none)`);
+  if (conditionalNodes.length) {
+    console.log(
+      `\n  ${conditionalNodes.length} node(s) have conditional requirements this model does not\n` +
+      '  represent (negations and xlen guards). Their unconditional edges are kept;\n' +
+      '  the conditional parts are dropped rather than flattened into false hard edges:\n' +
+      `    ${conditionalNodes.join(', ')}`,
+    );
+  }
 }

--- a/src/isa-dependency-graph.json
+++ b/src/isa-dependency-graph.json
@@ -47,8 +47,14 @@
       ]
     },
     "C": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Zca",
+          "src": "udb",
+          "ref": "C.yaml requirements.extension"
+        }
+      ],
+      "conditionalRequirements": true
     },
     "D": {
       "requires": [
@@ -236,16 +242,26 @@
       "verified": "udb"
     },
     "Shtvala": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "H",
+          "src": "udb",
+          "ref": "Shtvala.yaml requirements.extension"
+        }
+      ]
     },
     "Shvsatpa": {
       "requires": [],
       "verified": "udb"
     },
     "Shvstvala": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "H",
+          "src": "udb",
+          "ref": "Shvstvala.yaml requirements.extension"
+        }
+      ]
     },
     "Shvstvecd": {
       "requires": [],
@@ -541,16 +557,32 @@
       "verified": "none"
     },
     "Supm": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "U",
+          "src": "udb",
+          "ref": "Supm.yaml requirements.extension"
+        }
+      ],
+      "conditionalRequirements": true
     },
     "Sv32": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "Sv32.yaml requirements.extension"
+        }
+      ]
     },
     "Sv39": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "Sv39.yaml requirements.extension"
+        }
+      ]
     },
     "Sv48": {
       "requires": [
@@ -571,20 +603,57 @@
       ]
     },
     "Svade": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Sm",
+          "src": "udb",
+          "ref": "Svade.yaml requirements.extension"
+        }
+      ],
+      "requiresOneOf": [
+        {
+          "options": [
+            "Sv32",
+            "Sv39"
+          ],
+          "default": "Sv32",
+          "src": "udb",
+          "ref": "Svade.yaml requirements.extension.anyOf"
+        }
+      ]
     },
     "Svadu": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Sm",
+          "src": "udb",
+          "ref": "Svadu.yaml requirements.extension"
+        }
+      ],
+      "requiresOneOf": [
+        {
+          "options": [
+            "Sv32",
+            "Sv39"
+          ],
+          "default": "Sv32",
+          "src": "udb",
+          "ref": "Svadu.yaml requirements.extension.anyOf"
+        }
+      ]
     },
     "Svatag": {
       "requires": [],
       "verified": "none"
     },
     "Svbare": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "S",
+          "src": "udb",
+          "ref": "Svbare.yaml requirements.extension"
+        }
+      ]
     },
     "Svinval": {
       "requires": [
@@ -675,8 +744,13 @@
       "verified": "udb"
     },
     "Za64rs": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Za128rs",
+          "src": "udb",
+          "ref": "Za64rs.yaml requirements.extension"
+        }
+      ]
     },
     "Zaamo": {
       "requires": [],
@@ -776,16 +850,71 @@
       ]
     },
     "Zce": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Zca",
+          "src": "udb",
+          "ref": "Zce.yaml requirements.extension"
+        },
+        {
+          "ext": "Zcb",
+          "src": "udb",
+          "ref": "Zce.yaml requirements.extension"
+        },
+        {
+          "ext": "Zcmp",
+          "src": "udb",
+          "ref": "Zce.yaml requirements.extension"
+        },
+        {
+          "ext": "Zcmt",
+          "src": "udb",
+          "ref": "Zce.yaml requirements.extension"
+        }
+      ],
+      "conflicts": [
+        {
+          "ext": "Zcd",
+          "src": "udb",
+          "ref": "Zce.yaml requirements … not: Zcd"
+        }
+      ],
+      "conditionalRequirements": true
     },
     "Zcf": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "F",
+          "src": "udb",
+          "ref": "Zcf.yaml requirements.extension"
+        },
+        {
+          "ext": "Zca",
+          "src": "udb",
+          "ref": "Zcf.yaml requirements.extension"
+        }
+      ]
     },
     "Zclsd": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Zca",
+          "src": "udb",
+          "ref": "Zclsd.yaml requirements.extension"
+        },
+        {
+          "ext": "Zilsd",
+          "src": "udb",
+          "ref": "Zclsd.yaml requirements.extension"
+        }
+      ],
+      "conflicts": [
+        {
+          "ext": "Zcf",
+          "src": "udb",
+          "ref": "Zclsd.yaml requirements … not: Zcf"
+        }
+      ]
     },
     "Zcmlsd": {
       "requires": [],
@@ -801,12 +930,41 @@
       ]
     },
     "Zcmp": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Zca",
+          "src": "udb",
+          "ref": "Zcmp.yaml requirements.extension"
+        }
+      ],
+      "conflicts": [
+        {
+          "ext": "Zcd",
+          "src": "udb",
+          "ref": "Zcmp.yaml requirements … not: Zcd"
+        }
+      ]
     },
     "Zcmt": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Zca",
+          "src": "udb",
+          "ref": "Zcmt.yaml requirements.extension"
+        },
+        {
+          "ext": "Zicsr",
+          "src": "udb",
+          "ref": "Zcmt.yaml requirements.extension"
+        }
+      ],
+      "conflicts": [
+        {
+          "ext": "Zcd",
+          "src": "udb",
+          "ref": "Zcmt.yaml requirements … not: Zcd"
+        }
+      ]
     },
     "Zdinx": {
       "requires": [
@@ -865,6 +1023,13 @@
           "src": "udb",
           "ref": "Zfinx.yaml requirements.extension"
         }
+      ],
+      "conflicts": [
+        {
+          "ext": "F",
+          "src": "udb",
+          "ref": "Zfinx.yaml requirements … not: F"
+        }
       ]
     },
     "Zhinx": {
@@ -892,6 +1057,13 @@
           "ext": "Zicsr",
           "src": "isa-manual",
           "ref": "Vol.I §21 — Zhinxmin uses the fcsr/frm/fflags CSRs"
+        }
+      ],
+      "conflicts": [
+        {
+          "ext": "Zfhmin",
+          "src": "udb",
+          "ref": "Zhinxmin.yaml requirements … not: Zfhmin"
         }
       ]
     },
@@ -945,8 +1117,24 @@
       ]
     },
     "Zicfiss": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Zaamo",
+          "src": "udb",
+          "ref": "Zicfiss.yaml requirements.extension"
+        },
+        {
+          "ext": "Zicsr",
+          "src": "udb",
+          "ref": "Zicfiss.yaml requirements.extension"
+        },
+        {
+          "ext": "Zimop",
+          "src": "udb",
+          "ref": "Zicfiss.yaml requirements.extension"
+        }
+      ],
+      "conditionalRequirements": true
     },
     "Zicntr": {
       "requires": [
@@ -1530,28 +1718,53 @@
       ]
     },
     "Zvl1024b": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Zvl512b",
+          "src": "udb",
+          "ref": "Zvl1024b.yaml requirements.extension"
+        }
+      ]
     },
     "Zvl128b": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Zvl64b",
+          "src": "udb",
+          "ref": "Zvl128b.yaml requirements.extension"
+        }
+      ]
     },
     "Zvl256b": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Zvl128b",
+          "src": "udb",
+          "ref": "Zvl256b.yaml requirements.extension"
+        }
+      ]
     },
     "Zvl32b": {
       "requires": [],
       "verified": "udb"
     },
     "Zvl512b": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Zvl256b",
+          "src": "udb",
+          "ref": "Zvl512b.yaml requirements.extension"
+        }
+      ]
     },
     "Zvl64b": {
-      "requires": [],
-      "verified": "udb"
+      "requires": [
+        {
+          "ext": "Zvl32b",
+          "src": "udb",
+          "ref": "Zvl64b.yaml requirements.extension"
+        }
+      ]
     },
     "Zvw": {
       "requires": [],

--- a/src/isaGraph.js
+++ b/src/isaGraph.js
@@ -134,7 +134,7 @@ export function validateGraph(graph = graphData, catalogIds = null) {
       }
     }
 
-    if (requires.length === 0 && !node.requiresOneOf && !node.verified) {
+    if (requires.length === 0 && !node.requiresOneOf && !node.verified && !node.conditionalRequirements) {
       warnings.push(`${id}: no dependencies and no "verified" marker — checked, or assumed?`);
     }
   }

--- a/tests/isa-graph.test.mjs
+++ b/tests/isa-graph.test.mjs
@@ -79,6 +79,64 @@ test('known dependencies survived the move off the hand-written table', () => {
   assert.ok(INCOMPATIBLE_WITH.RV32E.includes('F'), 'RV32E/F conflict lost');
 });
 
+test('requirements nested under allOf are read, not skipped', () => {
+  // UDB writes `requirements: {allOf: [{extension: {name: Zvl32b}}, {param: ...}]}`
+  // as well as the flatter `requirements: {extension: {name: F}}`. Reading only
+  // the second loses ~44 blocks, the whole Zvl*b chain among them.
+  assert.deepEqual(SMART_DEPENDENCIES.Zvl64b, ['Zvl32b']);
+  assert.deepEqual(SMART_DEPENDENCIES.Zvl128b, ['Zvl64b']);
+  assert.ok(closure('Zvl1024b').has('Zvl32b'), 'the VLEN chain should be transitive');
+  assert.deepEqual(SMART_DEPENDENCIES.Sv39, ['S']);
+  assert.deepEqual(SMART_DEPENDENCIES.Za64rs, ['Za128rs']);
+});
+
+test('conditional requirements are not flattened into hard edges', () => {
+  // C.yaml reads "Zca, and (not F or xlen 64 or Zcf), and (not D or Zcd)".
+  // Flattening yields "C requires F and D", which is false — C is legal with
+  // neither. Only the unconditional member is an edge.
+  assert.deepEqual(SMART_DEPENDENCIES.C, ['Zca']);
+  const c = DEPENDENCY_GRAPH.nodes.C;
+  assert.equal(c.conditionalRequirements, true, 'C should be marked as having conditions we drop');
+
+  // Supm and Zicfiss use if/then implications; only the unconditional part is an edge.
+  assert.deepEqual(SMART_DEPENDENCIES.Supm, ['U']);
+  assert.deepEqual(SMART_DEPENDENCIES.Zicfiss.sort(), ['Zaamo', 'Zicsr', 'Zimop']);
+  assert.equal(DEPENDENCY_GRAPH.nodes.Zicfiss.conditionalRequirements, true);
+});
+
+test('what every branch of a choice requires is required outright', () => {
+  // Zce's version block is a oneOf of three whole configurations that differ
+  // only in xlen and F. All three demand Zca, Zcb, Zcmp and Zcmt, so those are
+  // real edges — dropping the group entirely would understate them as zero.
+  assert.deepEqual(SMART_DEPENDENCIES.Zce.sort(), ['Zca', 'Zcb', 'Zcmp', 'Zcmt']);
+  const zce = DEPENDENCY_GRAPH.nodes.Zce;
+  assert.equal(zce.conditionalRequirements, true, 'the branch-specific parts are still dropped');
+  assert.equal(zce.verified, undefined, 'an unmodelled conditional is not a verified absence');
+  // Nothing that appears in only some branches leaks in.
+  assert.ok(!SMART_DEPENDENCIES.Zce.includes('F'), 'F is only in one branch');
+  assert.ok(!SMART_DEPENDENCIES.Zce.includes('Zcf'), 'Zcf is only in one branch');
+});
+
+test('UDB negations become conflicts, not dependencies', () => {
+  // Zfinx declares "Zicsr, and not F" — it replaces the F register file. Read
+  // as a dependency this inverts into "Zfinx requires F", which would build an
+  // architecturally invalid config.
+  assert.deepEqual(SMART_DEPENDENCIES.Zfinx, ['Zicsr']);
+  assert.deepEqual(INCOMPATIBLE_WITH.Zfinx, ['F']);
+  assert.deepEqual(INCOMPATIBLE_WITH.Zhinxmin, ['Zfhmin']);
+  assert.deepEqual(INCOMPATIBLE_WITH.Zcmp, ['Zcd']);
+
+  // A negation inside a condition is NOT an absolute exclusion: C's
+  // "anyOf[not F, xlen 64, Zcf]" does not make C incompatible with F.
+  assert.equal(INCOMPATIBLE_WITH.C, undefined, 'C must not be marked incompatible with F');
+
+  const result = resolveSelection({ selected: ['Zfinx', 'F'] });
+  assert.ok(
+    result.conflicts.some((c) => c.ext === 'F' && c.with === 'Zfinx'),
+    `selecting Zfinx with F should conflict, got ${JSON.stringify(result.conflicts)}`,
+  );
+});
+
 test('the Zvl divergence against clang is closed in the graph', () => {
   // clang and UDB both imply a minimum-VLEN token for the Zve* profiles; the
   // old table did not, and carried the gap in a KNOWN_DIVERGENCES ratchet.


### PR DESCRIPTION
Reviewing #137 surfaced a defect in the seeder merged in #145.

## The bug

The seeder read `requirements.extension` but not `requirements.allOf[].extension`. UDB uses **both**:

```yaml
requirements:              requirements:
  extension:                 allOf:
    name: F                    - extension: {name: Zvl32b}
                               - param: {name: VLEN, greaterThanOrEqual: 64}
```

The second form covers **~44 blocks**, so the graph shipped in #145 was missing **21 nodes' worth of real dependencies** — including the entire `Zvl*b` chain (`Zvl64b → Zvl32b → …`), `C → Zca`, `Sv39 → S`, `Za64rs → Za128rs`, and the `Zc*` family.

## Four forms, and why the difference matters

| form | treatment |
|---|---|
| `allOf` | hard requirements |
| `anyOf`/`oneOf` | a **choice** when every member names an extension (`Svpbmt`, `Svade`). Otherwise a **condition** — branch-specific parts dropped, but whatever *every* branch requires is kept |
| `if`/`then` | an **implication**, not a dependency (`Supm`, `Zicfiss`) — neither side is a requirement |
| `not:` | **negative information**, now captured as a **conflict** instead of discarded |

**The `oneOf` intersection.** `Zce`'s version block is three alternative whole configurations differing only in `xlen` and `F`. All three demand `Zca`, `Zcb`, `Zcmp`, `Zcmt` — so those are genuine edges. Dropping the group entirely would understate `Zce` as having zero dependencies.

**Negations are not all equal.** `Zfinx` declares `allOf[Zicsr, not: F]` — an unconditional "must not have F", because it replaces the F register file. But `C` declares `anyOf[not: F, xlen: 64, Zcf]`, which excludes nothing on its own. Exclusions are therefore only taken from unguarded positions, so `C` is **not** marked incompatible with `F`.

Six conflicts now come from UDB: `Zfinx↔F`, `Zhinxmin↔Zfhmin`, `Zcmp↔Zcd`, `Zcmt↔Zcd`, `Zce↔Zcd`, `Zclsd↔Zcf`. Each was verified against its YAML by hand.

## Why flattening is not a shortcut

Treating these forms alike doesn't lose nuance — it **inverts meaning**:

| flattened claim | reality |
|---|---|
| `Zfinx` requires `F` | UDB says `not: F` — the exact opposite |
| `Zcmp` requires `Zcd` | UDB says `not: Zcd` — the exact opposite |
| `C` requires `F` and `D` | `C` is legal with neither |

Nodes whose conditional parts are dropped are marked `conditionalRequirements`, so an empty `requires` is never misread as "UDB says this depends on nothing."

## Testing

46 tests pass (4 new, covering the `allOf` nesting, conditional non-flattening, the `oneOf` intersection, and negation-as-conflict). Build clean. All 32 generated `-march` strings still accepted by clang — worth checking, since new conflicts feed `buildMarchString`. Stripping a conflict citation still fails the gate.