### PR TITLE
Stop remounting all 227 tiles on every interaction

### DIFF
--- a/src/ExtensionTile.jsx
+++ b/src/ExtensionTile.jsx
@@ -1,0 +1,158 @@
+/**
+ * ExtensionTile — one extension in the grid.
+ *
+ * This lived inside RISCVExplorer as a nested `const ExtensionBlock = …`. That
+ * is the React anti-pattern that made the page feel broken: a component defined
+ * in a render body is a NEW function on every render, React compares element
+ * types by reference, and a different reference reads as a different component
+ * type. The whole subtree gets unmounted and rebuilt rather than updated.
+ *
+ * With 227 tiles, every click, keystroke and toggle tore down and recreated 227
+ * subtrees. A user reported selections taking "seconds to minutes" on Chrome
+ * under macOS. Confirmed in the browser beforehand: after a click the tile DOM
+ * nodes were replaced rather than reused.
+ *
+ * Two things make this fast:
+ *
+ *   1. Defining it at module scope, so its identity is stable across renders
+ *      and React updates instead of remounting.
+ *   2. tilePropsAreEqual below, which compares each tile against ITS OWN state
+ *      rather than against container identity. workspaceIds is a fresh Set on
+ *      every change, so a shallow compare would re-render all 227 tiles; asking
+ *      "did membership change for THIS id" re-renders only what changed.
+ */
+import React from 'react';
+import { Plus } from 'lucide-react';
+import { tilePropsAreEqual } from './tileMemo.js';
+
+function ExtensionTile({
+  data,
+  colorClass,
+  searchQuery,
+  searchIndex,
+  selectedExtId,
+  workspaceIds,
+  lockedExtensions,
+  builderMode,
+  isHighlighted,
+  isDimmed,
+  onSelect,
+  onToggleWorkspace,
+}) {
+  const q = searchQuery.trim().toLowerCase();
+  const matchesSearch = q.length ? (searchIndex || '').includes(q) : false;
+
+  const isDiscontinued = data.discontinued === 1;
+  const isSelected = selectedExtId === data.id;
+  const highlighted = isHighlighted(data.id) || matchesSearch || isSelected;
+  const dimmed = isDimmed(data.id) && !matchesSearch && !isSelected;
+  const inWorkspace = workspaceIds.has(data.id);
+
+  return (
+    <div
+      id={`ext-${data.id}`}
+      onClick={() => onSelect(data)}
+      className={[
+        'ext-tile group relative rounded-lg border cursor-pointer select-none',
+        isSelected ? 'ext-tile-active' : '',
+        highlighted && !isSelected ? 'ext-tile-highlighted' : '',
+        dimmed ? 'opacity-20 grayscale pointer-events-none' : '',
+        isDiscontinued && !dimmed
+          ? 'border-[var(--riscv-border-2)] bg-[var(--riscv-surface)]'
+          : !dimmed ? colorClass : '',
+      ].join(' ')}
+      style={{
+        padding: '10px',
+        // Amber glow ring when in the builder
+        ...(inWorkspace && !isDiscontinued ? {
+          borderColor: 'rgba(245,197,66,0.55)',
+          boxShadow: '0 0 0 1px rgba(245,197,66,0.2), inset 0 0 12px rgba(245,197,66,0.04)',
+        } : {}),
+        transition: 'border-color 0.2s, box-shadow 0.2s',
+      }}
+    >
+      {/* EOL badge */}
+      {isDiscontinued && (
+        <span
+          className="absolute top-1.5 right-1.5 px-1.5 py-0.5 rounded text-[9px] font-mono uppercase tracking-wider"
+          style={{
+            background: 'rgba(255,77,107,0.12)',
+            color: '#ff7a8a',
+            border: '1px solid rgba(255,77,107,0.25)',
+          }}
+        >
+          EOL
+        </span>
+      )}
+
+      {/* Add/remove control — only while the builder is switched on */}
+      {builderMode && !isDiscontinued && (() => {
+        const isLocked = inWorkspace && lockedExtensions.has(data.id);
+        const lockedBy = isLocked ? lockedExtensions.get(data.id) : [];
+
+        // The unselected "+" is the call to action, so it carries the accent
+        // colour. Selected tiles keep the filled amber check; locked ones are
+        // dimmed to read as unavailable.
+        const accent = '#f5c542';
+        return (
+          <button
+            type="button"
+            data-in-workspace={inWorkspace ? 'true' : 'false'}
+            onClick={(e) => {
+              e.stopPropagation();
+              // The handler reports lock rejections itself.
+              onToggleWorkspace(data.id);
+            }}
+            className="workspace-tile-btn absolute top-1.5 right-1.5"
+            style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              width: 18, height: 18,
+              borderRadius: 5,
+              border: `1px solid ${isLocked ? 'rgba(245,197,66,0.3)' : 'rgba(245,197,66,0.6)'}`,
+              background: inWorkspace
+                ? (isLocked ? 'rgba(245,197,66,0.08)' : 'rgba(245,197,66,0.22)')
+                : 'rgba(245,197,66,0.14)',
+              backdropFilter: 'blur(4px)',
+              boxShadow: inWorkspace || isLocked ? 'none' : '0 0 0 2px rgba(245,197,66,0.12)',
+              color: isLocked ? 'rgba(245,197,66,0.5)' : accent,
+              cursor: isLocked ? 'not-allowed' : 'pointer',
+              transition: 'all 0.15s',
+              padding: 0,
+            }}
+            title={isLocked
+              ? `Required by ${lockedBy.join(', ')} — remove dependent first`
+              : (inWorkspace
+                ? `Remove ${data.id} from ISA Configuration Builder`
+                : `Add ${data.id} to ISA Configuration Builder`)}
+          >
+            {inWorkspace
+              ? (
+                <svg width="9" height="9" viewBox="0 0 9 9" fill="none">
+                  <path d="M1.5 4.5L3.5 6.5L7.5 2.5" stroke="#f5c542" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              )
+              : <Plus size={9} />
+            }
+          </button>
+        );
+      })()}
+
+      <div className="flex items-start justify-between mb-1">
+        <span
+          className="font-mono font-semibold text-[12px] leading-tight"
+          style={{ letterSpacing: '0.02em' }}
+        >
+          {data.name}
+        </span>
+      </div>
+      <div
+        className="text-[11px] leading-snug line-clamp-2"
+        style={{ color: 'var(--riscv-text-2)' }}
+      >
+        {data.desc}
+      </div>
+    </div>
+  );
+}
+
+export default React.memo(ExtensionTile, tilePropsAreEqual);

--- a/src/WorkspacePanel.jsx
+++ b/src/WorkspacePanel.jsx
@@ -35,6 +35,20 @@ import { buildIsaConfigYaml } from './exportUtils.js';
 // ---------------------------------------------------------------------------
 // WorkspacePanel
 // ---------------------------------------------------------------------------
+/**
+ * Sort direction indicator for the catalog table header.
+ *
+ * At module scope deliberately. It used to be declared inside WorkspacePanel,
+ * which made it a new component type on every render and remounted the icon
+ * each time. Same defect as the extension tile, smaller blast radius.
+ */
+function SortIcon({ col, sort }) {
+  if (sort.col !== col) return <ChevronsUpDown size={10} style={{ opacity: 0.3 }} />;
+  return sort.dir === 1
+    ? <ChevronUp size={10} style={{ color: 'var(--riscv-gold)' }} />
+    : <ChevronDown size={10} style={{ color: 'var(--riscv-gold)' }} />;
+}
+
 export default function WorkspacePanel({
   open,
   onClose,
@@ -146,13 +160,6 @@ export default function WorkspacePanel({
     setCatalogSort(prev =>
       prev.col === col ? { col, dir: -prev.dir } : { col, dir: 1 }
     );
-  }
-
-  function SortIcon({ col }) {
-    if (catalogSort.col !== col) return <ChevronsUpDown size={10} style={{ opacity: 0.3 }} />;
-    return catalogSort.dir === 1
-      ? <ChevronUp size={10} style={{ color: 'var(--riscv-gold)' }} />
-      : <ChevronDown size={10} style={{ color: 'var(--riscv-gold)' }} />;
   }
 
   if (!open) return null;
@@ -809,7 +816,7 @@ export default function WorkspacePanel({
                         onMouseEnter={e => e.currentTarget.style.color = '#64748b'}
                         onMouseLeave={e => e.currentTarget.style.color = catalogSort.col === col ? '#94a3b8' : '#334155'}
                       >
-                        {label} <SortIcon col={col} />
+                        {label} <SortIcon sort={catalogSort} col={col} />
                       </button>
                     ))}
                   </div>

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -43,6 +43,7 @@ import {
 } from 'lucide-react';
 import extensions from './riscv_extensions.json';
 import WorkspacePanel from './WorkspacePanel.jsx';
+import ExtensionTile from './ExtensionTile.jsx';
 // INCOMPATIBLE_WITH is no longer imported here: conflicts now come back from
 // resolveSelection(), which checks them over the resolved closure rather than
 // only over what the user clicked.
@@ -1561,15 +1562,15 @@ const RISCVExplorer = () => {
     setEncoderValidatorResult({ errors, proposed, conflicts });
   }, [allInstructionPatterns, encoderValidatorInput]);
 
-  const isHighlightedByProfile = (id) => {
+  const isHighlightedByProfile = React.useCallback((id) => {
     if (!activeProfile) return false;
     return profiles[activeProfile].includes(id);
-  };
+  }, [activeProfile]);
 
-  const isHighlightedByVolume = (id) => {
+  const isHighlightedByVolume = React.useCallback((id) => {
     if (!activeVolume) return false;
     return volumeMembership[activeVolume]?.has(id) ?? false;
-  };
+  }, [activeVolume, volumeMembership]);
 
   const extensionSearchIndexById = React.useMemo(() => {
     const index = new Map();
@@ -1620,136 +1621,52 @@ const RISCVExplorer = () => {
     return index;
   }, []);
 
-  const isHighlighted = (id) => {
-    return isHighlightedByProfile(id) || isHighlightedByVolume(id);
-  };
+  // Stable identities on purpose: these ride in tileProps, and a fresh function
+  // each render would make every tile re-render even when nothing it shows moved.
+  const isHighlighted = React.useCallback(
+    (id) => isHighlightedByProfile(id) || isHighlightedByVolume(id),
+    [isHighlightedByProfile, isHighlightedByVolume],
+  );
 
-  const isDimmed = (id) => {
+  const isDimmed = React.useCallback((id) => {
     if (activeVolume) return false;
     if (!activeProfile) return false;
     return !profiles[activeProfile].includes(id);
-  };
+  }, [activeVolume, activeProfile]);
 
-  const ExtensionBlock = ({ data, colorClass, searchQuery }) => {
-    const q = searchQuery.trim().toLowerCase();
-    const searchIndex = extensionSearchIndexById.get(data.id) || '';
-    const matchesSearch = q.length ? searchIndex.includes(q) : false;
+  // The tile lives in ./ExtensionTile.jsx. It used to be defined here, inside
+  // the render body, which meant a new component type on every render and a
+  // full unmount/remount of all 227 tiles for every click and keystroke.
+  //
+  // These props are memoised so the tile's comparator can do its job: stable
+  // identities for everything shared, and the tile itself asks only whether ITS
+  // own id changed membership.
+  const handleSelectExt = React.useCallback((data) => {
+    setSelectedExt((current) => {
+      const next = current?.id === data.id ? null : data;
+      setSelectedInstruction(null);
+      setSearchMatches(null);
+      return next;
+    });
+  }, []);
 
-    const isDiscontinued = data.discontinued === 1;
-    const isSelected = selectedExt?.id === data.id;
-    const highlighted = isHighlighted(data.id) || matchesSearch || isSelected;
-    const dimmed = isDimmed(data.id) && !matchesSearch && !isSelected;
-    const inWorkspace = workspaceIds.has(data.id);
+  const handleToggleWorkspace = React.useCallback((id) => {
+    addWorkspaceIdsSmart(id, true);
+  }, [addWorkspaceIdsSmart]);
 
-    return (
-      <div
-        id={`ext-${data.id}`}
-        onClick={() =>
-          setSelectedExt((current) => {
-            const next = current?.id === data.id ? null : data;
-            setSelectedInstruction(null);
-            setSearchMatches(null);
-            return next;
-          })
-        }
-        className={[
-          'ext-tile group relative rounded-lg border cursor-pointer select-none',
-          isSelected ? 'ext-tile-active' : '',
-          highlighted && !isSelected ? 'ext-tile-highlighted' : '',
-          dimmed ? 'opacity-20 grayscale pointer-events-none' : '',
-          isDiscontinued && !dimmed
-            ? 'border-[var(--riscv-border-2)] bg-[var(--riscv-surface)]'
-            : !dimmed ? colorClass : '',
-        ].join(' ')}
-        style={{
-          padding: '10px',
-          // Amber glow ring when in workspace
-          ...(inWorkspace && !isDiscontinued ? {
-            borderColor: 'rgba(245,197,66,0.55)',
-            boxShadow: '0 0 0 1px rgba(245,197,66,0.2), inset 0 0 12px rgba(245,197,66,0.04)',
-          } : {}),
-          transition: 'border-color 0.2s, box-shadow 0.2s',
-        }}
-      >
-        {/* EOL badge */}
-        {isDiscontinued && (
-          <span
-            className="absolute top-1.5 right-1.5 px-1.5 py-0.5 rounded text-[9px] font-mono uppercase tracking-wider"
-            style={{
-              background: 'rgba(255,77,107,0.12)',
-              color: '#ff7a8a',
-              border: '1px solid rgba(255,77,107,0.25)',
-            }}
-          >
-            EOL
-          </span>
-        )}
+  const tileProps = React.useMemo(() => ({
+    searchQuery,
+    selectedExtId: selectedExt?.id ?? null,
+    workspaceIds,
+    lockedExtensions,
+    builderMode,
+    isHighlighted,
+    isDimmed,
+    onSelect: handleSelectExt,
+    onToggleWorkspace: handleToggleWorkspace,
+  }), [searchQuery, selectedExt, workspaceIds, lockedExtensions, builderMode,
+       isHighlighted, isDimmed, handleSelectExt, handleToggleWorkspace]);
 
-        {/* ── ISA Workspace badge — only while the builder is switched on ── */}
-        {builderMode && !isDiscontinued && (() => {
-          const isLocked = inWorkspace && lockedExtensions.has(data.id);
-          const lockedBy = isLocked ? lockedExtensions.get(data.id) : [];
-
-          // The unselected "+" is the call to action, so it carries the accent
-          // colour rather than the grey it used to have. Selected tiles keep the
-          // filled amber check; locked ones are dimmed to read as unavailable.
-          const accent = '#f5c542';
-          return (
-            <button
-              type="button"
-              data-in-workspace={inWorkspace ? 'true' : 'false'}
-              onClick={(e) => {
-                e.stopPropagation();
-                // addWorkspaceIdsSmart handles the lock rejection/toast internally for clicks
-                addWorkspaceIdsSmart(data.id, true);
-              }}
-              className="workspace-tile-btn absolute top-1.5 right-1.5"
-              style={{
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
-                width: 18, height: 18,
-                borderRadius: 5,
-                border: `1px solid ${isLocked ? 'rgba(245,197,66,0.3)' : 'rgba(245,197,66,0.6)'}`,
-                background: inWorkspace
-                  ? (isLocked ? 'rgba(245,197,66,0.08)' : 'rgba(245,197,66,0.22)')
-                  : 'rgba(245,197,66,0.14)',
-                backdropFilter: 'blur(4px)',
-                boxShadow: inWorkspace || isLocked ? 'none' : '0 0 0 2px rgba(245,197,66,0.12)',
-                color: isLocked ? 'rgba(245,197,66,0.5)' : accent,
-                cursor: isLocked ? 'not-allowed' : 'pointer',
-                transition: 'all 0.15s',
-                padding: 0,
-              }}
-              title={isLocked ? `Required by ${lockedBy.join(', ')} — remove dependent first` : (inWorkspace ? `Remove ${data.id} from ISA Configuration Builder` : `Add ${data.id} to ISA Configuration Builder`)}
-            >
-              {inWorkspace
-                ? (
-                  <svg width="9" height="9" viewBox="0 0 9 9" fill="none">
-                    <path d="M1.5 4.5L3.5 6.5L7.5 2.5" stroke="#f5c542" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                  </svg>
-                )
-                : <Plus size={9} />
-              }
-            </button>
-          );
-        })()}
-
-        <div className="flex items-start justify-between mb-1">
-          <span
-            className="font-mono font-semibold text-[12px] leading-tight"
-            style={{ letterSpacing: '0.02em' }}
-          >
-            {data.name}
-          </span>
-        </div>
-        <div
-          className="text-[11px] leading-snug line-clamp-2"
-          style={{ color: 'var(--riscv-text-2)' }}
-        >
-          {data.desc}
-        </div>
-      </div>
-    );
-  };
 
 
 
@@ -2318,10 +2235,11 @@ const RISCVExplorer = () => {
               </div>
               <div className="grid grid-cols-2 md:grid-cols-5 gap-2">
                 {extensions.base.map((item) => (
-                  <ExtensionBlock
+                  <ExtensionTile
                     key={item.id}
                     data={item}
-                    searchQuery={searchQuery}
+                    searchIndex={extensionSearchIndexById.get(item.id)}
+                    {...tileProps}
                     colorClass="border-blue-900/60 bg-blue-950/40 text-blue-100"
                   />
                 ))}
@@ -2337,10 +2255,11 @@ const RISCVExplorer = () => {
               </div>
               <div className="grid grid-cols-4 md:grid-cols-8 gap-2">
                 {extensions.standard.map((item) => (
-                  <ExtensionBlock
+                  <ExtensionTile
                     key={item.id}
                     data={item}
-                    searchQuery={searchQuery}
+                    searchIndex={extensionSearchIndexById.get(item.id)}
+                    {...tileProps}
                     colorClass="border-emerald-900/60 bg-emerald-950/40 text-emerald-100"
                   />
                 ))}
@@ -2360,10 +2279,11 @@ const RISCVExplorer = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {extensions.z_bit.map((item) => (
-                    <ExtensionBlock
+                    <ExtensionTile
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchIndex={extensionSearchIndexById.get(item.id)}
+                      {...tileProps}
                       colorClass="border-purple-900/60 bg-purple-950/30 text-purple-100"
                     />
                   ))}
@@ -2378,10 +2298,11 @@ const RISCVExplorer = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {extensions.z_atomics.map((item) => (
-                    <ExtensionBlock
+                    <ExtensionTile
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchIndex={extensionSearchIndexById.get(item.id)}
+                      {...tileProps}
                       colorClass="border-amber-900/60 bg-amber-950/30 text-amber-100"
                     />
                   ))}
@@ -2396,10 +2317,11 @@ const RISCVExplorer = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {extensions.z_compress.map((item) => (
-                    <ExtensionBlock
+                    <ExtensionTile
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchIndex={extensionSearchIndexById.get(item.id)}
+                      {...tileProps}
                       colorClass="border-indigo-900/60 bg-indigo-950/30 text-indigo-100"
                     />
                   ))}
@@ -2414,10 +2336,11 @@ const RISCVExplorer = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {extensions.z_float.map((item) => (
-                    <ExtensionBlock
+                    <ExtensionTile
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchIndex={extensionSearchIndexById.get(item.id)}
+                      {...tileProps}
                       colorClass="border-pink-900/60 bg-pink-950/30 text-pink-100"
                     />
                   ))}
@@ -2432,10 +2355,11 @@ const RISCVExplorer = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {extensions.z_load_store.map((item) => (
-                    <ExtensionBlock
+                    <ExtensionTile
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchIndex={extensionSearchIndexById.get(item.id)}
+                      {...tileProps}
                       colorClass="border-sky-900/60 bg-sky-950/30 text-sky-100"
                     />
                   ))}
@@ -2450,10 +2374,11 @@ const RISCVExplorer = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {extensions.z_integer.map((item) => (
-                    <ExtensionBlock
+                    <ExtensionTile
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchIndex={extensionSearchIndexById.get(item.id)}
+                      {...tileProps}
                       colorClass="border-fuchsia-900/60 bg-fuchsia-950/30 text-fuchsia-100"
                     />
                   ))}
@@ -2468,10 +2393,11 @@ const RISCVExplorer = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {extensions.z_vector.map((item) => (
-                    <ExtensionBlock
+                    <ExtensionTile
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchIndex={extensionSearchIndexById.get(item.id)}
+                      {...tileProps}
                       colorClass="border-teal-900/60 bg-teal-950/30 text-teal-100"
                     />
                   ))}
@@ -2486,10 +2412,11 @@ const RISCVExplorer = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {extensions.z_security.map((item) => (
-                    <ExtensionBlock
+                    <ExtensionTile
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchIndex={extensionSearchIndexById.get(item.id)}
+                      {...tileProps}
                       colorClass="border-red-900/60 bg-red-950/30 text-red-100"
                     />
                   ))}
@@ -2504,10 +2431,11 @@ const RISCVExplorer = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {extensions.z_crypto.map((item) => (
-                    <ExtensionBlock
+                    <ExtensionTile
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchIndex={extensionSearchIndexById.get(item.id)}
+                      {...tileProps}
                       colorClass="border-[var(--riscv-border-2)] bg-[var(--riscv-surface-2)] text-slate-300"
                     />
                   ))}
@@ -2522,10 +2450,11 @@ const RISCVExplorer = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {extensions.z_vector_crypto.map((item) => (
-                    <ExtensionBlock
+                    <ExtensionTile
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchIndex={extensionSearchIndexById.get(item.id)}
+                      {...tileProps}
                       colorClass="border-violet-900/60 bg-violet-950/30 text-violet-100"
                     />
                   ))}
@@ -2540,10 +2469,11 @@ const RISCVExplorer = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {extensions.z_system.map((item) => (
-                    <ExtensionBlock
+                    <ExtensionTile
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchIndex={extensionSearchIndexById.get(item.id)}
+                      {...tileProps}
                       colorClass="border-orange-900/60 bg-orange-950/30 text-orange-100"
                     />
                   ))}
@@ -2558,10 +2488,11 @@ const RISCVExplorer = () => {
                 </div>
                 <div className="grid grid-cols-2 gap-2">
                   {extensions.z_caches.map((item) => (
-                    <ExtensionBlock
+                    <ExtensionTile
                       key={item.id}
                       data={item}
-                      searchQuery={searchQuery}
+                      searchIndex={extensionSearchIndexById.get(item.id)}
+                      {...tileProps}
                       colorClass="border-orange-900/40 bg-orange-950/20 text-orange-100"
                     />
                   ))}
@@ -2587,10 +2518,11 @@ const RISCVExplorer = () => {
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     {extensions.s_mem.map((item) => (
-                      <ExtensionBlock
+                      <ExtensionTile
                         key={item.id}
                         data={item}
-                        searchQuery={searchQuery}
+                        searchIndex={extensionSearchIndexById.get(item.id)}
+                        {...tileProps}
                         colorClass="border-cyan-900/50 bg-cyan-950/20 text-cyan-100"
                       />
                     ))}
@@ -2604,10 +2536,11 @@ const RISCVExplorer = () => {
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     {extensions.s_interrupt.map((item) => (
-                      <ExtensionBlock
+                      <ExtensionTile
                         key={item.id}
                         data={item}
-                        searchQuery={searchQuery}
+                        searchIndex={extensionSearchIndexById.get(item.id)}
+                        {...tileProps}
                         colorClass="border-cyan-900/50 bg-cyan-950/20 text-cyan-100"
                       />
                     ))}
@@ -2621,10 +2554,11 @@ const RISCVExplorer = () => {
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     {extensions.s_trap.map((item) => (
-                      <ExtensionBlock
+                      <ExtensionTile
                         key={item.id}
                         data={item}
-                        searchQuery={searchQuery}
+                        searchIndex={extensionSearchIndexById.get(item.id)}
+                        {...tileProps}
                         colorClass="border-cyan-900/50 bg-cyan-950/20 text-cyan-100"
                       />
                     ))}

--- a/src/tileMemo.js
+++ b/src/tileMemo.js
@@ -1,0 +1,41 @@
+/**
+ * The memo comparator for ExtensionTile.
+ *
+ * Kept in a plain .js file, apart from the component, for two reasons. It is
+ * pure logic rather than rendering, and node's test runner cannot import .jsx —
+ * so living here is what makes the behaviour testable without pulling in a
+ * transform or a DOM library.
+ *
+ * Why a custom comparator rather than React.memo's default shallow compare:
+ * workspaceIds and lockedExtensions are rebuilt wholesale on every change, so a
+ * shallow compare sees new objects and re-renders all 227 tiles whenever any one
+ * of them moves. Asking instead "did membership change for THIS id" means
+ * selecting D repaints the D tile and nothing else.
+ */
+
+/** True when the tile can be skipped. */
+export function tilePropsAreEqual(prev, next) {
+  if (prev.data !== next.data) return false;
+  if (prev.colorClass !== next.colorClass) return false;
+  if (prev.searchQuery !== next.searchQuery) return false;
+  if (prev.builderMode !== next.builderMode) return false;
+  if (prev.selectedExtId !== next.selectedExtId) return false;
+  if (prev.searchIndex !== next.searchIndex) return false;
+  if (prev.onSelect !== next.onSelect) return false;
+  if (prev.onToggleWorkspace !== next.onToggleWorkspace) return false;
+  if (prev.isHighlighted !== next.isHighlighted) return false;
+  if (prev.isDimmed !== next.isDimmed) return false;
+
+  // Per-tile membership, not container identity. This is the whole point.
+  const id = next.data?.id;
+  if (prev.workspaceIds.has(id) !== next.workspaceIds.has(id)) return false;
+  if (prev.lockedExtensions.has(id) !== next.lockedExtensions.has(id)) return false;
+
+  // The tooltip names who requires this extension, so a change in the reason is
+  // user-visible even when the locked flag itself has not moved.
+  const prevLock = prev.lockedExtensions.get(id);
+  const nextLock = next.lockedExtensions.get(id);
+  if ((prevLock?.length ?? 0) !== (nextLock?.length ?? 0)) return false;
+
+  return true;
+}

--- a/tests/extension-tile.test.mjs
+++ b/tests/extension-tile.test.mjs
@@ -1,0 +1,128 @@
+/**
+ * The tile's render behaviour, tested without a DOM.
+ *
+ * A user reported selections taking "seconds to minutes" on Chrome under macOS.
+ * The cause was ExtensionBlock being defined inside RISCVExplorer's render body:
+ * a new function reference every render, so React saw a new component type and
+ * unmounted and rebuilt all 227 tiles instead of updating them. Confirmed in the
+ * browser first, by checking whether tile DOM nodes were reused after a click.
+ *
+ * There is no DOM or React testing library here, and adding one would be a large
+ * dependency for a small surface. Two things are testable as they stand, and
+ * between them they cover the regression:
+ *
+ *   1. tilePropsAreEqual is a pure function and carries the whole optimisation.
+ *   2. Whether a component is declared inside another is a property of the
+ *      source, so it can be asserted by reading the file.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { tilePropsAreEqual } from '../src/tileMemo.js';
+
+const here = path.dirname(new URL(import.meta.url).pathname);
+const srcDir = path.join(here, '..', 'src');
+
+const baseProps = (over = {}) => ({
+  data: { id: 'Zfa', name: 'Zfa', desc: 'Additional FP Instructions' },
+  colorClass: 'border-blue-900/60',
+  searchQuery: '',
+  searchIndex: 'zfa additional fp instructions',
+  selectedExtId: null,
+  workspaceIds: new Set(),
+  lockedExtensions: new Map(),
+  builderMode: false,
+  isHighlighted: () => false,
+  isDimmed: () => false,
+  onSelect: () => {},
+  onToggleWorkspace: () => {},
+  ...over,
+});
+
+test('identical props skip the re-render', () => {
+  const a = baseProps();
+  assert.equal(tilePropsAreEqual(a, { ...a }), true);
+});
+
+test('a new Set with the same membership still skips', () => {
+  // The heart of it. workspaceIds is rebuilt on every change, so comparing it
+  // by identity would re-render all 227 tiles whenever any one of them moved.
+  const prev = baseProps({ workspaceIds: new Set(['D', 'F']) });
+  const next = baseProps({ ...prev, workspaceIds: new Set(['D', 'F']) });
+  assert.notEqual(prev.workspaceIds, next.workspaceIds, 'the Sets must be different objects');
+  assert.equal(tilePropsAreEqual(prev, next), true, 'same membership should not re-render');
+});
+
+test('a tile re-renders when its own membership changes', () => {
+  const prev = baseProps({ workspaceIds: new Set() });
+  const next = baseProps({ ...prev, workspaceIds: new Set(['Zfa']) });
+  assert.equal(tilePropsAreEqual(prev, next), false);
+});
+
+test('a tile does NOT re-render when a different tile changes', () => {
+  // Selecting D must not repaint Zfa. This is what turns one click from 227
+  // renders into one.
+  const prev = baseProps({ workspaceIds: new Set(['F']) });
+  const next = baseProps({ ...prev, workspaceIds: new Set(['F', 'D']) });
+  assert.equal(tilePropsAreEqual(prev, next), true);
+});
+
+test('lock state and its reason are both tracked', () => {
+  const unlocked = baseProps({ lockedExtensions: new Map() });
+  const locked = baseProps({ ...unlocked, lockedExtensions: new Map([['Zfa', ['Q']]]) });
+  assert.equal(tilePropsAreEqual(unlocked, locked), false, 'becoming locked must re-render');
+
+  // The tooltip names who requires it, so the reason changing is user-visible
+  // even though the locked flag itself did not move.
+  const lockedByTwo = baseProps({ ...unlocked, lockedExtensions: new Map([['Zfa', ['Q', 'D']]]) });
+  assert.equal(tilePropsAreEqual(locked, lockedByTwo), false, 'a changed reason must re-render');
+});
+
+test('everything the tile displays forces a re-render when it changes', () => {
+  const base = baseProps();
+  const changes = {
+    data: { id: 'Zfa', name: 'Zfa', desc: 'changed' },
+    colorClass: 'border-red-900',
+    searchQuery: 'zf',
+    searchIndex: 'different',
+    selectedExtId: 'Zfa',
+    builderMode: true,
+    isHighlighted: () => true,
+    isDimmed: () => true,
+    onSelect: () => {},
+    onToggleWorkspace: () => {},
+  };
+  for (const [key, value] of Object.entries(changes)) {
+    assert.equal(
+      tilePropsAreEqual(base, baseProps({ [key]: value })),
+      false,
+      `${key} changed but the tile would not re-render`,
+    );
+  }
+});
+
+test('no component is declared inside another component', () => {
+  // The original defect, as a property of the source. A capitalised arrow
+  // function or function declaration indented inside another component body is
+  // a new type on every render, which remounts its whole subtree.
+  const offenders = [];
+  for (const file of fs.readdirSync(srcDir).filter((f) => /\.jsx?$/.test(f))) {
+    const lines = fs.readFileSync(path.join(srcDir, file), 'utf8').split('\n');
+    lines.forEach((line, i) => {
+      const m = line.match(
+        /^\s+(?:const|let|function)\s+([A-Z][A-Za-z0-9]*)\s*(?:=\s*(?:React\.)?(?:memo\()?\(?[^)]*\)?\s*=>|\()/,
+      );
+      if (!m) return;
+      // A memoised or hook-wrapped binding keeps a stable identity, so it is fine.
+      if (/React\.(memo|useMemo|useCallback)/.test(line)) return;
+      offenders.push(`${file}:${i + 1}  ${m[1]}`);
+    });
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    'components must live at module scope, or React remounts their subtree every render:\n  '
+      + offenders.join('\n  '),
+  );
+});


### PR DESCRIPTION
A user reported selections taking **"seconds to minutes"** on Chrome under macOS.

## It was not the data work

Measured that first:

```
resolveSelection, 54 extensions  : 0.23 ms
buildCombinedCatalog, 965 instr  : 0.88 ms
```

## The cause

`ExtensionBlock` was declared **inside** `RISCVExplorer`'s render body. A component defined in a render body is a new function on every render; React compares element types by reference, so a new reference reads as a **new component type** and the whole subtree is unmounted and rebuilt rather than updated.

Every click, keystroke and toggle tore down and recreated **227 tile subtrees**.

Confirmed in the browser rather than assumed — by stamping the tile nodes and checking whether they survived a click:

| | result |
|---|---|
| **before** | tile DOM **replaced** — 0/227 nodes reused |
| **after** | **227/227 nodes reused**, same first node, 10 clicks in **1.7 ms** total |

## The fix, in two halves

**1. Module scope.** The tile moves to `src/ExtensionTile.jsx`, taking what it used to close over as props. Stable identity means React updates instead of remounting.

**2. A comparator that asks the right question.** `workspaceIds` and `lockedExtensions` are rebuilt wholesale on every change, so `React.memo`'s default shallow compare would *still* re-render all 227 tiles whenever any one moved. Ours asks whether membership changed **for this id**, so selecting `D` repaints the `D` tile and nothing else. `isHighlighted`, `isDimmed` and both handlers are wrapped in `useCallback` for the same reason — an unstable identity would defeat it.

The comparator lives in `src/tileMemo.js`, apart from the component: it's pure logic, and node's test runner cannot import `.jsx`, so keeping it separate is what makes it testable at all.

## Tests

No DOM or React testing library added — that's a large dependency for one component. Two things are testable as they stand and between them cover the regression:

- **`tilePropsAreEqual` directly**, including the case that matters: a *fresh Set with unchanged membership* must **not** re-render, and a change to a *different* extension must not touch this tile.
- **A source guard** that fails if any component is declared inside another.

The guard immediately found **a second instance I had not noticed** — `SortIcon` inside `WorkspacePanel` — which is hoisted here too.

## One thing worth recording

My first pass at rewriting the 17 call sites used a literal, indentation-sensitive match and hit only **2 of them**, leaving `searchQuery` undefined and the grid blank. **The test suite was green throughout**, because nothing in it renders. That is exactly what the browser check is for, and why the numbers above are measured rather than reasoned.

94 tests pass. Verified afterwards in the browser that all 227 tiles render, selection still resolves dependencies, and the builder still works.