### PR TITLE
The "in the configuration" tick is green

### DIFF
--- a/src/ExtensionTile.jsx
+++ b/src/ExtensionTile.jsx
@@ -90,9 +90,9 @@ function ExtensionTile({
         const isLocked = inWorkspace && lockedExtensions.has(data.id);
         const lockedBy = isLocked ? lockedExtensions.get(data.id) : [];
 
-        // The unselected "+" is the call to action, so it carries the accent
-        // colour. Selected tiles keep the filled amber check; locked ones are
-        // dimmed to read as unavailable.
+        // Amber says "you can add this"; green says "it is in". Using one colour
+        // for both made a full configuration a wall of undifferentiated amber.
+        // Locked tiles stay dimmed to read as unavailable.
         const accent = '#f5c542';
         return (
           <button
@@ -108,13 +108,16 @@ function ExtensionTile({
               display: 'flex', alignItems: 'center', justifyContent: 'center',
               width: 18, height: 18,
               borderRadius: 5,
-              border: `1px solid ${isLocked ? 'rgba(245,197,66,0.3)' : 'rgba(245,197,66,0.6)'}`,
+              border: `1px solid ${
+                isLocked ? 'rgba(245,197,66,0.3)'
+                  : inWorkspace ? 'var(--riscv-check-edge)' : 'rgba(245,197,66,0.6)'
+              }`,
               background: inWorkspace
-                ? (isLocked ? 'rgba(245,197,66,0.08)' : 'rgba(245,197,66,0.22)')
+                ? (isLocked ? 'rgba(245,197,66,0.08)' : 'var(--riscv-check-fill)')
                 : 'rgba(245,197,66,0.14)',
               backdropFilter: 'blur(4px)',
               boxShadow: inWorkspace || isLocked ? 'none' : '0 0 0 2px rgba(245,197,66,0.12)',
-              color: isLocked ? 'rgba(245,197,66,0.5)' : accent,
+              color: isLocked ? 'rgba(245,197,66,0.5)' : (inWorkspace ? 'var(--riscv-check)' : accent),
               cursor: isLocked ? 'not-allowed' : 'pointer',
               transition: 'all 0.15s',
               padding: 0,
@@ -128,7 +131,7 @@ function ExtensionTile({
             {inWorkspace
               ? (
                 <svg width="9" height="9" viewBox="0 0 9 9" fill="none">
-                  <path d="M1.5 4.5L3.5 6.5L7.5 2.5" stroke="#f5c542" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  <path d="M1.5 4.5L3.5 6.5L7.5 2.5" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" />
                 </svg>
               )
               : <Plus size={9} />

--- a/src/index.css
+++ b/src/index.css
@@ -44,6 +44,15 @@
   /* Raised plate behind toolbars and chips. */
   --riscv-plate: rgba(15, 23, 42, 0.4);
 
+  /* "In the configuration" confirmation. Amber marks the action available, so
+     the completed state gets its own colour rather than more amber.
+     Same green ramp in both themes; the shade differs because no single value
+     is strong on both grounds — green-500 measures 8.02:1 on the dark tile but
+     only 2.03:1 on the light emerald wash, and green-700 the reverse. */
+  --riscv-check: #22c55e;
+  --riscv-check-fill: rgba(34, 197, 94, 0.20);
+  --riscv-check-edge: rgba(34, 197, 94, 0.55);
+
   /* Field colors for encoding diagram */
   --field-opcode: #f5c542;
   /* gold   — [6:0]   */
@@ -447,6 +456,10 @@ pre,
   --riscv-tint-4: rgba(45, 40, 80, 0.11);
   --riscv-hairline: rgba(45, 40, 80, 0.08);
   --riscv-plate: rgba(255, 255, 255, 0.75);
+
+  --riscv-check: #15803d;
+  --riscv-check-fill: rgba(21, 128, 61, 0.14);
+  --riscv-check-edge: rgba(21, 128, 61, 0.45);
 
   /* Encoding field colours, pulled toward pastel so the diagram stays legible
      on white without the neon look the dark theme wants. */


### PR DESCRIPTION
Amber marked both the action *and* the result, so a full configuration was a wall of undifferentiated amber. Now **amber means "you can add this", green means "it is in".**

## No single green works on both grounds

Measured rather than picked by eye:

| candidate | on dark tile | on light emerald wash |
|---|---|---|
| `green-500` | **8.02:1** | 2.03:1 |
| `green-700` | 3.65:1 | **4.46:1** |

The best *single* value would have been `green-700` at 3.65:1 either side — readable, but muted for a 9px icon.

So both themes take the **same green ramp at different shades**: `green-500` on dark, `green-700` on light. Same hue, so it reads as one colour, with roughly double the contrast on each ground. Worst case is now **4.46:1**, against the light emerald tile wash — the lightest ground a tick ever sits on.

## Details

The tick follows `currentColor` rather than a baked hex, so fill, edge and glyph move together and there's one token to change.

**The selected-tile ring stays amber** — that marks selection, while the tick marks membership of the configuration. Separating them is the point; say the word if you'd rather they matched.

114 tests pass. Verified in both themes.