### PR TITLE
Implementation parameters, and a VLEN you can actually set

### DIFF
--- a/scripts/seed-dependency-graph.mjs
+++ b/scripts/seed-dependency-graph.mjs
@@ -68,6 +68,10 @@ function extensionRequirements(requirements) {
   const choices = [];
   const conditional = [];
   const excluded = [];
+  // Implementation parameters the extension constrains. These are not
+  // dependencies — VLEN is not an extension — but they are the other half of
+  // what makes a configuration real, and UDB states them right here.
+  const params = [];
 
   /**
    * True when every member names an extension and nothing else. Two spellings
@@ -115,6 +119,15 @@ function extensionRequirements(requirements) {
           if (!negated) hard.push(value);
           else if (!guarded) excluded.push(value);
           break;
+        case 'param':
+          // { name: VLEN, greaterThanOrEqual: 128 } and friends. Only taken
+          // from unguarded, unnegated positions, same rule as extensions.
+          if (!negated && !guarded && value && typeof value.name === 'string') {
+            const { name, reason, ...rest } = value;
+            const [kind, bound] = Object.entries(rest)[0] ?? [];
+            if (kind) params.push({ name, kind, value: bound, ...(reason ? { reason } : {}) });
+          }
+          break;
         case 'allOf':
           walk(value, negated, guarded);
           break;
@@ -159,7 +172,7 @@ function extensionRequirements(requirements) {
   };
 
   walk(requirements);
-  return { hard, choices, conditional, excluded };
+  return { hard, choices, conditional, excluded, params };
 }
 
 function readUdb(root) {
@@ -175,12 +188,18 @@ function readUdb(root) {
     const hard = new Set();
     const choices = [];
     const excluded = new Set();
+    const params = [];
     let skipped = 0;
     for (const req of [doc.requirements, ...(doc.versions ?? []).map((v) => v?.requirements)]) {
       if (!req) continue;
       const found = extensionRequirements(req);
       found.hard.forEach((n) => hard.add(n));
       found.excluded.forEach((n) => excluded.add(n));
+      for (const prm of found.params) {
+        if (!params.some((x) => x.name === prm.name && x.kind === prm.kind && x.value === prm.value)) {
+          params.push(prm);
+        }
+      }
       skipped += found.conditional.length;
       for (const options of found.choices) {
         const key = options.slice().sort().join('|');
@@ -189,12 +208,13 @@ function readUdb(root) {
     }
     hard.delete(id); // a few files name themselves via version constraints
     if (skipped) conditionalNodes.push(`${id} (${skipped} group${skipped > 1 ? 's' : ''})`);
-    if (hard.size || choices.length || excluded.size || skipped) {
+    if (hard.size || choices.length || excluded.size || skipped || params.length) {
       graph[id] = {
         hard: [...hard].sort(),
         choices,
         excluded: [...excluded].sort(),
         conditional: skipped > 0,
+        params,
       };
     }
   }
@@ -302,6 +322,9 @@ for (const id of catalogIds.slice().sort((a, b) => a.localeCompare(b))) {
   // never read as "UDB says this extension depends on nothing" when what UDB
   // actually says is "it depends, conditionally".
   if (udb[id]?.conditional) node.conditionalRequirements = true;
+  if (udb[id]?.params?.length) {
+    node.params = udb[id].params.map((prm) => ({ ...prm, src: 'udb', ref: `${id}.yaml requirements … param` }));
+  }
 
   if (requires.length === 0 && !node.requiresOneOf && !node.conditionalRequirements) {
     node.verified = udbKnown.has(id) ? 'udb' : 'none';

--- a/src/WorkspacePanel.jsx
+++ b/src/WorkspacePanel.jsx
@@ -22,6 +22,7 @@ import {
   ChevronDown,
   ChevronsUpDown,
   Zap,
+  Sliders,
 } from 'lucide-react';
 
 import {
@@ -31,6 +32,7 @@ import {
   DATA_PROVENANCE,
 } from './marchUtils.js';
 import { buildIsaConfigYaml } from './exportUtils.js';
+import { resolveParams, impliedVlen, vlenExtension } from './isaGraph.js';
 
 // ---------------------------------------------------------------------------
 // WorkspacePanel
@@ -740,6 +742,86 @@ export default function WorkspacePanel({
               </div>
             )}
           </Section>
+
+          {/* Implementation parameters */}
+          {!isEmpty && (() => {
+            const ids = Array.from(workspaceIds);
+            const params = resolveParams(ids);
+            const vlen = impliedVlen(ids);
+            const VLEN_CHOICES = [32, 64, 128, 256, 512, 1024];
+            return (
+              <>
+                <Divider />
+                <Section label="Implementation Parameters" count={params.length} icon={<Sliders size={11} />}>
+                  {/* Vector length first: it is the one parameter -march can
+                      carry, and the one people come looking for. It is set by
+                      picking a Zvl*b extension, which is not obvious. */}
+                  <div style={{ marginBottom: params.length ? 14 : 0 }}>
+                    <div style={{ fontSize: 11, color: 'var(--riscv-text-2)', marginBottom: 6 }}>
+                      Vector length (VLEN)
+                      {vlen
+                        ? <span style={{ color: 'var(--riscv-gold)', fontWeight: 700 }}>{`  ≥ ${vlen} bits`}</span>
+                        : <span style={{ color: 'var(--riscv-text-3)' }}>  not constrained — no vector extension selected</span>}
+                    </div>
+                    <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+                      {VLEN_CHOICES.map((bits) => {
+                        const ext = vlenExtension(bits);
+                        const active = vlen === bits;
+                        return (
+                          <button
+                            key={bits}
+                            type="button"
+                            onClick={() => ext && onAddId(ext)}
+                            title={`Set VLEN ≥ ${bits} by adding ${ext}`}
+                            style={{
+                              fontSize: 11, fontFamily: 'monospace', padding: '4px 9px', borderRadius: 6,
+                              cursor: 'pointer',
+                              border: `1px solid ${active ? 'rgba(245,197,66,0.6)' : 'rgba(255,255,255,0.12)'}`,
+                              background: active ? 'rgba(245,197,66,0.18)' : 'rgba(255,255,255,0.03)',
+                              color: active ? 'var(--riscv-gold)' : 'var(--riscv-text-2)',
+                            }}
+                          >
+                            {bits}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    <div style={{ fontSize: 10, color: 'var(--riscv-text-3)', marginTop: 6 }}>
+                      There is no VLEN flag. Vector length is expressed by the Zvl*b extensions,
+                      so choosing one here adds it to the configuration.
+                    </div>
+                  </div>
+
+                  {params.length > 0 && (
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                      {params.map((prm) => (
+                        <div key={prm.name} style={{
+                          borderRadius: 7, padding: '8px 10px',
+                          background: prm.conflict ? 'rgba(255,77,107,0.08)' : 'rgba(255,255,255,0.02)',
+                          border: `1px solid ${prm.conflict ? 'rgba(255,77,107,0.3)' : 'rgba(255,255,255,0.06)'}`,
+                        }}>
+                          <div style={{ display: 'flex', justifyContent: 'space-between', gap: 10 }}>
+                            <span style={{ fontFamily: 'monospace', fontSize: 11, color: 'var(--riscv-text)' }}>{prm.name}</span>
+                            <span style={{ fontFamily: 'monospace', fontSize: 11, color: 'var(--riscv-gold)' }}>
+                              {prm.kind === 'greaterThanOrEqual' ? `≥ ${prm.value}`
+                                : Array.isArray(prm.value) ? prm.value.length === 1 ? String(prm.value[0]) : `one of ${prm.value.length}`
+                                : String(prm.value)}
+                            </span>
+                          </div>
+                          <div style={{ fontSize: 10, color: 'var(--riscv-text-3)', marginTop: 3 }}>
+                            required by {prm.from.join(', ')}
+                          </div>
+                          {prm.conflict && (
+                            <div style={{ fontSize: 10, color: '#ff7a8a', marginTop: 4 }}>{prm.conflict}</div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </Section>
+              </>
+            );
+          })()}
 
           {/* Instruction catalog tab */}
           {!isEmpty && (

--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -16,6 +16,7 @@
 
 import { buildMarchString, BASE_ISA_IDS, BASE_ISA_PREFIX_MAP } from './marchUtils.js';
 import { buildCombinedCatalog } from './marchUtils.js';
+import { resolveParams } from './isaGraph.js';
 
 // Tokens that are not valid ISA string entries (e.g. K, P are retired/placeholder)
 const INVALID_ISA_TOKENS = new Set(['K', 'P']);
@@ -167,6 +168,35 @@ export function buildIsaConfigYaml(selectedIds, allExts, includeInstructions = t
   lines.push(`# Zicsr/Zifencei present → User Spec 2.3+; supervisor exts → Priv Spec 1.11+`);
   lines.push(`user_spec_version: "${userSpecVersion}"`);
   lines.push(`privilege_spec_version: "${privSpecVersion}"`);
+  lines.push(``);
+  lines.push(`# Implementation parameters the selection constrains, from`);
+  lines.push(`# riscv-unified-db. -march can express only VLEN, and only obliquely`);
+  lines.push(`# through the Zvl*b extensions, so these are the part of the`);
+  lines.push(`# configuration a compiler flag cannot carry.`);
+  lines.push(`#`);
+  lines.push(`#   greaterThanOrEqual — a floor; the largest wins`);
+  lines.push(`#   includes           — the value must offer at least these`);
+  lines.push(`#   oneOf              — pick one; each extension narrows the field`);
+  lines.push(`#   equal              — fixed`);
+  const params = resolveParams(selectedIds);
+  if (params.length === 0) {
+    lines.push(`parameters: {}   # nothing in this selection constrains one`);
+  } else {
+    lines.push(`parameters:`);
+    for (const prm of params) {
+      lines.push(`  ${prm.name}:`);
+      lines.push(`    constraint: ${prm.kind}`);
+      const value = Array.isArray(prm.value)
+        ? `[${prm.value.map((v) => (typeof v === 'string' ? JSON.stringify(v) : v)).join(', ')}]`
+        : (typeof prm.value === 'string' ? JSON.stringify(prm.value) : prm.value);
+      lines.push(`    value: ${value}`);
+      lines.push(`    required_by: [${prm.from.join(', ')}]`);
+      if (prm.reason) lines.push(`    reason: ${JSON.stringify(prm.reason)}`);
+      // A conflict is left in the file on purpose: silently dropping it would
+      // produce a configuration that looks valid and is not.
+      if (prm.conflict) lines.push(`    CONFLICT: ${JSON.stringify(prm.conflict)}`);
+    }
+  }
   lines.push(``);
   lines.push(`extensions:`);
   for (const ext of allExtsList) {

--- a/src/isa-dependency-graph.json
+++ b/src/isa-dependency-graph.json
@@ -248,6 +248,15 @@
           "src": "udb",
           "ref": "Shtvala.yaml requirements.extension"
         }
+      ],
+      "params": [
+        {
+          "name": "REPORT_GPA_IN_HTVAL_ON_GUEST_PAGE_FAULT",
+          "kind": "equal",
+          "value": true,
+          "src": "udb",
+          "ref": "Shtvala.yaml requirements … param"
+        }
       ]
     },
     "Shvsatpa": {
@@ -265,6 +274,15 @@
     },
     "Shvstvecd": {
       "requires": [],
+      "params": [
+        {
+          "name": "VSTVEC_MODES",
+          "kind": "includes",
+          "value": 0,
+          "src": "udb",
+          "ref": "Shvstvecd.yaml requirements … param"
+        }
+      ],
       "verified": "udb"
     },
     "Sm": {
@@ -514,6 +532,24 @@
     },
     "Ssstrict": {
       "requires": [],
+      "params": [
+        {
+          "name": "TRAP_ON_UNIMPLEMENTED_INSTRUCTION",
+          "kind": "equal",
+          "value": true,
+          "reason": "Ssstrict requires unimplemented opcodes to trap",
+          "src": "udb",
+          "ref": "Ssstrict.yaml requirements … param"
+        },
+        {
+          "name": "TRAP_ON_UNIMPLEMENTED_CSR",
+          "kind": "equal",
+          "value": true,
+          "reason": "Ssstrict requires unimplemented CSR accesses to trap",
+          "src": "udb",
+          "ref": "Ssstrict.yaml requirements … param"
+        }
+      ],
       "verified": "udb"
     },
     "Sstc": {
@@ -530,22 +566,70 @@
     },
     "Sstvecd": {
       "requires": [],
+      "params": [
+        {
+          "name": "STVEC_MODES",
+          "kind": "includes",
+          "value": 0,
+          "src": "udb",
+          "ref": "Sstvecd.yaml requirements … param"
+        }
+      ],
       "verified": "udb"
     },
     "Sstvecv": {
       "requires": [],
+      "params": [
+        {
+          "name": "STVEC_MODES",
+          "kind": "includes",
+          "value": 1,
+          "src": "udb",
+          "ref": "Sstvecv.yaml requirements … param"
+        }
+      ],
       "verified": "udb"
     },
     "Ssu32xl": {
       "requires": [],
+      "params": [
+        {
+          "name": "UXLEN",
+          "kind": "includes",
+          "value": 32,
+          "src": "udb",
+          "ref": "Ssu32xl.yaml requirements … param"
+        }
+      ],
       "verified": "udb"
     },
     "Ssu64xl": {
       "requires": [],
+      "params": [
+        {
+          "name": "UXLEN",
+          "kind": "includes",
+          "value": 64,
+          "src": "udb",
+          "ref": "Ssu64xl.yaml requirements … param"
+        }
+      ],
       "verified": "udb"
     },
     "Ssube": {
       "requires": [],
+      "params": [
+        {
+          "name": "U_MODE_ENDIANNESS",
+          "kind": "oneOf",
+          "value": [
+            "big",
+            "dynamic"
+          ],
+          "src": "udb",
+          "ref": "Ssube.yaml requirements … param"
+        }
+      ],
       "verified": "udb"
     },
     "Ssvxscr": {
@@ -573,6 +657,15 @@
           "src": "udb",
           "ref": "Sv32.yaml requirements.extension"
         }
+      ],
+      "params": [
+        {
+          "name": "SXLEN",
+          "kind": "includes",
+          "value": 32,
+          "src": "udb",
+          "ref": "Sv32.yaml requirements … param"
+        }
       ]
     },
     "Sv39": {
@@ -581,6 +674,15 @@
           "ext": "S",
           "src": "udb",
           "ref": "Sv39.yaml requirements.extension"
+        }
+      ],
+      "params": [
+        {
+          "name": "SXLEN",
+          "kind": "includes",
+          "value": 64,
+          "src": "udb",
+          "ref": "Sv39.yaml requirements … param"
         }
       ]
     },
@@ -652,6 +754,16 @@
           "ext": "S",
           "src": "udb",
           "ref": "Svbare.yaml requirements.extension"
+        }
+      ],
+      "params": [
+        {
+          "name": "SATP_MODE_BARE",
+          "kind": "equal",
+          "value": true,
+          "reason": "Svbare mandates that the `satp` mode Bare must be supported.",
+          "src": "udb",
+          "ref": "Svbare.yaml requirements … param"
         }
       ]
     },
@@ -741,6 +853,19 @@
     },
     "Za128rs": {
       "requires": [],
+      "params": [
+        {
+          "name": "LRSC_RESERVATION_STRATEGY",
+          "kind": "oneOf",
+          "value": [
+            "reserve exactly enough to cover the access",
+            "reserve naturally-aligned 64-byte region",
+            "reserve naturally-aligned 128-byte region"
+          ],
+          "src": "udb",
+          "ref": "Za128rs.yaml requirements … param"
+        }
+      ],
       "verified": "udb"
     },
     "Za64rs": {
@@ -749,6 +874,18 @@
           "ext": "Za128rs",
           "src": "udb",
           "ref": "Za64rs.yaml requirements.extension"
+        }
+      ],
+      "params": [
+        {
+          "name": "LRSC_RESERVATION_STRATEGY",
+          "kind": "oneOf",
+          "value": [
+            "reserve exactly enough to cover the access",
+            "reserve naturally-aligned 64-byte region"
+          ],
+          "src": "udb",
+          "ref": "Za64rs.yaml requirements … param"
         }
       ]
     },
@@ -1073,6 +1210,16 @@
     },
     "Zic64b": {
       "requires": [],
+      "params": [
+        {
+          "name": "CACHE_BLOCK_SIZE",
+          "kind": "equal",
+          "value": 64,
+          "reason": "Zic64b mandates 64-byte cache block sizes",
+          "src": "udb",
+          "ref": "Zic64b.yaml requirements … param"
+        }
+      ],
       "verified": "udb"
     },
     "Zicbom": {
@@ -1101,6 +1248,15 @@
     },
     "Zicclsm": {
       "requires": [],
+      "params": [
+        {
+          "name": "MISALIGNED_LDST",
+          "kind": "equal",
+          "value": true,
+          "src": "udb",
+          "ref": "Zicclsm.yaml requirements … param"
+        }
+      ],
       "verified": "udb"
     },
     "Ziccrse": {
@@ -1724,6 +1880,15 @@
           "src": "udb",
           "ref": "Zvl1024b.yaml requirements.extension"
         }
+      ],
+      "params": [
+        {
+          "name": "VLEN",
+          "kind": "greaterThanOrEqual",
+          "value": 1024,
+          "src": "udb",
+          "ref": "Zvl1024b.yaml requirements … param"
+        }
       ]
     },
     "Zvl128b": {
@@ -1732,6 +1897,15 @@
           "ext": "Zvl64b",
           "src": "udb",
           "ref": "Zvl128b.yaml requirements.extension"
+        }
+      ],
+      "params": [
+        {
+          "name": "VLEN",
+          "kind": "greaterThanOrEqual",
+          "value": 128,
+          "src": "udb",
+          "ref": "Zvl128b.yaml requirements … param"
         }
       ]
     },
@@ -1742,10 +1916,28 @@
           "src": "udb",
           "ref": "Zvl256b.yaml requirements.extension"
         }
+      ],
+      "params": [
+        {
+          "name": "VLEN",
+          "kind": "greaterThanOrEqual",
+          "value": 256,
+          "src": "udb",
+          "ref": "Zvl256b.yaml requirements … param"
+        }
       ]
     },
     "Zvl32b": {
       "requires": [],
+      "params": [
+        {
+          "name": "VLEN",
+          "kind": "greaterThanOrEqual",
+          "value": 32,
+          "src": "udb",
+          "ref": "Zvl32b.yaml requirements … param"
+        }
+      ],
       "verified": "udb"
     },
     "Zvl512b": {
@@ -1755,6 +1947,15 @@
           "src": "udb",
           "ref": "Zvl512b.yaml requirements.extension"
         }
+      ],
+      "params": [
+        {
+          "name": "VLEN",
+          "kind": "greaterThanOrEqual",
+          "value": 512,
+          "src": "udb",
+          "ref": "Zvl512b.yaml requirements … param"
+        }
       ]
     },
     "Zvl64b": {
@@ -1763,6 +1964,15 @@
           "ext": "Zvl32b",
           "src": "udb",
           "ref": "Zvl64b.yaml requirements.extension"
+        }
+      ],
+      "params": [
+        {
+          "name": "VLEN",
+          "kind": "greaterThanOrEqual",
+          "value": 64,
+          "src": "udb",
+          "ref": "Zvl64b.yaml requirements … param"
         }
       ]
     },

--- a/src/isaGraph.js
+++ b/src/isaGraph.js
@@ -331,6 +331,100 @@ export function resolveSelection({
   return { resolved: [...resolved], implied, redundant, conflicts, choices, unknown };
 }
 
+/**
+ * Implementation parameters a selection constrains.
+ *
+ * These are the other half of a configuration. -march can express only one of
+ * them — VLEN, and then only obliquely, through the Zvl*b extensions — but a
+ * configuration handed to riscv-config or to hardware needs the rest.
+ *
+ * Constraints from different extensions are merged, and the merge is where the
+ * meaning lives:
+ *
+ *   greaterThanOrEqual  the largest floor wins. Zvl64b and Zvl128b together
+ *                       mean VLEN >= 128, not two separate demands.
+ *   includes            union. Sv32 and Sv39 together mean SXLEN must offer
+ *                       both 32 and 64.
+ *   oneOf               intersection: each extension narrows the field. Za64rs
+ *                       permits fewer strategies than Za128rs, so together the
+ *                       stricter list stands.
+ *   equal               all must agree. Disagreement is a real conflict and is
+ *                       reported rather than silently resolved.
+ *
+ * @returns {Array<{name, kind, value, from: string[], reason?: string, conflict?: string}>}
+ */
+export function resolveParams(ids, graph = graphData) {
+  const byName = new Map();
+
+  for (const id of ids) {
+    for (const prm of graph.nodes?.[id]?.params ?? []) {
+      const existing = byName.get(prm.name);
+      if (!existing) {
+        byName.set(prm.name, {
+          name: prm.name,
+          kind: prm.kind,
+          value: Array.isArray(prm.value) ? [...prm.value] : prm.value,
+          from: [id],
+          ...(prm.reason ? { reason: prm.reason } : {}),
+        });
+        continue;
+      }
+      existing.from.push(id);
+
+      if (prm.kind !== existing.kind) {
+        existing.conflict = `${prm.name} is constrained as both ${existing.kind} and ${prm.kind}`;
+        continue;
+      }
+      switch (prm.kind) {
+        case 'greaterThanOrEqual':
+          existing.value = Math.max(existing.value, prm.value);
+          break;
+        case 'includes': {
+          const set = new Set([].concat(existing.value, prm.value));
+          existing.value = [...set].sort((a, b) => (a > b ? 1 : -1));
+          break;
+        }
+        case 'oneOf': {
+          const allowed = new Set(prm.value);
+          const narrowed = [].concat(existing.value).filter((v) => allowed.has(v));
+          if (narrowed.length === 0) {
+            existing.conflict = `${prm.name}: ${existing.from.join(' and ')} allow no common value`;
+          } else {
+            existing.value = narrowed;
+          }
+          break;
+        }
+        case 'equal':
+          if (existing.value !== prm.value) {
+            existing.conflict =
+              `${prm.name}: ${existing.from.join(' and ')} require ${existing.value} and ${prm.value}`;
+          }
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * The VLEN floor a selection implies, or null when it has no vector extension.
+ * Vector length is set by picking a Zvl*b extension rather than by a flag, so
+ * this is the number a user actually chose without necessarily realising it.
+ */
+export function impliedVlen(ids, graph = graphData) {
+  const vlen = resolveParams(ids, graph).find((p) => p.name === 'VLEN');
+  return vlen && vlen.kind === 'greaterThanOrEqual' ? vlen.value : null;
+}
+
+/** The Zvl*b extension that sets a given VLEN floor, for the reverse direction. */
+export function vlenExtension(bits, graph = graphData) {
+  const id = `Zvl${bits}b`;
+  return graph.nodes?.[id] ? id : null;
+}
+
 /** One-line explanation of why `ext` is in a resolution, for UI and errors. */
 export function explain(ext, result) {
   const hit = result.implied.find((entry) => entry.ext === ext);

--- a/tests/isa-graph.test.mjs
+++ b/tests/isa-graph.test.mjs
@@ -25,7 +25,11 @@ import {
   resolveSelection,
   closure,
   explain,
+  resolveParams,
+  impliedVlen,
+  vlenExtension,
 } from '../src/isaGraph.js';
+import { PROFILES } from '../src/profiles.js';
 
 const catalogIds = (() => {
   const file = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'src', 'riscv_extensions.json');
@@ -319,4 +323,73 @@ test('the implied path is the shortest one', () => {
   });
   const result = resolveSelection({ selected: ['A'], graph });
   assert.deepEqual(explain('C', result).split(' -> '), ['A', 'C']);
+});
+
+// ---------------------------------------------------------------------------
+// Implementation parameters
+// ---------------------------------------------------------------------------
+
+test('the graph carries the parameters UDB attaches to extensions', () => {
+  const withParams = Object.entries(DEPENDENCY_GRAPH.nodes).filter(([, n]) => n.params?.length);
+  assert.ok(withParams.length >= 20, `expected UDB's parameter constraints, found ${withParams.length}`);
+  for (const [id, node] of withParams) {
+    for (const prm of node.params) {
+      assert.ok(prm.name, `${id}: a parameter with no name`);
+      assert.ok(
+        ['greaterThanOrEqual', 'includes', 'oneOf', 'equal'].includes(prm.kind),
+        `${id}/${prm.name}: unknown constraint kind "${prm.kind}"`,
+      );
+      assert.equal(prm.src, 'udb', `${id}/${prm.name} should cite UDB`);
+    }
+  }
+});
+
+test('VLEN is the maximum floor across the selection, not the last one seen', () => {
+  // Zvl32b, Zvl64b and Zvl128b all appear once V is selected. The answer is
+  // 128, not 32: these are floors, and the largest wins.
+  const { resolved } = resolveSelection({ selected: ['RV64I', 'V'], base: 'RV64I' });
+  assert.equal(impliedVlen(resolved), 128);
+
+  assert.equal(impliedVlen(resolveSelection({ selected: ['RV64I', 'Zve32x'], base: 'RV64I' }).resolved), 32);
+  assert.equal(impliedVlen(resolveSelection({ selected: ['RV64I', 'Zve64d'], base: 'RV64I' }).resolved), 64);
+
+  // No vector extension means no constraint at all, which is not the same as 0.
+  assert.equal(impliedVlen(['RV64I', 'M']), null);
+});
+
+test('oneOf constraints intersect, so the stricter extension wins', () => {
+  // Za64rs permits two reservation strategies, Za128rs three. Together only the
+  // two both allow are legal — a union here would let through a configuration
+  // neither extension accepts.
+  const params = resolveParams(['Za64rs', 'Za128rs']);
+  const lrsc = params.find((p) => p.name === 'LRSC_RESERVATION_STRATEGY');
+  assert.ok(lrsc, 'LRSC_RESERVATION_STRATEGY should be constrained');
+  assert.equal(lrsc.kind, 'oneOf');
+  assert.equal(lrsc.value.length, 2);
+  assert.ok(!lrsc.value.some((v) => /128-byte/.test(v)), 'Za64rs forbids the 128-byte strategy');
+  assert.deepEqual(lrsc.from.sort(), ['Za128rs', 'Za64rs']);
+});
+
+test('includes constraints union, because each is a separate demand', () => {
+  // Sv32 needs SXLEN to offer 32, Sv39 needs 64. Supporting both means offering
+  // both, so these accumulate rather than narrow.
+  const sxlen = resolveParams(['Sv32', 'Sv39']).find((p) => p.name === 'SXLEN');
+  assert.equal(sxlen.kind, 'includes');
+  assert.deepEqual([...sxlen.value].sort((a, b) => a - b), [32, 64]);
+});
+
+test('vlenExtension maps a width back to the extension that sets it', () => {
+  assert.equal(vlenExtension(128), 'Zvl128b');
+  assert.equal(vlenExtension(1024), 'Zvl1024b');
+  assert.equal(vlenExtension(48), null, 'there is no Zvl48b');
+});
+
+test('a profile reports the parameters it constrains', () => {
+  const { resolved } = resolveSelection({ selected: PROFILES.RVA23, base: 'RV64I' });
+  const params = resolveParams(resolved);
+  const names = params.map((p) => p.name);
+  for (const expected of ['VLEN', 'CACHE_BLOCK_SIZE', 'LRSC_RESERVATION_STRATEGY']) {
+    assert.ok(names.includes(expected), `RVA23 should constrain ${expected}`);
+  }
+  assert.deepEqual(params.filter((p) => p.conflict), [], 'a ratified profile must not self-conflict');
 });


### PR DESCRIPTION
Asked whether the builder should let you set parameters like vector length. It should — and **VLEN was already being set, invisibly.**

There is no `-mvlen` flag. Vector length is expressed by the `Zvl*b` extensions, so selecting `V` already pinned **VLEN ≥ 128** through `Zvl128b` without ever saying so, and raising it meant knowing which token to go hunting for.

## 1. The graph now carries parameters

The seeder used to skip `param:` entries — I documented them as *"conditions on an implementation, not extension dependencies."* True, but they're the other half of a configuration.

**21 extensions constrain 10 parameters:** `VLEN`, `SXLEN`, `UXLEN`, `STVEC_MODES`, `VSTVEC_MODES`, `CACHE_BLOCK_SIZE`, `MISALIGNED_LDST`, `LRSC_RESERVATION_STRATEGY`, `SATP_MODE_BARE`, and the two `Ssstrict` traps.

## 2. Merging is where the meaning lives

| kind | rule | why |
|---|---|---|
| `greaterThanOrEqual` | largest floor wins | `Zvl32b`+`Zvl64b`+`Zvl128b` means **≥ 128**, not three demands |
| `includes` | union | `Sv32`+`Sv39` means SXLEN must offer **both** 32 and 64 |
| `oneOf` | **intersection** | `Za64rs` permits fewer strategies than `Za128rs`; a union would admit a value **neither** accepts |
| `equal` | must agree | disagreement is reported, not quietly resolved |

## 3. The UI, and the export

The panel lists resolved parameters with the extensions that required each, and puts **VLEN first with a selector** — picking `256` adds `Zvl256b` for you.

Verified in the browser: 128 → 256 moves the extension count **77 → 78**, leaves instructions at **965**, and puts `zvl256b` into the `-march` string in canonical position:

```
…_zve64x_zvfhmin_zvkb_zvkt_zvl128b_zvl256b_zvl32b_zvl64b
```

The exported YAML gains a `parameters:` block. Its header used to admit it was *"not tied to any specific external validator schema"* — parameters are exactly what riscv-config validates, so this is what makes the export consumable rather than decorative. **Conflicts are written into the file** rather than dropped: a config that looks valid and isn't is worse than one that says where it disagrees.

```yaml
parameters:
  LRSC_RESERVATION_STRATEGY:
    constraint: oneOf
    value: ["reserve exactly enough to cover the access", "reserve naturally-aligned 64-byte region"]
    required_by: [Za64rs, Za128rs]
```

## Testing

**104 tests pass**, including that VLEN takes the maximum rather than the last value seen, that `oneOf` narrows while `includes` accumulates, and that a ratified profile never self-conflicts.