### PR TITLE
Rename the feature to ISA Configuration Builder

### DIFF
--- a/src/WorkspacePanel.jsx
+++ b/src/WorkspacePanel.jsx
@@ -213,7 +213,7 @@ export default function WorkspacePanel({
               fontWeight: 700, fontSize: 15, letterSpacing: '-0.01em',
               color: '#e2e8f0',
             }}>
-              Custom ISA Configuration Builder
+              ISA Configuration Builder
             </span>
 
             {/* Stats badges */}

--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -1,5 +1,5 @@
 /**
- * exportUtils.js — Export generator for the Custom ISA Configuration Builder
+ * exportUtils.js — Export generator for the ISA Configuration Builder
  *
  * Goal: produce a complete, accurate, self-describing ISA configuration file
  * that is valuable on its own terms, not shaped to satisfy any specific

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1719,7 +1719,7 @@ const RISCVExplorer = () => {
                 transition: 'all 0.15s',
                 padding: 0,
               }}
-              title={isLocked ? `Required by ${lockedBy.join(', ')} — remove dependent first` : (inWorkspace ? `Remove ${data.id} from Custom ISA Configuration Builder` : `Add ${data.id} to Custom ISA Configuration Builder`)}
+              title={isLocked ? `Required by ${lockedBy.join(', ')} — remove dependent first` : (inWorkspace ? `Remove ${data.id} from ISA Configuration Builder` : `Add ${data.id} to ISA Configuration Builder`)}
             >
               {inWorkspace
                 ? (
@@ -1960,7 +1960,7 @@ const RISCVExplorer = () => {
                   <span className="whitespace-nowrap">Encoder Validator</span>
                 </button>
 
-                {/* Custom ISA Configuration Builder — fused action group */}
+                {/* ISA Configuration Builder — fused action group */}
                 <div className="relative inline-flex items-stretch rounded-xl">
 
                   {/* Active glow ring */}
@@ -1985,12 +1985,12 @@ const RISCVExplorer = () => {
                     style={{ boxShadow: builderMode ? '0 4px 18px rgba(251,191,36,0.4)' : '0 2px 10px rgba(0,0,0,0.2)' }}
                     title={
                       builderMode
-                        ? 'Custom ISA Builder is ON — click any extension’s + to add it. Click here to turn off.'
-                        : 'Turn on the Custom ISA Builder to start picking extensions'
+                        ? 'ISA Configuration Builder is ON — click any extension’s + to add it. Click here to turn off.'
+                        : 'Turn on the ISA Configuration Builder to start picking extensions'
                     }
                   >
                     <Cpu size={14} className="opacity-80 flex-shrink-0" />
-                    <span className="whitespace-nowrap">Custom ISA Builder</span>
+                    <span className="whitespace-nowrap">ISA Configuration Builder</span>
                     <span
                       className={[
                         'inline-flex items-center justify-center px-1.5 h-[16px] rounded-full text-[10px] font-black tracking-wide',


### PR DESCRIPTION
## Why "Custom" was wrong

In RISC-V, **custom** is a term of art: custom extensions are vendor-defined and non-standard, using the `X` prefix and reserved opcode space. This feature offers none of those.

```
catalog extensions : 227
vendor/custom (X*) : 0
```

Everything it composes is standard, and since #151 it can start from a **ratified profile**. The name pointed at the opposite of what the tool does — in front of an audience that reads that word precisely.

## It also had two names in the interface

| where | said |
|---|---|
| toolbar button | `Custom ISA Builder` |
| the panel it opens | `Custom ISA Configuration Builder` |
| code comments | `ISA Workspace` |

The button and the panel disagreed with each other.

## Now

One name in every user-visible string — the button, the panel heading, all **227** tile tooltips, and the export generator. *Configuration* is what both UDB and riscv-config call a concrete base-plus-extensions selection.

Verified in the browser: `document.body.innerText.includes('Custom ISA')` → **false**.

## Deliberately not renamed

Internal identifiers — `workspaceIds`, `addWorkspaceIdsSmart`, `WorkspacePanel`, 114 references. Renaming them would bury a user-facing change in an unreviewable diff. Worth doing separately, if at all.

## One measurement worth recording

The longer label costs **35px** of header width (1651 → 1686). It does **not** introduce an overflow — the header already needed 1651px, so it clips on a 1440px laptop either way. Pre-existing and unrelated; I measured it rather than assume, and left it alone.

81 tests pass, build clean.