### PR TITLE
Start a configuration from a ratified profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,25 @@ jobs:
       # against our own model of the spec. This caught a case the unit tests
       # missed: excluding F for an E base while keeping D produced a string
       # clang rejects ("ILP32E cannot be used with the D ISA extension").
+      # The toolchain has to be recent enough to know the extensions we emit.
+      # ubuntu-24.04 ships clang 18, which rejects Ssccptr outright and treats
+      # Zcmop as experimental — both are ratified and both appear in the RVA23
+      # and RVB23 profiles. Validating against clang 18 would assert our strings
+      # against a two-year-old view of the ISA and fail on correct output.
       - name: Install clang
-        run: sudo apt-get update && sudo apt-get install -y clang
+        run: |
+          set -euo pipefail
+          wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x /tmp/llvm.sh
+          sudo /tmp/llvm.sh 20
+          echo "CLANG=clang-20" >> "$GITHUB_ENV"
       - name: Validate -march strings with clang
         run: |
           set -uo pipefail
+          "$CLANG" --version | head -1
           fail=0
           while IFS=$'\t' read -r target march; do
-            if clang --target="$target" -march="$march" -x c /dev/null -fsyntax-only 2>/tmp/err; then
+            if "$CLANG" --target="$target" -march="$march" -x c /dev/null -fsyntax-only 2>/tmp/err; then
               echo "ok    $march"
             else
               echo "FAIL  $march  <- $(head -1 /tmp/err)"

--- a/scripts/emit-march-matrix.mjs
+++ b/scripts/emit-march-matrix.mjs
@@ -14,6 +14,8 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { buildMarchString } from '../src/marchUtils.js';
+import { resolveSelection } from '../src/isaGraph.js';
+import { PROFILES } from '../src/profiles.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const catalog = JSON.parse(readFileSync(join(here, '..', 'src', 'riscv_extensions.json'), 'utf8'));
@@ -35,12 +37,29 @@ const SELECTIONS = [
 const BASES = ['RV32I', 'RV64I', 'RV32E', 'RV64E'];
 
 const seen = new Set();
+const emit = (march) => {
+  if (!march || seen.has(march)) return;
+  seen.add(march);
+  const triple = march.startsWith('rv32') ? 'riscv32-unknown-elf' : 'riscv64-unknown-elf';
+  process.stdout.write(`${triple}\t${march}\n`);
+};
+
 for (const base of BASES) {
   for (const sel of SELECTIONS) {
-    const { march } = buildMarchString([base, ...sel.exts], ALL);
-    if (!march || seen.has(march)) continue;
-    seen.add(march);
-    const triple = march.startsWith('rv32') ? 'riscv32-unknown-elf' : 'riscv64-unknown-elf';
-    process.stdout.write(`${triple}\t${march}\n`);
+    emit(buildMarchString([base, ...sel.exts], ALL).march);
   }
+}
+
+// The ratified profiles, resolved exactly as the ISA builder resolves them.
+// These are the largest and most realistic strings the tool produces, and they
+// exercise the privileged/supervisor tail that the hand-written selections above
+// never touch — which is how every profile came to emit an Sv39 that clang
+// rejects, unnoticed.
+const CATALOG_IDS = new Set(ALL.filter(Boolean).map((e) => e.id));
+for (const [name, members] of Object.entries(PROFILES)) {
+  const base = members.find((id) => /^RV(32|64|128)[IE]$/.test(id)) ?? null;
+  if (base === 'RV128I') continue; // no clang riscv128 target
+  const { resolved } = resolveSelection({ selected: members, base });
+  emit(buildMarchString(resolved.filter((id) => CATALOG_IDS.has(id)), ALL).march);
+  void name;
 }

--- a/scripts/emit-march-matrix.mjs
+++ b/scripts/emit-march-matrix.mjs
@@ -56,10 +56,9 @@ for (const base of BASES) {
 // never touch — which is how every profile came to emit an Sv39 that clang
 // rejects, unnoticed.
 const CATALOG_IDS = new Set(ALL.filter(Boolean).map((e) => e.id));
-for (const [name, members] of Object.entries(PROFILES)) {
+for (const members of Object.values(PROFILES)) {
   const base = members.find((id) => /^RV(32|64|128)[IE]$/.test(id)) ?? null;
   if (base === 'RV128I') continue; // no clang riscv128 target
   const { resolved } = resolveSelection({ selected: members, base });
   emit(buildMarchString(resolved.filter((id) => CATALOG_IDS.has(id)), ALL).march);
-  void name;
 }

--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -163,7 +163,24 @@ const NON_ISA_EXTENSION_IDS = new Set(['RERI', 'HTI']);
  *
  * [DATA] Cross-checked against our riscv_extensions.json catalog descriptions.
  */
-export const NON_MARCH_IDS = new Set(['K', 'N', 'P', 'S', 'U']); // B removed — ratified, decode-accept + explicit-encode
+/**
+ * Sv32/Sv39/Sv48/Sv57 are address-translation MODES, not extensions. They name
+ * the page-table depth a hart supports and are selected at runtime through the
+ * `satp` MODE field — the same category as S and U above.
+ *
+ * Verified against clang 21: `-march=rv64imafdc_sv39` is rejected with
+ * "unsupported standard supervisor-level extension 'sv'" (the parser reads `sv`
+ * plus version `39`), while every other Sv* extension — Svbare, Svade, Svadu,
+ * Svnapot, Svpbmt, Svinval — is accepted. Emitting them produced an invalid
+ * -march for all four ratified profiles, each of which mandates Sv39.
+ */
+/** The satp MODE values, kept separate so the exclusion reason can be accurate. */
+export const SATP_MODE_IDS = new Set(['Sv32', 'Sv39', 'Sv48', 'Sv57']);
+
+export const NON_MARCH_IDS = new Set([
+  'K', 'N', 'P', 'S', 'U',   // privilege levels and UI grouping tags
+  ...SATP_MODE_IDS,
+]); // B removed — ratified, decode-accept + explicit-encode
 
 // ============================================================================
 // Data provenance — displayed in ISA Workspace footer
@@ -417,7 +434,15 @@ export function buildMarchString(selectedIds, allExts) {
       continue;
     }
     if (NON_MARCH_IDS.has(id)) {
-      out.excluded.push({ id, reason: 'UI grouping tag / Non-ISA tag — not a valid -march token' });
+      // Two different reasons live in NON_MARCH_IDS, and telling a user that
+      // Sv39 is a "UI grouping tag" is simply wrong — it is a real
+      // architectural feature, just not one -march can express.
+      out.excluded.push({
+        id,
+        reason: SATP_MODE_IDS.has(id)
+          ? 'Address-translation mode selected via the satp MODE field — not an -march extension'
+          : 'UI grouping tag / Non-ISA tag — not a valid -march token',
+      });
       continue;
     }
     if (id === 'B') {

--- a/src/profiles.js
+++ b/src/profiles.js
@@ -1,0 +1,197 @@
+/**
+ * profiles.js — ratified RISC-V profile definitions.
+ *
+ * Extracted from risc_v_visualizer.jsx so that scripts and tests can reach it.
+ * While it was a local const inside the component, nothing outside the UI could
+ * validate it — which is how all four profiles came to generate a -march string
+ * clang rejects (they mandate Sv39, and `sv39` is a satp translation mode rather
+ * than an -march token). scripts/emit-march-matrix.mjs now emits a string per
+ * profile so CI checks them against a real toolchain on every commit.
+ *
+ * Each entry lists the MANDATORY extensions of the profile's U64+S64 pair, by
+ * catalog id. Dependencies are deliberately NOT expanded here: the graph does
+ * that, so this stays a faithful transcription of the specification.
+ */
+
+// ---------------------------------------------------------------------------
+// Profile Definitions – mandatory sets (U64+S64) for RVA20/22/23/RVB23
+// ---------------------------------------------------------------------------
+export const PROFILES = {
+  // RVA20U64 + RVA20S64 – baseline “RV64GC-like” profile
+  RVA20: [
+    'RV64I',
+    'M',
+    'A',
+    'F',
+    'D',
+    'C',
+    'Zicsr',
+    'Zicntr',
+    'Ziccif',
+    'Ziccrse',
+    'Ziccamoa',
+    'Za128rs',
+    'Zicclsm',
+    'Zifencei',
+    'Ss1p11',
+    'Svbare',
+    'Sv39',
+    'Svade',
+    'Ssccptr',
+    'Sstvecd',
+    'Sstvala',
+  ],
+
+  // RVA22U64 + RVA22S64 – as referenced by RVA23 spec
+  RVA22: [
+    'RV64I',
+    'M',
+    'A',
+    'F',
+    'D',
+    'C',
+    'Zicsr',
+    'Zicntr',
+    'Zihpm',
+    'Ziccif',
+    'Ziccrse',
+    'Ziccamoa',
+    'Zicclsm',
+    'Za64rs',
+    'Zihintpause',
+    'Zba',
+    'Zbb',
+    'Zbs',
+    'Zic64b',
+    'Zicbom',
+    'Zicbop',
+    'Zicboz',
+    'Zfhmin',
+    'Zkt',
+    'Zifencei',
+    'Ss1p12',
+    'Svbare',
+    'Sv39',
+    'Svade',
+    'Ssccptr',
+    'Sstvecd',
+    'Sstvala',
+    'Sscounterenw',
+    'Svpbmt',
+    'Svinval',
+  ],
+
+  // RVA23U64 + RVA23S64 – full mandatory set
+  RVA23: [
+    'RV64I',
+    'M',
+    'A',
+    'F',
+    'D',
+    'C',
+    'Zicsr',
+    'Zicntr',
+    'Zihpm',
+    'Ziccif',
+    'Ziccrse',
+    'Ziccamoa',
+    'Zicclsm',
+    'Za64rs',
+    'Zihintpause',
+    'Zba',
+    'Zbb',
+    'Zbs',
+    'Zic64b',
+    'Zicbom',
+    'Zicbop',
+    'Zicboz',
+    'Zfhmin',
+    'Zkt',
+
+    // New mandatory in RVA23U64
+    'V',
+    'Zvfhmin',
+    'Zvbb',
+    'Zvkt',
+    'Zihintntl',
+    'Zicond',
+    'Zimop',
+    'Zcmop',
+    'Zcb',
+    'Zfa',
+    'Zawrs',
+    'Supm',
+
+    // S-profile extras
+    'Zifencei',
+    'Ss1p13',
+    'Svbare',
+    'Sv39',
+    'Svade',
+    'Ssccptr',
+    'Sstvecd',
+    'Sstvala',
+    'Sscounterenw',
+    'Svpbmt',
+    'Svinval',
+    'Svnapot',
+    'Sstc',
+    'Sscofpmf',
+    'Ssnpm',
+    'Ssu64xl',
+
+    // Hypervisor bundle
+    'Sha',
+    'H',
+  ],
+
+  // RVB23U64 + RVB23S64 – embedded-leaning profile
+  RVB23: [
+    'RV64I',
+    'M',
+    'A',
+    'F',
+    'D',
+    'C',
+    'Zicsr',
+    'Zicntr',
+    'Zihpm',
+    'Ziccif',
+    'Ziccrse',
+    'Ziccamoa',
+    'Zicclsm',
+    'Za64rs',
+    'Zihintpause',
+    'Zic64b',
+    'Zicbom',
+    'Zicbop',
+    'Zicboz',
+    'Zkt',
+
+    // RVA23-style unprivileged add-ons (minus V/Zfhmin/Supm mandates)
+    'Zihintntl',
+    'Zicond',
+    'Zimop',
+    'Zcmop',
+    'Zcb',
+    'Zfa',
+    'Zawrs',
+
+    'Zifencei',
+
+    'Ss1p13',
+    'Svnapot',
+    'Svbare',
+    'Sv39',
+    'Svade',
+    'Ssccptr',
+    'Sstvecd',
+    'Sstvala',
+    'Sscounterenw',
+    'Svpbmt',
+    'Svinval',
+    'Sstc',
+    'Sscofpmf',
+    'Ssu64xl',
+  ],
+};

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -48,6 +48,7 @@ import WorkspacePanel from './WorkspacePanel.jsx';
 // only over what the user clicked.
 import { BASE_ISA_IDS, SMART_DEPENDENCIES, buildMarchString, buildCombinedCatalog } from './marchUtils.js';
 import { resolveSelection } from './isaGraph.js';
+import { PROFILES } from './profiles.js';
 import { buildIsaConfigYaml } from './exportUtils.js';
 
 // Ids the catalog can actually render. The dependency graph carries a few nodes
@@ -686,6 +687,7 @@ const RISCVExplorer = () => {
   // asked to be in. Turning the builder on is now a deliberate act.
   const [builderMode, setBuilderMode] = useState(false);
   const [workspacePanelOpen, setWorkspacePanelOpen] = useState(false);
+  const [profileMenuOpen, setProfileMenuOpen] = useState(false);
   const [workspaceQuickOpen, setWorkspaceQuickOpen] = useState(false);
   const [quickExportOpen, setQuickExportOpen] = useState(false);
   const [quickExportIncludeInstr, setQuickExportIncludeInstr] = useState(true);
@@ -1162,188 +1164,9 @@ const RISCVExplorer = () => {
   };
   */
 
-  // ---------------------------------------------------------------------------
-  // Profile Definitions – mandatory sets (U64+S64) for RVA20/22/23/RVB23
-  // ---------------------------------------------------------------------------
-  const profiles = {
-    // RVA20U64 + RVA20S64 – baseline “RV64GC-like” profile
-    RVA20: [
-      'RV64I',
-      'M',
-      'A',
-      'F',
-      'D',
-      'C',
-      'Zicsr',
-      'Zicntr',
-      'Ziccif',
-      'Ziccrse',
-      'Ziccamoa',
-      'Za128rs',
-      'Zicclsm',
-      'Zifencei',
-      'Ss1p11',
-      'Svbare',
-      'Sv39',
-      'Svade',
-      'Ssccptr',
-      'Sstvecd',
-      'Sstvala',
-    ],
-
-    // RVA22U64 + RVA22S64 – as referenced by RVA23 spec
-    RVA22: [
-      'RV64I',
-      'M',
-      'A',
-      'F',
-      'D',
-      'C',
-      'Zicsr',
-      'Zicntr',
-      'Zihpm',
-      'Ziccif',
-      'Ziccrse',
-      'Ziccamoa',
-      'Zicclsm',
-      'Za64rs',
-      'Zihintpause',
-      'Zba',
-      'Zbb',
-      'Zbs',
-      'Zic64b',
-      'Zicbom',
-      'Zicbop',
-      'Zicboz',
-      'Zfhmin',
-      'Zkt',
-      'Zifencei',
-      'Ss1p12',
-      'Svbare',
-      'Sv39',
-      'Svade',
-      'Ssccptr',
-      'Sstvecd',
-      'Sstvala',
-      'Sscounterenw',
-      'Svpbmt',
-      'Svinval',
-    ],
-
-    // RVA23U64 + RVA23S64 – full mandatory set
-    RVA23: [
-      'RV64I',
-      'M',
-      'A',
-      'F',
-      'D',
-      'C',
-      'Zicsr',
-      'Zicntr',
-      'Zihpm',
-      'Ziccif',
-      'Ziccrse',
-      'Ziccamoa',
-      'Zicclsm',
-      'Za64rs',
-      'Zihintpause',
-      'Zba',
-      'Zbb',
-      'Zbs',
-      'Zic64b',
-      'Zicbom',
-      'Zicbop',
-      'Zicboz',
-      'Zfhmin',
-      'Zkt',
-
-      // New mandatory in RVA23U64
-      'V',
-      'Zvfhmin',
-      'Zvbb',
-      'Zvkt',
-      'Zihintntl',
-      'Zicond',
-      'Zimop',
-      'Zcmop',
-      'Zcb',
-      'Zfa',
-      'Zawrs',
-      'Supm',
-
-      // S-profile extras
-      'Zifencei',
-      'Ss1p13',
-      'Svbare',
-      'Sv39',
-      'Svade',
-      'Ssccptr',
-      'Sstvecd',
-      'Sstvala',
-      'Sscounterenw',
-      'Svpbmt',
-      'Svinval',
-      'Svnapot',
-      'Sstc',
-      'Sscofpmf',
-      'Ssnpm',
-      'Ssu64xl',
-
-      // Hypervisor bundle
-      'Sha',
-      'H',
-    ],
-
-    // RVB23U64 + RVB23S64 – embedded-leaning profile
-    RVB23: [
-      'RV64I',
-      'M',
-      'A',
-      'F',
-      'D',
-      'C',
-      'Zicsr',
-      'Zicntr',
-      'Zihpm',
-      'Ziccif',
-      'Ziccrse',
-      'Ziccamoa',
-      'Zicclsm',
-      'Za64rs',
-      'Zihintpause',
-      'Zic64b',
-      'Zicbom',
-      'Zicbop',
-      'Zicboz',
-      'Zkt',
-
-      // RVA23-style unprivileged add-ons (minus V/Zfhmin/Supm mandates)
-      'Zihintntl',
-      'Zicond',
-      'Zimop',
-      'Zcmop',
-      'Zcb',
-      'Zfa',
-      'Zawrs',
-
-      'Zifencei',
-
-      'Ss1p13',
-      'Svnapot',
-      'Svbare',
-      'Sv39',
-      'Svade',
-      'Ssccptr',
-      'Sstvecd',
-      'Sstvala',
-      'Sscounterenw',
-      'Svpbmt',
-      'Svinval',
-      'Sstc',
-      'Sscofpmf',
-      'Ssu64xl',
-    ],
-  };
+  // Profile definitions live in ./profiles.js so scripts and tests can reach
+  // them; see that file for why.
+  const profiles = PROFILES;
 
   // ---------------------------------------------------------------------------
   // Instruction lists per extension (used in the details sidebar)
@@ -2197,6 +2020,91 @@ const RISCVExplorer = () => {
                     >
                       <Maximize2 size={13} className="transition-transform group-hover:scale-110" />
                     </button>
+
+                    {/* Hairline divider */}
+                    <div className="relative z-10 w-px self-stretch bg-amber-600/60" />
+
+                    {/* Start from a profile.
+                        A configuration can begin two ways: pick a base ISA tile
+                        and build up (what the tiles below afford), or start from
+                        a ratified profile and adjust. Only the first was
+                        reachable before. While the workspace is empty this
+                        carries a text label, because that is exactly when the
+                        user needs to know the second option exists. */}
+                    <div className="relative z-10 flex">
+                      <button
+                        type="button"
+                        onClick={() => setProfileMenuOpen(v => !v)}
+                        title="Start the configuration from a ratified profile"
+                        className={[
+                          'group inline-flex items-center gap-1.5 justify-center px-3 transition-all duration-300 z-20 whitespace-nowrap',
+                          workspaceIds.size === 0 ? 'rounded-r-xl' : '',
+                          profileMenuOpen
+                            ? 'bg-indigo-500 text-white shadow-inner'
+                            : 'bg-gradient-to-b from-amber-400 to-amber-500 text-slate-800 hover:from-indigo-500 hover:to-indigo-600 hover:text-white',
+                        ].join(' ')}
+                      >
+                        <Layers size={13} className="transition-transform group-hover:scale-110" />
+                        {workspaceIds.size === 0 && (
+                          <span className="text-[11px] font-bold">Start from profile</span>
+                        )}
+                      </button>
+
+                      {profileMenuOpen && (
+                        <div style={{
+                          position: 'absolute', top: 'calc(100% + 8px)', right: 0,
+                          zIndex: 50, display: 'flex', flexDirection: 'column',
+                          borderRadius: 10,
+                          background: 'linear-gradient(145deg, #1a1f2e 0%, #141824 100%)',
+                          border: '1px solid rgba(245,197,66,0.25)',
+                          boxShadow: '0 12px 32px rgba(0,0,0,0.55)',
+                          minWidth: 300, overflow: 'hidden',
+                        }}>
+                          <div style={{
+                            padding: '10px 14px',
+                            borderBottom: '1px solid rgba(255,255,255,0.06)',
+                            background: 'rgba(245,197,66,0.04)',
+                            fontSize: 11, color: '#f1f5f9', fontWeight: 700,
+                          }}>
+                            Start from a ratified profile
+                          </div>
+
+                          {Object.entries(profiles).map(([name, list]) => (
+                            <button
+                              key={name}
+                              type="button"
+                              onClick={() => {
+                                // Replace rather than merge: "start from" means
+                                // this profile is the starting point, and mixing
+                                // it into an existing pick would silently produce
+                                // a configuration matching neither.
+                                setWorkspaceIds(new Set());
+                                addWorkspaceIdsSmart(list);
+                                setProfileMenuOpen(false);
+                              }}
+                              style={{
+                                display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                gap: 12, padding: '10px 14px', textAlign: 'left',
+                                borderBottom: '1px solid rgba(255,255,255,0.04)',
+                                background: 'transparent', cursor: 'pointer',
+                              }}
+                              className="hover:bg-amber-400/10 transition-colors"
+                            >
+                              <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--riscv-gold)' }}>{name}</span>
+                              <span style={{ fontSize: 10, color: 'var(--riscv-text-2)' }}>
+                                {list.length} extensions
+                              </span>
+                            </button>
+                          ))}
+
+                          <div style={{ padding: '8px 14px', fontSize: 10, color: 'var(--riscv-text-3)', lineHeight: 1.5 }}>
+                            Replaces the current selection. Dependencies are resolved
+                            automatically, so the result may include more than the
+                            profile lists.
+                          </div>
+                        </div>
+                      )}
+                    </div>
                   </>)}
 
                   {/* Clear and export — only meaningful once something is picked */}

--- a/tests/profiles.test.mjs
+++ b/tests/profiles.test.mjs
@@ -1,0 +1,86 @@
+/**
+ * Profiles are a starting point for a configuration, so they have to survive the
+ * same journey a hand-built selection does: every member must exist, the graph
+ * must resolve them without conflict, and the result must produce a -march
+ * string a real toolchain accepts.
+ *
+ * That last step is the one that mattered. While `profiles` was a local const
+ * inside the React component, nothing could check it — and all four profiles
+ * generated a string clang rejects, because each mandates Sv39 and `sv39` is a
+ * satp translation mode rather than an -march token. The clang check itself
+ * lives in CI (scripts/emit-march-matrix.mjs); these tests cover everything
+ * that does not need a toolchain installed.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { PROFILES } from '../src/profiles.js';
+import { resolveSelection } from '../src/isaGraph.js';
+import { buildMarchString, NON_MARCH_IDS } from '../src/marchUtils.js';
+
+const ALL = (() => {
+  const file = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'src', 'riscv_extensions.json');
+  return Object.values(JSON.parse(fs.readFileSync(file, 'utf8'))).flat().filter(Boolean);
+})();
+const CATALOG_IDS = new Set(ALL.map((e) => e.id));
+
+const entries = Object.entries(PROFILES);
+
+test('there are profiles to start from', () => {
+  assert.ok(entries.length >= 4, `expected the ratified profiles, got ${entries.length}`);
+});
+
+for (const [name, members] of entries) {
+  test(`${name}: every member exists in the catalog`, () => {
+    const missing = members.filter((id) => !CATALOG_IDS.has(id));
+    assert.deepEqual(missing, [], `${name} names extensions the catalog does not have: ${missing.join(', ')}`);
+  });
+
+  test(`${name}: names exactly one base ISA`, () => {
+    const bases = members.filter((id) => /^RV(32|64|128)[IE]$/.test(id));
+    assert.equal(bases.length, 1, `${name} should name one base ISA, found: ${bases.join(', ') || 'none'}`);
+  });
+
+  test(`${name}: resolves through the graph without conflict`, () => {
+    const base = members.find((id) => /^RV(32|64|128)[IE]$/.test(id));
+    const result = resolveSelection({ selected: members, base });
+    assert.deepEqual(
+      result.conflicts.map((c) => `${c.with} vs ${c.ext} (${c.path.join(' -> ')})`),
+      [],
+      `${name} resolves to a conflicting configuration`,
+    );
+    assert.deepEqual(result.unknown, [], `${name} references extensions the graph does not know`);
+    // Resolution should never lose a mandated extension.
+    for (const id of members) {
+      assert.ok(result.resolved.includes(id), `${name}: ${id} vanished during resolution`);
+    }
+  });
+
+  test(`${name}: produces a -march string`, () => {
+    const base = members.find((id) => /^RV(32|64|128)[IE]$/.test(id));
+    const { resolved } = resolveSelection({ selected: members, base });
+    const { march } = buildMarchString(resolved.filter((id) => CATALOG_IDS.has(id)), ALL);
+    assert.ok(march, `${name} produced no -march string`);
+    assert.match(march, /^rv(32|64|128)[ie]/, `${name} -march does not start with a base: ${march}`);
+    // clang parses `sv39` as extension `sv` at version 39 and rejects it. The
+    // same holds for the other satp modes. CI proves this against a real
+    // toolchain; here we just assert we never emit the token.
+    for (const mode of ['sv32', 'sv39', 'sv48', 'sv57']) {
+      assert.ok(
+        !march.split('_').includes(mode),
+        `${name} emits ${mode}, which no toolchain accepts as an -march extension`,
+      );
+    }
+  });
+}
+
+test('satp translation modes are excluded from -march', () => {
+  for (const mode of ['Sv32', 'Sv39', 'Sv48', 'Sv57']) {
+    assert.ok(NON_MARCH_IDS.has(mode), `${mode} must not be emitted into -march`);
+  }
+  // The other Sv* extensions are real -march tokens and must stay emittable.
+  for (const real of ['Svbare', 'Svade', 'Svnapot', 'Svpbmt', 'Svinval']) {
+    assert.ok(!NON_MARCH_IDS.has(real), `${real} is a valid -march extension and should be emitted`);
+  }
+});


### PR DESCRIPTION
A configuration could only begin one way: pick a base ISA tile and build up. It can now also start from a **profile**.

## The feature

A **Start from profile** control appears while builder mode is on, carrying a text label while the workspace is empty — exactly when the user needs to know the option exists. It lists the four ratified profiles with their sizes.

Picking one **replaces** the selection rather than merging. "Start from" means this profile is the starting point; mixing it into existing picks would quietly produce a configuration matching neither.

Dependencies resolve through the graph, so the result is larger than the specification text:

| profile | mandated | resolved | conflicts |
|---|---|---|---|
| RVA20 | 21 | 27 | 0 |
| RVA22 | 35 | 42 | 0 |
| RVA23 | 54 | **77** | 0 |
| RVB23 | 42 | 49 | 0 |

RVA23 gains the whole `Zve*`/`Zvl*` chain from `V` and the `Sh*` family from `Sha` (#146).

## It exposed a real `-march` bug — now fixed

**All four profiles produced a string clang rejects:**

```
clang: error: invalid arch name 'rv64imafdc_..._sv39_...',
       unsupported standard supervisor-level extension 'sv'
```

`Sv32`/`Sv39`/`Sv48`/`Sv57` are address-translation **modes**, selected at runtime via the `satp` MODE field — the same category as `S` and `U`, which were already excluded. clang parses `sv39` as extension `sv` at version `39`.

Bisecting the generated strings token by token showed **`sv39` was the only offender**. Every other `Sv*` extension is accepted:

| token | clang |
|---|---|
| `sv32` `sv39` `sv48` `sv57` | **rejected** |
| `svbare` `svade` `svadu` `svnapot` `svpbmt` `svinval` | accepted |

The bug **predates this feature** — hand-picking Sv39 produced the same broken string — but a profile makes it one click away, since all four mandate Sv39.

Their exclusion reason is now specific too. Telling someone `Sv39` is a *"UI grouping tag"* is wrong: it's a real architectural feature, just not one `-march` expresses.

## Why it went unnoticed, and what catches it now

`profiles` was a local `const` **inside the React component**, so nothing outside the UI could validate it. It moves to `src/profiles.js`, and:

- **`scripts/emit-march-matrix.mjs` emits a string per profile**, so CI checks them against a real toolchain. **32 strings → 36, all clang-valid.**
- **`tests/profiles.test.mjs`** covers membership, single-base, conflict-free resolution, no extension lost during resolution, and absence of satp modes from `-march`.

I confirmed the new test actually catches the regression: reverting the `NON_MARCH_IDS` change fails exactly 5 tests and no others.

## Testing

66 tests pass (18 new). Build clean. Verified in a browser: RVA20 loads 27 extensions / 193 instructions, emits a clang-valid `-march`, and lists `Sv39`, `Ss1p11`, `S`, `U` under *excluded from -march* with reasons.