### PR TITLE
Cross-check the dependency model against riscv-config

### DIFF
--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -174,6 +174,26 @@ const NON_ISA_EXTENSION_IDS = new Set(['RERI', 'HTI']);
  * Svnapot, Svpbmt, Svinval — is accepted. Emitting them produced an invalid
  * -march for all four ratified profiles, each of which mandates Sv39.
  */
+/**
+ * Shorthand extensions that ABSORB their members in an ISA string.
+ *
+ * These are not ordinary dependencies. D depends on F and both belong in the
+ * string; Zkn is a *name for* its members, so listing both is malformed. The
+ * riscv-config validator (riscv/riscv-config, isa_validator.py) rejects it:
+ *
+ *   "Zkn is a superset of Zbkb, Zbkc, Zbkx, Zkne, Zknd, Zknh. In presence of
+ *    Zkn the subsets must be ignored in the ISA string."
+ *
+ * clang accepts the redundant form, which is why a toolchain check never
+ * noticed. The members stay in the dependency graph — selecting Zkn genuinely
+ * does give you Zbkb — they are simply not spelled out in -march.
+ */
+export const SHORTHAND_BUNDLES = {
+  Zkn: ['Zbkb', 'Zbkc', 'Zbkx', 'Zknd', 'Zkne', 'Zknh'],
+  Zks: ['Zbkb', 'Zbkc', 'Zbkx', 'Zksed', 'Zksh'],
+  Zk:  ['Zbkb', 'Zbkc', 'Zbkx', 'Zknd', 'Zkne', 'Zknh', 'Zkn', 'Zkr', 'Zkt'],
+};
+
 /** The satp MODE values, kept separate so the exclusion reason can be accurate. */
 export const SATP_MODE_IDS = new Set(['Sv32', 'Sv39', 'Sv48', 'Sv57']);
 
@@ -422,8 +442,30 @@ export function buildMarchString(selectedIds, allExts) {
   const singles = [];
   const multis = [];
 
+  // A shorthand and its members must not both appear. riscv-config rejects
+  // "Zkn is a superset of Zbkb, Zbkc, Zbkx, Zkne, Zknd, Zknh. In presence of
+  // Zkn the subsets must be ignored in the ISA string." clang tolerates the
+  // redundant form, so this is invisible to a toolchain check.
+  //
+  // Deliberately narrow. It is NOT "drop anything implied by something else" —
+  // D implies F and both belong in the string. Only these three shorthands
+  // absorb their members.
+  const absorbed = new Map(); // member -> shorthand that covers it
+  for (const [shorthand, members] of Object.entries(SHORTHAND_BUNDLES)) {
+    if (!selectedIds.includes(shorthand)) continue;
+    for (const member of members) absorbed.set(member, shorthand);
+  }
+
   for (const id of selectedIds) {
     if (BASE_ISA_IDS.has(id)) continue;
+
+    if (absorbed.has(id)) {
+      out.excluded.push({
+        id,
+        reason: `Covered by ${absorbed.get(id)} — a shorthand must not list its own members`,
+      });
+      continue;
+    }
 
     if (SPEC_VERSION_TAG_PATTERN.test(id)) {
       out.excluded.push({ id, reason: 'Privileged spec version compliance tag — not an -march option' });

--- a/tests/riscv-config-rules.test.mjs
+++ b/tests/riscv-config-rules.test.mjs
@@ -1,0 +1,150 @@
+/**
+ * Our dependency model, checked against riscv-config — RISC-V International's
+ * own validator (riscv/riscv-config, isa_validator.py, v3.18.3).
+ *
+ * A third opinion, independent of riscv-unified-db and of clang. All 32 of our
+ * canonical -march strings were accepted by it, and 9 of its rules were already
+ * encoded here. The rules below are transcribed from that file so a future
+ * change that contradicts the official validator fails in CI.
+ *
+ * The rules are transcribed rather than executed. riscv-config is Python, knows
+ * 74 sub-extensions against our 227 (so it skips every profile), spells strings
+ * differently from -march, and crashes on valid input — get_extension_list
+ * ("RV64IZicsr_Zk") raises IndexError, because it reads the third character of
+ * a two-character extension name. Shelling out to it would add a dependency, a
+ * translation layer, and a silent-skip problem, for rules that fit in a table.
+ *
+ * Three of its rules are deliberately NOT asserted; see EXCLUDED below.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { closure, resolveSelection } from '../src/isaGraph.js';
+import { buildMarchString, SHORTHAND_BUNDLES } from '../src/marchUtils.js';
+
+const ALL = (() => {
+  const file = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'src', 'riscv_extensions.json');
+  return Object.values(JSON.parse(fs.readFileSync(file, 'utf8'))).flat().filter(Boolean);
+})();
+const CATALOG_IDS = new Set(ALL.map((e) => e.id));
+
+/** "X cannot exist without Y" — from isa_validator.py. */
+const REQUIRES = {
+  F: 'Zicsr',
+  D: 'F',
+  Q: 'D',
+  S: 'U',
+  Zfinx: 'Zicsr',
+  Zdinx: 'Zfinx',
+  Zhinx: 'Zfinx',
+  Zhinxmin: 'Zfinx',
+};
+
+/** "X and Y cannot exist together" — from isa_validator.py. */
+const CONFLICTS = [
+  ['F', 'Zfinx'],
+  ['Zhinx', 'Zfh'],
+  ['Zhinxmin', 'Zfh'],
+];
+
+/**
+ * Rules we do not assert, with the reason. Kept visible so nobody has to
+ * re-derive why the transcription is incomplete.
+ */
+const EXCLUDED = {
+  'Zam -> A': 'Zam is not in our catalog, so the rule has nothing to apply to.',
+  'N -> U': 'N (User-Level Interrupts) was removed from the specification in 2024. ' +
+            'riscv-config still carries the rule; we keep N only as a historical catalog entry.',
+  'Zfa -> Zfh': 'Disputed. riscv-config claims Zfa requires Zfh; UDB (Zfa.yaml) requires only F, ' +
+                'and Zfa adds instructions for whichever FP types are present — only its ' +
+                'half-precision forms need Zfh. riscv-config appends this message but never sets ' +
+                'its error flag, so even there it is advisory. We follow UDB.',
+};
+
+test('the exclusion list stays honest', () => {
+  // A reason that says nothing is worse than no entry at all.
+  for (const [rule, reason] of Object.entries(EXCLUDED)) {
+    assert.ok(reason.length > 40, `${rule}: exclusion reason is too thin to be useful`);
+  }
+  assert.equal(Object.keys(EXCLUDED).length, 3, 'exclusions changed — update the reasoning too');
+});
+
+for (const [ext, required] of Object.entries(REQUIRES)) {
+  test(`riscv-config: ${ext} cannot exist without ${required}`, () => {
+    assert.ok(CATALOG_IDS.has(ext), `${ext} is missing from the catalog`);
+    assert.ok(
+      closure(ext).has(required),
+      `${ext} should reach ${required}; closure is [${[...closure(ext)].join(', ')}]`,
+    );
+  });
+}
+
+for (const [a, b] of CONFLICTS) {
+  test(`riscv-config: ${a} and ${b} cannot exist together`, () => {
+    // Checked through resolveSelection, not the flat conflict table: Zhinxmin
+    // conflicts with Zfhmin, and Zfh only reaches that through Zfh -> Zfhmin.
+    // Reading the table alone reports a false gap.
+    const result = resolveSelection({ selected: [a, b] });
+    assert.ok(
+      result.conflicts.length > 0,
+      `selecting ${a} with ${b} should conflict, got none`,
+    );
+  });
+}
+
+/**
+ * Transcribed from riscv-config, NOT derived from SHORTHAND_BUNDLES.
+ *
+ * Deriving the expectation from the constant under test makes the test vacuous:
+ * delete an entry and the loop simply stops checking it. This list is the
+ * independent statement of what must hold.
+ */
+const EXPECTED_SHORTHANDS = {
+  Zkn: ['Zbkb', 'Zbkc', 'Zbkx', 'Zknd', 'Zkne', 'Zknh'],
+  Zks: ['Zbkb', 'Zbkc', 'Zbkx', 'Zksed', 'Zksh'],
+  Zk:  ['Zbkb', 'Zbkc', 'Zbkx', 'Zknd', 'Zkne', 'Zknh', 'Zkn', 'Zkr', 'Zkt'],
+};
+
+test('every shorthand riscv-config knows about is modelled', () => {
+  for (const [shorthand, members] of Object.entries(EXPECTED_SHORTHANDS)) {
+    assert.ok(SHORTHAND_BUNDLES[shorthand], `${shorthand} is missing from SHORTHAND_BUNDLES`);
+    assert.deepEqual(
+      [...SHORTHAND_BUNDLES[shorthand]].sort(),
+      [...members].sort(),
+      `${shorthand} members disagree with riscv-config`,
+    );
+  }
+});
+
+test('a shorthand absorbs its members in the ISA string', () => {
+  // riscv-config: "In presence of Zkn the subsets must be ignored in the ISA
+  // string." clang accepts the redundant form, so only the official validator
+  // catches this.
+  for (const [shorthand, members] of Object.entries(EXPECTED_SHORTHANDS)) {
+    const { resolved } = resolveSelection({ selected: ['RV64I', shorthand], base: 'RV64I' });
+    const { march, excluded } = buildMarchString(resolved.filter((id) => CATALOG_IDS.has(id)), ALL);
+    assert.ok(march, `${shorthand} produced no -march string`);
+    const tokens = march.split('_');
+    assert.ok(tokens.includes(shorthand.toLowerCase()), `${shorthand} itself should be emitted`);
+    for (const member of members) {
+      assert.ok(
+        !tokens.includes(member.toLowerCase()),
+        `${march} lists ${member}, which ${shorthand} already covers`,
+      );
+      assert.ok(
+        excluded.some((e) => e.id === member),
+        `${member} should be reported as covered by ${shorthand}, not dropped silently`,
+      );
+    }
+  }
+});
+
+test('ordinary dependencies are NOT absorbed', () => {
+  // The rule above is narrow. D implies F and both belong in the string; a
+  // blanket "drop anything implied" would silently mangle every config.
+  const { resolved } = resolveSelection({ selected: ['RV64I', 'D'], base: 'RV64I' });
+  const { march } = buildMarchString(resolved.filter((id) => CATALOG_IDS.has(id)), ALL);
+  assert.match(march, /f/, `F should still appear alongside D: ${march}`);
+  assert.match(march, /d/, `D should appear: ${march}`);
+});


### PR DESCRIPTION
[riscv-config](https://riscv-config.readthedocs.io/en/latest/quickstart.html) is **RISC-V International's own validator**. Running our output through it gives a third opinion, independent of riscv-unified-db and of clang.

## It confirms our work

```
accepted by riscv-config : 32
rejected                 : 0
skipped                  : 4   (profiles use extensions it does not know)
```

Of its 14 dependency/conflict rules, **9 were already encoded here** — including `"S cannot exist without U"`, the rule behind the builder bug reported earlier. Three more are satisfied through the **resolved closure** rather than the flat table: `Zhinxmin` conflicts with `Zfhmin`, and `Zfh` reaches that via `Zfh → Zfhmin`. Checking the table alone reports a false gap — my first pass did exactly that.

## It found a real defect clang cannot see

Selecting `Zkn` emitted every member alongside the shorthand:

```
rv64i_zbkb_zbkc_zbkx_zkn_zknd_zkne_zknh
```

| validator | verdict |
|---|---|
| clang | **accepts** — which is why our toolchain check never noticed |
| riscv-config | **rejects**: *"In presence of Zkn the subsets must be ignored in the ISA string"* |

`Zkn`, `Zks` and `Zk` now absorb their members, and the members are reported under `excluded` rather than dropped silently:

```
Zkn  ->  rv64i_zkn
Zk   ->  rv64i_zk
Zks  ->  rv64i_zks
```

**The rule is deliberately narrow.** It is *not* "drop anything implied by something else" — `D` implies `F` and both belong in the string. A shorthand is a *name for* its members; an ordinary dependency is not. There's a test pinning that distinction.

## Why the rules are transcribed rather than executed

I recommend **not** shelling out to riscv-config in CI:

- It knows **74** sub-extensions against our **227**, so it skips every profile — a check that silently skips more as we grow is a check that quietly stops working.
- It spells strings differently from `-march` (`RV64IMAFDCZicsr_Zifencei`), needing a translation layer that is itself a bug surface.
- **It crashes on valid input.** `get_extension_list("RV64IZicsr_Zk")` raises `IndexError` — it reads the third character of a two-character extension name.

The rules fit in a table, so they are a table.

Three are excluded with stated reasons: `Zam` isn't in our catalog; `N` was removed from the spec in 2024; and `Zfa → Zfh` is disputed — UDB requires only `F`, and riscv-config appends that message but **never sets its error flag**, so even there it's advisory.

## A note on the test itself

The first version of the shorthand test was vacuous: it looped over `SHORTHAND_BUNDLES` to check `SHORTHAND_BUNDLES`, so deleting an entry just stopped it being checked. I caught that by deliberately removing `Zkn` and watching the test still pass. The expectations are now transcribed independently, and removing `Zkn` fails two tests.

## Testing

81 tests pass (13 new). Build clean, all 36 `-march` strings still accepted by clang. Both negative tests verified by breaking the source and watching the right tests fail.