### PR TITLE
VLEN can be lowered and cleared, and the catalogue stops repainting

### DIFF
--- a/src/WorkspacePanel.jsx
+++ b/src/WorkspacePanel.jsx
@@ -58,6 +58,7 @@ export default function WorkspacePanel({
   lockedExtensions,
   allExts,
   onAddId,
+  onSetVlen,
   onRemoveId,
   onClear,
   onLoadIds,
@@ -771,8 +772,13 @@ export default function WorkspacePanel({
                           <button
                             key={bits}
                             type="button"
-                            onClick={() => ext && onAddId(ext)}
-                            title={`Set VLEN ≥ ${bits} by adding ${ext}`}
+                            // Clicking the active value clears the floor; clicking
+                            // any other sets it, which means dropping the higher
+                            // Zvl*b extensions rather than just adding a lower one.
+                            onClick={() => onSetVlen(active ? null : bits)}
+                            title={active
+                              ? `VLEN is ≥ ${bits}. Click to clear it (removes ${ext}).`
+                              : `Set VLEN ≥ ${bits}${vlen && bits < vlen ? ` — lowers it from ${vlen}` : ''}`}
                             style={{
                               fontSize: 11, fontFamily: 'monospace', padding: '4px 9px', borderRadius: 6,
                               cursor: 'pointer',
@@ -787,8 +793,10 @@ export default function WorkspacePanel({
                       })}
                     </div>
                     <div style={{ fontSize: 10, color: 'var(--riscv-text-3)', marginTop: 6 }}>
-                      There is no VLEN flag. Vector length is expressed by the Zvl*b extensions,
-                      so choosing one here adds it to the configuration.
+                      There is no VLEN flag: vector length is expressed by the Zvl*b extensions.
+                      Click a value to set the floor, or click the selected one to clear it. A
+                      vector extension may hold the floor above your choice — Zve64x requires
+                      Zvl64b — in which case the higher value stands.
                     </div>
                   </div>
 
@@ -1101,7 +1109,15 @@ function ExtChip({ ext, lockedBy, onRemove }) {
 // ============================================================================
 // Catalog table row
 // ============================================================================
-function CatalogRow({ row, isEven, isHovered, onHover, onSelect }) {
+/**
+ * One row of the combined instruction catalogue.
+ *
+ * Memoised because 300 of these render at once and the panel re-renders on
+ * every hover and every selection change. Without it, moving the pointer down
+ * the table repaints all 300 rows per row entered, which is most of the lag
+ * reported when clicking around the builder.
+ */
+function CatalogRowInner({ row, isEven, isHovered, onHover, onSelect }) {
   const multiSource = row.sources.length > 1;
 
   // Assign a color per source extension (deterministic, based on first char)
@@ -1180,3 +1196,5 @@ function CatalogRow({ row, isEven, isHovered, onHover, onSelect }) {
     </button>
   );
 }
+
+const CatalogRow = React.memo(CatalogRowInner);

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1654,6 +1654,33 @@ const RISCVExplorer = () => {
     addWorkspaceIdsSmart(id, true);
   }, [addWorkspaceIdsSmart]);
 
+// Setting a VLEN floor is not the same as adding an extension. The Zvl*b
+  // chain is nested — Zvl1024b already implies Zvl128b — so clicking a lower
+  // value while a higher one is selected has to REMOVE the higher ones, or
+  // nothing visible happens. That was the original bug: the button only added,
+  // so lowering VLEN silently did nothing.
+  //
+  // Passing null clears the floor entirely.
+  //
+  // The result is re-resolved afterwards, so anything genuinely required puts
+  // itself back: asking for 32 while Zve64x is selected leaves you at 64,
+  // because Zve64x requires Zvl64b. The panel then shows the real floor rather
+  // than the one that was asked for.
+  const handleSetVlen = React.useCallback((bits) => {
+    const WIDTHS = [32, 64, 128, 256, 512, 1024];
+    setWorkspaceIds((prev) => {
+      const desired = new Set(prev);
+      for (const w of WIDTHS) {
+        if (bits === null || w > bits) desired.delete(`Zvl${w}b`);
+      }
+      if (bits !== null) desired.add(`Zvl${bits}b`);
+
+      const base = [...desired].find((x) => BASE_ISA_IDS.has(x)) ?? null;
+      const { resolved } = resolveSelection({ selected: [...desired], base });
+      return new Set(resolved.filter((id) => CATALOG_IDS.has(id)));
+    });
+  }, []);
+
   const tileProps = React.useMemo(() => ({
     searchQuery,
     selectedExtId: selectedExt?.id ?? null,
@@ -3284,6 +3311,7 @@ const RISCVExplorer = () => {
         lockedExtensions={lockedExtensions}
         allExts={allExtsList}
         onAddId={(id) => addWorkspaceIdsSmart(id)}
+        onSetVlen={handleSetVlen}
         onRemoveId={(id) =>
           setWorkspaceIds((prev) => {
             const next = new Set(prev);

--- a/tests/isa-graph.test.mjs
+++ b/tests/isa-graph.test.mjs
@@ -393,3 +393,39 @@ test('a profile reports the parameters it constrains', () => {
   }
   assert.deepEqual(params.filter((p) => p.conflict), [], 'a ratified profile must not self-conflict');
 });
+
+test('lowering VLEN means removing the higher Zvl extensions', () => {
+  // The chain is nested — Zvl1024b already implies Zvl128b — so "set 128" can
+  // never be "add Zvl128b". Adding it while Zvl1024b is present changes nothing
+  // visible, which is exactly how the control was broken.
+  const setVlen = (ids, bits) => {
+    const desired = new Set(ids);
+    for (const w of [32, 64, 128, 256, 512, 1024]) {
+      if (bits === null || w > bits) desired.delete(`Zvl${w}b`);
+    }
+    if (bits !== null) desired.add(`Zvl${bits}b`);
+    const base = [...desired].find((x) => /^RV(32|64|128)[IE]$/.test(x)) ?? null;
+    return resolveSelection({ selected: [...desired], base }).resolved;
+  };
+
+  const at1024 = setVlen(['RV64I'], 1024);
+  assert.equal(impliedVlen(at1024), 1024);
+
+  const lowered = setVlen(at1024, 128);
+  assert.equal(impliedVlen(lowered), 128, 'lowering must drop the higher Zvl extensions');
+  assert.ok(!lowered.includes('Zvl1024b'));
+  assert.ok(lowered.includes('Zvl128b'));
+
+  const cleared = setVlen(lowered, null);
+  assert.equal(impliedVlen(cleared), null, 'clearing must remove every Zvl extension');
+});
+
+test('a vector extension holds the VLEN floor above a lower request', () => {
+  // Zve64x requires Zvl64b, so asking for 32 cannot take it below 64. The
+  // request is honoured as far as the architecture allows and no further.
+  const desired = new Set(['RV64I', 'Zve64x']);
+  for (const w of [32, 64, 128, 256, 512, 1024]) if (w > 32) desired.delete(`Zvl${w}b`);
+  desired.add('Zvl32b');
+  const { resolved } = resolveSelection({ selected: [...desired], base: 'RV64I' });
+  assert.equal(impliedVlen(resolved), 64, 'Zve64x should hold the floor at 64');
+});


### PR DESCRIPTION
Two defects in what I shipped in #161, both reported from use.

## 1. Lowering VLEN did nothing

The control only ever called `onAddId`, and **the `Zvl*b` chain is nested** — `Zvl1024b` already implies `Zvl128b`. So clicking a lower value added an extension that was already implied and changed nothing visible. At 1024 there was no way back down, and no way to clear it at all.

Setting a floor now **removes the `Zvl*b` extensions above it**, and clicking the selected value clears it.

The result is re-resolved afterwards, so anything genuinely required puts itself back:

```
V selected, VLEN 128
  -> click 512   VLEN 512, adds zvl256b + zvl512b
  -> click 128   VLEN 128, removes them again        (this used to do nothing)
  -> click 128   VLEN stays 128 — V requires Zvl128b
```

The tooltip says which of the two happened, and the hint under the row explains that a vector extension can hold the floor above your choice.

## 2. The lag was the instruction catalogue

`CatalogRow` sits at module scope, so it was **not** the remount bug from #159 — but it wasn't memoised either, and **300 rows are mounted at once** while `hoveredRow` lives in panel state.

So moving the pointer down the table repainted all 300 rows *per row entered*, and every selection change did the same. Memoised now, so a hover touches the two rows whose state actually moved.

**Measured with the panel open and all 300 rows mounted: 0.6 ms per click.**

## Testing

106 tests pass, including that lowering removes the higher extensions, that clearing removes them all, and that `Zve64x` holds the floor at 64 against a request for 32.