### PR TITLE
Add a favicon, and title the page Landscape

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>RISC-V Extension Visualizer</title>
+  <!-- Favicon, inlined as a data URI on purpose.
+       The build has no copy plugin: HtmlWebpackPlugin emits this file and
+       webpack emits bundle.js, and nothing else in public/ reaches dist/. A
+       favicon.svg dropped alongside this file would 404 in production without
+       anything failing. Inlining keeps one source that cannot silently vanish.
+       Three ascending bars: the spread of extensions the landscape covers. -->
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 32 32%22%3E%3Crect width=%2232%22 height=%2232%22 rx=%227%22 fill=%22%2314141e%22/%3E%3Crect x=%225.5%22 y=%2218%22 width=%225%22 height=%228.5%22 rx=%221.6%22 fill=%22%23f5c542%22/%3E%3Crect x=%2213.5%22 y=%2212%22 width=%225%22 height=%2214.5%22 rx=%221.6%22 fill=%22%23f5c542%22/%3E%3Crect x=%2221.5%22 y=%225.5%22 width=%225%22 height=%2221%22 rx=%221.6%22 fill=%22%23f5c542%22/%3E%3Crect x=%22.6%22 y=%22.6%22 width=%2230.8%22 height=%2230.8%22 rx=%226.4%22 fill=%22none%22 stroke=%22%23f5c542%22 stroke-opacity=%22.3%22 stroke-width=%221.2%22/%3E%3C/svg%3E">
 </head>
 <body>
   <div id="root"></div>

--- a/public/index.html
+++ b/public/index.html
@@ -3,14 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>RISC-V Extension Visualizer</title>
-  <!-- Favicon, inlined as a data URI on purpose.
-       The build has no copy plugin: HtmlWebpackPlugin emits this file and
-       webpack emits bundle.js, and nothing else in public/ reaches dist/. A
-       favicon.svg dropped alongside this file would 404 in production without
-       anything failing. Inlining keeps one source that cannot silently vanish.
-       Three ascending bars: the spread of extensions the landscape covers. -->
-  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 32 32%22%3E%3Crect width=%2232%22 height=%2232%22 rx=%227%22 fill=%22%2314141e%22/%3E%3Crect x=%225.5%22 y=%2218%22 width=%225%22 height=%228.5%22 rx=%221.6%22 fill=%22%23f5c542%22/%3E%3Crect x=%2213.5%22 y=%2212%22 width=%225%22 height=%2214.5%22 rx=%221.6%22 fill=%22%23f5c542%22/%3E%3Crect x=%2221.5%22 y=%225.5%22 width=%225%22 height=%2221%22 rx=%221.6%22 fill=%22%23f5c542%22/%3E%3Crect x=%22.6%22 y=%22.6%22 width=%2230.8%22 height=%2230.8%22 rx=%226.4%22 fill=%22none%22 stroke=%22%23f5c542%22 stroke-opacity=%22.3%22 stroke-width=%221.2%22/%3E%3C/svg%3E">
+  <title>RISC-V Extension Landscape</title>
+  <!-- Favicon: the official RISC-V mark, taken from the logo served by
+       docs.riscv.org and cropped to its square leading glyph. The full
+       wordmark is 6.3:1 and turns to mush below 128px; the mark alone stays
+       readable at 16.
+
+       Inlined as a data URI on purpose. The build has no copy plugin:
+       HtmlWebpackPlugin emits this file and webpack emits bundle.js, so a
+       favicon.svg dropped into public/ would 404 in production without
+       anything failing. One source, and it cannot silently go missing. -->
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%22-4 -4 85 85%22%3E%3Cpath d=%22M42.853 23.963c0 11.134-6.752 21.253-19.904 23.623l18.554 21.928 1.678-2.354 33.414-47.25V.005H22.273c13.828 1.35 20.58 12.818 20.58 23.958%22 fill=%22%23f3ab0d%22/%3E%3Cpath d=%22M52.292 73.221l24.631-34.417V76.6h-27.1zM4.728 37.455h12.818c9.44 0 14.172-6.74 14.172-13.492 0-6.758-4.732-13.165-14.172-13.165H0V76.6h32.738L4.728 42.858v-5.403M189.29 12.823h11.138v52.309h-11.139v-52.31m77.507 40.863l-57.933-.033v11.48h58.37c4.383 0 8.107-1.696 11.139-4.728 3.033-3.03 4.728-6.752 4.728-11.135s-1.695-8.09-4.728-11.14c-3.032-3.032-6.756-4.71-11.139-4.71l-42.462-.318a4.581 4.581 0 01-4.547-4.547 4.582 4.582 0 014.577-4.549l58.299-.042v-11.14h-58.373c-4.399 0-8.107 1.696-11.135 4.728-3.032 3.033-4.73 6.757-4.73 11.14 0 4.381 1.698 8.09 4.73 11.134 3.028 3.033 6.736 4.382 11.135 4.382l42.414.002a4.549 4.549 0 014.55 4.566 4.893 4.893 0 01-4.895 4.91m47.677-40.862h48.255v11.14h-48.255c-4.037 0-7.416 1.332-10.465 4.382-3.033 3.032-4.381 6.407-4.381 10.46 0 4.036 1.348 7.415 4.381 10.464 3.05 3.028 6.428 4.383 10.465 4.383h48.255l-.003 11.48h-48.228c-7.085 0-13.176-2.716-18.249-7.774-5.057-5.061-7.416-11.138-7.416-18.224 0-7.082 2.359-13.164 7.416-18.22 5.073-5.387 11.139-8.091 18.225-8.091M181.199 65.132L166.353 44.54c4.036-.334 7.415-1.683 10.119-4.716 3.032-3.045 4.727-6.753 4.727-11.134 0-4.383-1.695-8.107-4.727-11.14-3.033-3.032-6.757-4.728-11.14-4.728h-58.374v52.309h11.14V44.54h34.417l14.846 20.59zM164.665 33.83l-46.567-.083v-9.439l47.03-.095a4.6 4.6 0 014.608 4.577 5.062 5.062 0 01-5.07 5.04%22 fill=%22%23283272%22/%3E%3Cpath d=%22M418.399 65.132l-30.567-52.31h13.084l23.892 41.503 23.907-41.502h12.882l-30.381 52.309m-61.732-31.055h21.93v10.13h-21.93v-10.13%22 fill=%22%23f3ab0d%22/%3E%3Cpath d=%22M473.564 20.822h.88c1.03 0 1.861-.342 1.861-1.174 0-.734-.538-1.224-1.713-1.224-.49 0-.832.049-1.028.098zm-.05 4.553h-1.86v-8.028c.735-.146 1.763-.244 3.085-.244 1.517 0 2.202.244 2.79.587.44.343.782.979.782 1.762 0 .882-.684 1.567-1.664 1.86v.098c.784.293 1.224.881 1.469 1.958.245 1.224.392 1.714.587 2.007h-2.007c-.244-.293-.39-1.028-.636-1.958-.147-.881-.636-1.273-1.664-1.273h-.881zm-4.943-4.21c0 3.574 2.642 6.413 6.265 6.413 3.525 0 6.119-2.84 6.119-6.363 0-3.574-2.594-6.462-6.167-6.462-3.575 0-6.217 2.888-6.217 6.413zm14.44 0c0 4.553-3.574 8.126-8.223 8.126-4.601 0-8.273-3.573-8.273-8.125 0-4.455 3.672-8.029 8.273-8.029 4.65 0 8.223 3.574 8.223 8.029%22 fill=%22%23283272%22/%3E%3C/svg%3E">
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
The site had none: every visit requested `/favicon.ico`, got a **404**, and the tab showed the browser's blank-page glyph. The page title also still said *"RISC-V Extension Visualizer"* while the header, the repo and everything else said **Landscape**.

## The mark

The **official RISC-V logo**, taken from the file `docs.riscv.org` serves, cropped to its square leading glyph. Brand colours carried through untouched: `#f3ab0d` and `#283272`.

I originally drew a placeholder over a trademark concern. @rpsene is at RISC-V International, so first-party use on a RISC-V community tool is his call, and he made it.

**Why the glyph and not the full lockup:** the complete wordmark is 6.3:1 and turns to mush below 128px. Rendering them side by side made it obvious:

| candidate | 16px | verdict |
|---|---|---|
| full wordmark | unreadable smear | no |
| leading glyph | recognisable | **yes** |

The viewBox is padded by 4 units because the first crop clipped the gold chevron at larger sizes. Because the mark is navy *and* gold rather than a single tone, it reads on a light tab strip as well as a dark one — checked both.

## Why it's a data URI and not `public/favicon.svg`

Worth reviewing, because the obvious approach silently fails. **The build has no copy plugin.** `HtmlWebpackPlugin` emits `index.html`, webpack emits `bundle.js`, and *nothing else in `public/` reaches `dist/`*.

A `favicon.svg` dropped next to the template would 404 in production, with a green build and green tests. Inlining gives one source, 2.5 KB in the HTML, that cannot go missing.

(Adding `copy-webpack-plugin` is the alternative — a new dependency and build step for one file. Worth it if more static assets ever arrive; not for this.)

## Verified

- the data URI decodes to well-formed SVG, viewBox `-4 -4 85 85`, both brand colours intact
- the `<link>` survives the build into `dist/index.html`
- rendered at 16/24/32/64px on dark **and** light grounds
- `dist/index.html` title is `RISC-V Extension Landscape`

87 tests pass, build clean.