### PR TITLE
data: add the ratified bitmanip instructions REV8, ORC.B, BREV8, ZIP, UNZIP (#40 #85)

### DIFF
--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -304,8 +304,11 @@ for (const entry of umbrellaEntries) {
   }
 }
 
-assertExtension('B', { count: 42 });
-assertExtension('Zk', { count: 47 }); // Zkn(41) ∪ Zks(20) minus shared Zbkb/Zbkc/Zbkx = 47 unique
+// These counts rose when the ratified bitmanip instructions were added. Zbb
+// gained ORC.B and REV8 (+2), and Zbkb gained BREV8, ZIP, UNZIP and REV8.RV32,
+// which carries +4 into every umbrella that includes Zbkb.
+assertExtension('B', { count: 44 });
+assertExtension('Zk', { count: 51 }); // Zkn(45) ∪ Zks(24) minus shared Zbkb/Zbkc/Zbkx = 51 unique
 
 const zkExt = extMap.get('Zk');
 assert(zkExt?.members?.includes('Zkt'), 'Zk umbrella must include Zkt.');
@@ -326,8 +329,8 @@ for (const id of KNOWN_POPULATED_TAG_EXTS) {
   if (ext) assert(Object.keys(ext.instructions).length > 0, `Core extension ${id} is unexpectedly empty.`);
 }
 
-assertExtension('Zkn', { count: 41 });
-assertExtension('Zks', { count: 20 });
+assertExtension('Zkn', { count: 45 });
+assertExtension('Zks', { count: 24 });
 
 const rv64iExt = extMap.get('RV64I');
 assert(!!rv64iExt, 'RV64I extension entry must exist in catalog');

--- a/src/instr_dict.json
+++ b/src/instr_dict.json
@@ -16020,5 +16020,77 @@
     ],
     "match": "0x28004033",
     "mask": "0xfe00707f"
+  },
+  "orc_b": {
+    "encoding": "001010000111-----101-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zbb"
+    ],
+    "match": "0x28705013",
+    "mask": "0xfff0707f"
+  },
+  "brev8": {
+    "encoding": "011010000111-----101-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zbkb"
+    ],
+    "match": "0x68705013",
+    "mask": "0xfff0707f"
+  },
+  "rev8": {
+    "encoding": "011010111000-----101-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_zbb"
+    ],
+    "match": "0x6b805013",
+    "mask": "0xfff0707f"
+  },
+  "zip": {
+    "encoding": "000010001111-----001-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv32_zbkb"
+    ],
+    "match": "0x08f01013",
+    "mask": "0xfff0707f"
+  },
+  "unzip": {
+    "encoding": "000010001111-----101-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv32_zbkb"
+    ],
+    "match": "0x08f05013",
+    "mask": "0xfff0707f"
+  },
+  "rev8_rv32": {
+    "encoding": "011010011000-----101-----0010011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv32_zbkb"
+    ],
+    "match": "0x69805013",
+    "mask": "0xfff0707f"
   }
 }

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -3722,6 +3722,18 @@
           "mask": "0xfc00707f",
           "deprecated": true
         },
+        "REV8": {
+          "encoding": "011010111000-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv64_zbb"
+          ],
+          "match": "0x6b805013",
+          "mask": "0xfff0707f"
+        },
         "ANDN": {
           "encoding": "0100000----------111-----0110011",
           "variable_fields": [
@@ -3958,6 +3970,18 @@
           ],
           "match": "0x40004033",
           "mask": "0xfe00707f"
+        },
+        "ORC.B": {
+          "encoding": "001010000111-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zbb"
+          ],
+          "match": "0x28705013",
+          "mask": "0xfff0707f"
         },
         "BCLRI": {
           "encoding": "010010-----------001-----0010011",
@@ -15143,6 +15167,18 @@
           "mask": "0xfc00707f",
           "deprecated": true
         },
+        "REV8": {
+          "encoding": "011010111000-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv64_zbb"
+          ],
+          "match": "0x6b805013",
+          "mask": "0xfff0707f"
+        },
         "ANDN": {
           "encoding": "0100000----------111-----0110011",
           "variable_fields": [
@@ -15379,6 +15415,18 @@
           ],
           "match": "0x40004033",
           "mask": "0xfe00707f"
+        },
+        "ORC.B": {
+          "encoding": "001010000111-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zbb"
+          ],
+          "match": "0x28705013",
+          "mask": "0xfff0707f"
         }
       },
       "url": "https://docs.riscv.org/reference/isa/unpriv/b-st-ext.html"
@@ -21522,7 +21570,8 @@
       "name": "Zbkb",
       "tags": [
         "rv64_zbkb",
-        "rv_zbkb"
+        "rv_zbkb",
+        "rv32_zbkb"
       ],
       "desc": "Crypto Bitmanip (byte)",
       "use": "Byte-wise crypto bit ops",
@@ -21728,6 +21777,54 @@
           ],
           "match": "0x40004033",
           "mask": "0xfe00707f"
+        },
+        "BREV8": {
+          "encoding": "011010000111-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zbkb"
+          ],
+          "match": "0x68705013",
+          "mask": "0xfff0707f"
+        },
+        "ZIP": {
+          "encoding": "000010001111-----001-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbkb"
+          ],
+          "match": "0x08f01013",
+          "mask": "0xfff0707f"
+        },
+        "UNZIP": {
+          "encoding": "000010001111-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbkb"
+          ],
+          "match": "0x08f05013",
+          "mask": "0xfff0707f"
+        },
+        "REV8.RV32": {
+          "encoding": "011010011000-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbkb"
+          ],
+          "match": "0x69805013",
+          "mask": "0xfff0707f"
         }
       }
     },
@@ -22033,6 +22130,54 @@
           ],
           "match": "0x40004033",
           "mask": "0xfe00707f"
+        },
+        "BREV8": {
+          "encoding": "011010000111-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zbkb"
+          ],
+          "match": "0x68705013",
+          "mask": "0xfff0707f"
+        },
+        "ZIP": {
+          "encoding": "000010001111-----001-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbkb"
+          ],
+          "match": "0x08f01013",
+          "mask": "0xfff0707f"
+        },
+        "UNZIP": {
+          "encoding": "000010001111-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbkb"
+          ],
+          "match": "0x08f05013",
+          "mask": "0xfff0707f"
+        },
+        "REV8.RV32": {
+          "encoding": "011010011000-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbkb"
+          ],
+          "match": "0x69805013",
+          "mask": "0xfff0707f"
         },
         "CLMUL": {
           "encoding": "0000101----------001-----0110011",
@@ -22770,6 +22915,54 @@
           ],
           "match": "0x40004033",
           "mask": "0xfe00707f"
+        },
+        "BREV8": {
+          "encoding": "011010000111-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zbkb"
+          ],
+          "match": "0x68705013",
+          "mask": "0xfff0707f"
+        },
+        "ZIP": {
+          "encoding": "000010001111-----001-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbkb"
+          ],
+          "match": "0x08f01013",
+          "mask": "0xfff0707f"
+        },
+        "UNZIP": {
+          "encoding": "000010001111-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbkb"
+          ],
+          "match": "0x08f05013",
+          "mask": "0xfff0707f"
+        },
+        "REV8.RV32": {
+          "encoding": "011010011000-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbkb"
+          ],
+          "match": "0x69805013",
+          "mask": "0xfff0707f"
         },
         "CLMUL": {
           "encoding": "0000101----------001-----0110011",
@@ -23909,6 +24102,54 @@
           ],
           "match": "0x40004033",
           "mask": "0xfe00707f"
+        },
+        "BREV8": {
+          "encoding": "011010000111-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zbkb"
+          ],
+          "match": "0x68705013",
+          "mask": "0xfff0707f"
+        },
+        "ZIP": {
+          "encoding": "000010001111-----001-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbkb"
+          ],
+          "match": "0x08f01013",
+          "mask": "0xfff0707f"
+        },
+        "UNZIP": {
+          "encoding": "000010001111-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbkb"
+          ],
+          "match": "0x08f05013",
+          "mask": "0xfff0707f"
+        },
+        "REV8.RV32": {
+          "encoding": "011010011000-----101-----0010011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbkb"
+          ],
+          "match": "0x69805013",
+          "mask": "0xfff0707f"
         },
         "CLMUL": {
           "encoding": "0000101----------001-----0110011",


### PR DESCRIPTION
Closes #40
Closes #85

All five were missing from the **entire catalogue**, not only from Zbb and Zbkb.

### Root cause

`src/instr_dict.json` is a vendored snapshot of riscv-opcodes taken **before bitmanip was ratified**. It still carries the draft Zbp forms `gorci` and `grevi` and an `rv_zbp` tag, while the ratified instructions that replaced them never arrived.

### How the encodings were sourced

From riscv-opcodes upstream (`extensions/rv_zbb`, `rv_zbkb`, `rv32_zbkb`, `rv64_zbb`), not from the prose spec, and derived with a parser rather than by hand.

**The parser was validated before being trusted**: it reproduces all **23** bitmanip entries already present in `instr_dict.json` byte for byte. The six new entries come from machinery already proven against known-good data.

| mnemonic | match | mask | tag |
|---|---|---|---|
| ORC.B | `0x28705013` | `0xfff0707f` | rv_zbb |
| REV8 | `0x6b805013` | `0xfff0707f` | rv64_zbb |
| BREV8 | `0x68705013` | `0xfff0707f` | rv_zbkb |
| ZIP | `0x08f01013` | `0xfff0707f` | rv32_zbkb |
| UNZIP | `0x08f05013` | `0xfff0707f` | rv32_zbkb |
| REV8.RV32 | `0x69805013` | `0xfff0707f` | rv32_zbkb |

### Two things worth reviewing

**Zbkb gains the `rv32_zbkb` tag.** Without it ZIP and UNZIP could never appear, because *no catalogue entry claimed that tag at all*. This mirrors Zbb, which already carries `rv64_zbb` alongside `rv_zbb`.

**The sync script's expected-count assertions rejected the first run**, which is exactly what they are for. They are updated deliberately: Zbb +2 and Zbkb +4, carrying into every umbrella containing Zbkb, so B goes 42 → 44 and Zk/Zkn/Zks go 47/41/20 → 51/45/24.

### Verification

- Zbb 26 → 28 instructions, Zbkb 12 → 16
- All five reachable in the UI by mnemonic search **and** by hex encoding, each landing in the correct extension
- **No new encoding conflicts**: zero overlapping pairs involve any added instruction
- 114 tests pass

### Follow-up, not in this PR

The stale snapshot is a wider problem than these five. Zbb still lists SLOI, SROI, SLO and SRO, which were dropped before ratification, and `rv_zbp` should not exist at all. Regenerating `instr_dict.json` from current riscv-opcodes would fix that properly, but it touches all 1188 entries and deserves its own PR.