### PR TITLE
Resolve ISA builder dependencies transitively

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -42,8 +42,19 @@ import {
 } from 'lucide-react';
 import extensions from './riscv_extensions.json';
 import WorkspacePanel from './WorkspacePanel.jsx';
-import { BASE_ISA_IDS, SMART_DEPENDENCIES, INCOMPATIBLE_WITH, buildMarchString, buildCombinedCatalog } from './marchUtils.js';
+// INCOMPATIBLE_WITH is no longer imported here: conflicts now come back from
+// resolveSelection(), which checks them over the resolved closure rather than
+// only over what the user clicked.
+import { BASE_ISA_IDS, SMART_DEPENDENCIES, buildMarchString, buildCombinedCatalog } from './marchUtils.js';
+import { resolveSelection } from './isaGraph.js';
 import { buildIsaConfigYaml } from './exportUtils.js';
+
+// Ids the catalog can actually render. The dependency graph carries a few nodes
+// the catalog does not (UDB's S requires Sm, for which we have no entry), and
+// adding one of those to the workspace would show a row with nothing behind it.
+const CATALOG_IDS = new Set(
+  Object.values(extensions).flat().filter(Boolean).map((e) => e.id),
+);
 
 const BIT_WIDTH = 32n;
 const BIT_MASK_32 = (1n << BIT_WIDTH) - 1n;
@@ -736,31 +747,38 @@ const RISCVExplorer = () => {
         }
 
         next.add(id);
-
-        // 2. Smart Dependencies (e.g. D fundamentally requires F)
-        const deps = SMART_DEPENDENCIES[id];
-        if (deps) {
-          for (const dep of deps) {
-            if (!next.has(dep)) {
-              next.add(dep);
-              autoAdded.push(dep);
-            }
-          }
-        }
       }
 
-      // 3. Incompatibility Check (e.g. RV32E excludes F)
-      // Evaluate bidirectionally for all items currently in the 'next' set
-      for (const ext1 of next) {
-        const incompat = INCOMPATIBLE_WITH[ext1] || [];
-        for (const blocked of incompat) {
-          if (next.has(blocked)) {
-            // Revert the entire addition batch if it creates an invalid architectural state
-            setWorkspaceNotice(`Architecturally Invalid: ${ext1} is incompatible with ${blocked}`);
-            setTimeout(() => setWorkspaceNotice(null), 4500);
-            return prev;
-          }
-        }
+      // 2. Dependencies, resolved transitively through the graph.
+      //
+      // This used to walk SMART_DEPENDENCIES one level deep, which is only
+      // correct when a dependency has none of its own. It silently under-selected
+      // everything deeper: picking H added S but not U (H -> S -> U), and picking
+      // Zve64d added D and Zve64f but none of F, Zicsr, Zve32x, Zve64x or the
+      // Zvl*b tokens. resolveSelection() walks the whole closure.
+      const resolution = resolveSelection({
+        selected: Array.from(next),
+        base: Array.from(next).find((x) => BASE_ISA_IDS.has(x)) ?? null,
+      });
+
+      // 3. Incompatibility check, over the fully resolved set — so a conflict
+      // reached only through a dependency is caught too. The path is what makes
+      // the message useful: the offending extension is often one the user never
+      // picked (Zve64d -> D -> F on an E-base).
+      if (resolution.conflicts.length > 0) {
+        const c = resolution.conflicts[0];
+        const via = c.path.length > 1 ? ` (pulled in by ${c.path.join(' -> ')})` : '';
+        setWorkspaceNotice(`Architecturally Invalid: ${c.with} is incompatible with ${c.ext}${via}`);
+        setTimeout(() => setWorkspaceNotice(null), 4500);
+        return prev; // revert the whole batch, as before
+      }
+
+      for (const dep of resolution.resolved) {
+        // Skip graph-only nodes the catalog cannot show.
+        if (!CATALOG_IDS.has(dep)) continue;
+        if (next.has(dep)) continue;
+        next.add(dep);
+        autoAdded.push(dep);
       }
 
       if (autoAdded.length > 0) {

--- a/tests/isa-graph.test.mjs
+++ b/tests/isa-graph.test.mjs
@@ -223,6 +223,29 @@ test('traversal reports what it implied, and why', () => {
   assert.equal(explain('D', result), 'D was selected directly');
 });
 
+test('privilege levels resolve transitively', () => {
+  // The ISA builder walked dependencies one level deep, so selecting S added U
+  // but selecting H added only S — U went missing because it is reached through
+  // S. Anything that resolves a selection must take the whole closure.
+  const s = resolveSelection({ selected: ['S'] });
+  assert.ok(s.resolved.includes('U'), 'S requires U');
+
+  const h = resolveSelection({ selected: ['H'] });
+  assert.ok(h.resolved.includes('S'), 'H requires S');
+  assert.ok(h.resolved.includes('U'), 'H requires U transitively, through S');
+  assert.deepEqual(explain('U', h).split(' -> '), ['H', 'S', 'U']);
+});
+
+test('deep chains resolve completely, not one level down', () => {
+  // Zve64d used to yield only D and Zve64f. Everything below that was dropped.
+  const r = resolveSelection({ selected: ['Zve64d'] });
+  for (const required of ['D', 'F', 'Zicsr', 'Zve32f', 'Zve32x', 'Zve64x', 'Zvl32b', 'Zvl64b']) {
+    assert.ok(r.resolved.includes(required), `Zve64d should pull in ${required}`);
+  }
+  const q = resolveSelection({ selected: ['Q'] });
+  assert.ok(q.resolved.includes('F') && q.resolved.includes('Zicsr'), 'Q -> D -> F -> Zicsr');
+});
+
 test('traversal explains a conflict with the path that caused it', () => {
   // The case that used to vanish silently: nothing the user picked is F, but
   // Zve64d reaches it through D, and RV32E has no F registers.


### PR DESCRIPTION
Selecting **S** did not select **U** in the custom ISA builder.

## Root cause

The builder walked `SMART_DEPENDENCIES` exactly **one level deep**. That is only correct when a dependency has none of its own, so every deeper edge was silently dropped:

| selected | before | missing |
|---|---|---|
| `S` | `S, U` | — (worked; `U` is a direct edge) |
| `H` | `H, S` | **`U`** — reached via `H → S → U` |
| `Q` | `D, Q` | `F`, `Zicsr` |
| `Zve64d` | `D, Zve64d, Zve64f` | `F`, `Zicsr`, `Zve32f`, `Zve32x`, `Zve64x`, `Zvl32b`, `Zvl64b` |

Worth noting `S → U` is itself **new**. The old hand-written table had no `S` entry at all, so that edge only began existing when the graph landed in #145. That's why the symptom reads as an "S bug" when the defect is the one-level walk — which was under-selecting far more than S.

## After

```
S       ->  S, U
H       ->  H, S, U
Q       ->  D, F, Q, Zicsr
Zve64d  ->  D, F, Zicsr, Zve32f, Zve32x, Zve64d, Zve64f, Zve64x, Zvl32b, Zvl64b
```

Now uses `resolveSelection()` from the graph, which walks the full closure.

## Conflicts get better too

The incompatibility check moves onto the resolved closure, so a conflict reached only *through* a dependency is caught instead of missed — and the message carries the path, because the offending extension is usually one the user never clicked:

```
Architecturally Invalid: RV32E is incompatible with F (pulled in by Zve64d -> D -> F)
```

The UDB-sourced conflicts from #147 work here as well — `Zfinx` + `F` is now rejected.

## Details

- **Graph-only nodes are filtered.** UDB's `S` requires `Sm`, which has no catalog entry; adding it would render a row with nothing behind it.
- **`lockedExtensions` unchanged.** It reads direct edges only, which stays correct now that the full closure is always present — every intermediate is in the set, so each link is locked by its immediate dependent.
- **`INCOMPATIBLE_WITH` import dropped** from the visualizer; conflicts come back from `resolveSelection()` now.

## Testing

48 tests pass (2 new: `S → U`, `H → S → U` with its path asserted, and the deep chains). Build clean. All 32 generated `-march` strings still accepted by clang — worth re-checking since conflict handling feeds `buildMarchString`.