### PR TITLE
data: extend CSR coverage from riscv-unified-db (#130)

### DIFF
--- a/scripts/sync_udb_extensions.cjs
+++ b/scripts/sync_udb_extensions.cjs
@@ -414,6 +414,104 @@ if (parseFailures > 0) {
 // means UDB restructured its layout and our minimal parser is quietly missing
 // data, which would otherwise be reported as "No new extensions found".
 //
+// ---- Pass 2: CSR coverage across the whole catalog ----
+//
+// The pass above is deliberately narrow: supervisor-prefixed extensions with no
+// structured data at all. That left CSRs missing everywhere else, so Zicntr,
+// Zihpm, F, H, S, U and V carried none, and searching "mstatus" or "mcycle"
+// found nothing even though UDB describes all of them.
+//
+// findCsrs() rescans the entire CSR directory per extension. That is fine for a
+// handful of gaps but becomes 227 x 396 reads across the full catalog, so this
+// builds the index in a single pass instead.
+//
+// Ownership follows our catalog, not UDB's. UDB attributes vector CSRs to
+// Zvl32b, the minimum VLEN extension, because any V implementation has
+// VLEN >= 32. We file vector content under V, exactly as we already do for
+// vector instructions, so VL and VTYPE appear where a reader looks for them.
+const CSR_EXT_REMAP = { Zvl32b: 'V' };
+
+// A real YAML parse, not the text matcher csrDefinedBy() uses above.
+//
+// That matcher scans the indented block under definedBy for any `name:`, which
+// is fine for the simple supervisor entries it was written for and wrong at
+// catalog scale. mstatus declares a conditional dependence on V and F because
+// it carries VS and FS fields, so a text scan files mstatus, misa and sstatus
+// under both V and F, while Zihpm's 58 counters match nothing at all. Reading
+// the structure instead gives F its three FP CSRs and Zihpm its counters.
+//
+// The shape to respect: definedBy nests under an `extension` key, as
+// `definedBy: {extension: {name: Zicntr}}`, and may carry anyOf/allOf/oneOf.
+// Reading definedBy.name alone silently yields nothing, which reads as "UDB has
+// no CSR data" rather than as a bug.
+const YAML = require('yaml');
+
+function csrOwners(node, out = new Set()) {
+  if (node == null) return out;
+  if (typeof node === 'string') { out.add(node); return out; }
+  if (Array.isArray(node)) { node.forEach(n => csrOwners(n, out)); return out; }
+  if (typeof node !== 'object') return out;
+  if (node.extension) csrOwners(node.extension, out);
+  else if (typeof node.name === 'string') out.add(node.name);
+  for (const key of ['anyOf', 'allOf', 'oneOf']) if (node[key]) csrOwners(node[key], out);
+  return out;
+}
+
+// csr/ is not flat. Alongside ~85 loose files it holds per-extension
+// subdirectories (F, V, H, Zicntr, ...), which is where the FP, vector and
+// counter CSRs live. Reading only the top level sees 85 of 396 files and
+// reports F, V and Zihpm as having no CSRs at all.
+function walkCsrFiles(dir) {
+  const found = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...walkCsrFiles(full));
+    else if (entry.name.endsWith('.yaml')) found.push(full);
+  }
+  return found;
+}
+
+const csrIndex = new Map();
+for (const filepath of walkCsrFiles(UDB_CSR_DIR)) {
+  let doc;
+  try {
+    doc = YAML.parse(fs.readFileSync(filepath, 'utf8'));
+  } catch (err) {
+    parseFailures++;
+    console.warn('  warning: could not parse ' + filepath + ': ' + err.message);
+    continue;
+  }
+  if (!doc || !doc.name) continue;
+
+  const entry = buildCsrEntry(doc);
+  for (const owner of csrOwners(doc.definedBy)) {
+    const id = CSR_EXT_REMAP[owner] || owner;
+    if (!entryIndex.has(id)) continue;
+    if (!csrIndex.has(id)) csrIndex.set(id, {});
+    csrIndex.get(id)[doc.name] = entry;
+  }
+}
+
+let csrsAdded = 0;
+let extsGainedCsrs = 0;
+for (const [id, found] of csrIndex) {
+  const loc = entryIndex.get(id);
+  if (!loc) continue;
+  const entry = loc.entries[loc.index];
+  // Fill gaps only. An entry that already carries CSRs was curated or synced
+  // earlier, and replacing it silently would discard that work.
+  if (entry.csrs && Object.keys(entry.csrs).length) continue;
+  const names = Object.keys(found);
+  if (!names.length) continue;
+  entry.csrs = Object.fromEntries(names.sort().map(n => [n, found[n]]));
+  extsGainedCsrs++;
+  csrsAdded += names.length;
+  updated++;
+}
+
+console.log('');
+console.log('CSR coverage pass: ' + extsGainedCsrs + ' extension(s) gained ' + csrsAdded + ' CSR(s)');
+
 // This guard runs BEFORE the write: past the threshold, the in-memory catalog is
 // half-synced (real fields silently dropped), so persisting it would corrupt the
 // checked-in data on local runs and stage a bad diff. Abort untouched instead.

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -659,30 +659,6 @@ const EncodingDiagram = ({ encoding }) => {
   );
 };
 
-// CSR lookups for the details sidebar. Module scope so they are allocated
-// once rather than rebuilt on every render of the explorer.
-const extensionCsrs = {
-  S: [
-    'SSTATUS',
-    'SIE', 'SIP',
-    'STVEC',
-    'SSCRATCH',
-    'SEPC',
-    'SCAUSE',
-    'STVAL',
-    'SATP',
-  ],
-  U: [
-    'USTATUS',
-    'UIE', 'UIP',
-    'UTVEC',
-    'USCRATCH',
-    'UEPC',
-    'UCAUSE',
-    'UTVAL',
-  ],
-};
-
 const extensionCsrLabels = {
   S: 'Supervisor CSRs',
   U: 'User CSRs',
@@ -1367,9 +1343,16 @@ const RISCVExplorer = () => {
       if (mnemonicList.length) {
         parts.push(mnemonicList.join(' '));
       }
-      const csrList = extensionCsrs[ext.id];
-      if (Array.isArray(csrList) && csrList.length) {
-        parts.push(csrList.join(' '));
+      // CSRs now come from the catalogue entry, populated from
+      // riscv-unified-db, rather than a hand-written table covering S and U.
+      // Names and descriptions are both indexed, so 'mstatus' and 'machine
+      // status' both find their extension.
+      if (ext.csrs && typeof ext.csrs === 'object') {
+        const names = Object.keys(ext.csrs);
+        if (names.length) {
+          parts.push(names.join(' '));
+          parts.push(names.map((n) => ext.csrs[n]?.desc).filter(Boolean).join(' '));
+        }
       }
 
       const instructions = ext.instructions;
@@ -2598,21 +2581,29 @@ const RISCVExplorer = () => {
                         </div>
                       )}
 
-                      {extensionCsrs[selectedExt.id] && (
+                      {selectedExt.csrs && Object.keys(selectedExt.csrs).length > 0 && (
                         <div className="bg-slate-900 p-3 rounded border border-slate-700">
                           <h4 className="text-[11px] uppercase tracking-wider text-sky-300 font-bold mb-2">
                             {(extensionCsrLabels[selectedExt.id] || 'CSRs')}{' '}
-                            ({extensionCsrs[selectedExt.id].length})
+                            ({Object.keys(selectedExt.csrs).length})
                           </h4>
                           <div className="flex flex-wrap gap-1">
-                            {extensionCsrs[selectedExt.id].map((csr) => (
-                              <span
-                                key={csr}
-                                className="px-1.5 py-0.5 rounded border border-slate-700 bg-slate-800/70 text-[11px] font-mono text-slate-200"
-                              >
-                                {csr}
-                              </span>
-                            ))}
+                            {Object.keys(selectedExt.csrs).sort().map((name) => {
+                              const csr = selectedExt.csrs[name] || {};
+                              // Address and description are what identify a CSR;
+                              // both ride along in the catalogue entry.
+                              const tip = [csr.desc, csr.address, csr.priv_mode && `${csr.priv_mode}-mode`]
+                                .filter(Boolean).join(' · ');
+                              return (
+                                <span
+                                  key={name}
+                                  title={tip || undefined}
+                                  className="px-1.5 py-0.5 rounded border border-slate-700 bg-slate-800/70 text-[11px] font-mono text-slate-200"
+                                >
+                                  {name.toUpperCase()}
+                                </span>
+                              );
+                            })}
                           </div>
                         </div>
                       )}

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -5383,7 +5383,27 @@
           "mask": "0x707f"
         }
       },
-      "url": "https://docs.riscv.org/reference/isa/unpriv/f-st-ext.html"
+      "url": "https://docs.riscv.org/reference/isa/unpriv/f-st-ext.html",
+      "csrs": {
+        "fcsr": {
+          "address": "3",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Floating-point control and status register (`frm` + `fflags`)"
+        },
+        "fflags": {
+          "address": "1",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Floating-Point Accrued Exceptions"
+        },
+        "frm": {
+          "address": "2",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Floating-Point Dynamic Rounding Mode"
+        }
+      }
     },
     {
       "id": "H",
@@ -5612,7 +5632,177 @@
           "mask": "0xfe007fff"
         }
       },
-      "url": "https://docs.riscv.org/reference/isa/priv/hypervisor.html"
+      "url": "https://docs.riscv.org/reference/isa/priv/hypervisor.html",
+      "csrs": {
+        "hcontext": {
+          "address": "1704",
+          "priv_mode": "S",
+          "length": "MXLEN",
+          "desc": "Hypervisor Context"
+        },
+        "hcounteren": {
+          "address": "1542",
+          "priv_mode": "S",
+          "length": 32,
+          "desc": "Hypervisor Counter Enable"
+        },
+        "hedeleg": {
+          "address": "1538",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Hypervisor Exception Delegation"
+        },
+        "hedelegh": {
+          "address": "1554",
+          "priv_mode": "S",
+          "length": 32,
+          "desc": "Hypervisor Exception Delegation High"
+        },
+        "henvcfg": {
+          "address": "1546",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Hypervisor Environment Configuration"
+        },
+        "henvcfgh": {
+          "address": "1562",
+          "priv_mode": "S",
+          "length": 32,
+          "desc": "most-significant 32 bits of Hypervisor Environment Configuration"
+        },
+        "hgatp": {
+          "address": "1664",
+          "priv_mode": "S",
+          "length": "MXLEN",
+          "desc": "Hypervisor guest address translation and protection"
+        },
+        "hstateen0": {
+          "address": "1548",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Hypervisor State Enable 0 Register"
+        },
+        "hstateen0h": {
+          "address": "1564",
+          "priv_mode": "S",
+          "length": 32,
+          "desc": "Upper 32 bits of Hypervisor State Enable 0 Register"
+        },
+        "hstateen1": {
+          "address": "1549",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Hypervisor State Enable 1 Register"
+        },
+        "hstateen1h": {
+          "address": "1565",
+          "priv_mode": "S",
+          "length": 32,
+          "desc": "Upper 32 bits of Hypervisor State Enable 1 Register"
+        },
+        "hstateen2": {
+          "address": "1550",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Hypervisor State Enable 2 Register"
+        },
+        "hstateen2h": {
+          "address": "1566",
+          "priv_mode": "S",
+          "length": 32,
+          "desc": "Upper 32 bits of Hypervisor State Enable 2 Register"
+        },
+        "hstateen3": {
+          "address": "1551",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Hypervisor State Enable 3 Register"
+        },
+        "hstateen3h": {
+          "address": "1567",
+          "priv_mode": "S",
+          "length": 32,
+          "desc": "Upper 32 bits of Hypervisor State Enable 3 Register"
+        },
+        "hstatus": {
+          "address": "1536",
+          "priv_mode": "S",
+          "length": "MXLEN",
+          "desc": "Hypervisor Status"
+        },
+        "htimedelta": {
+          "address": "1541",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Hypervisor time delta"
+        },
+        "htimedeltah": {
+          "address": "1557",
+          "priv_mode": "S",
+          "length": 32,
+          "desc": "Hypervisor time delta, upper half"
+        },
+        "htinst": {
+          "address": "1610",
+          "priv_mode": "S",
+          "length": "MXLEN",
+          "desc": "Hypervisor Trap Instruction Register"
+        },
+        "htval": {
+          "address": "1603",
+          "priv_mode": "M",
+          "length": "MXLEN",
+          "desc": "Hypervisor Trap Value Register"
+        },
+        "mtinst": {
+          "address": "842",
+          "priv_mode": "M",
+          "length": "MXLEN",
+          "desc": "Machine Trap Instruction Register"
+        },
+        "mtval2": {
+          "address": "843",
+          "priv_mode": "M",
+          "length": "MXLEN",
+          "desc": "Machine Second Trap Value Register"
+        },
+        "vsatp": {
+          "address": "640",
+          "priv_mode": "VS",
+          "length": "MXLEN",
+          "desc": "Virtual Supervisor Address Translation and Protection"
+        },
+        "vscause": {
+          "address": "578",
+          "priv_mode": "VS",
+          "length": "MXLEN",
+          "desc": "Virtual Supervisor Cause"
+        },
+        "vsepc": {
+          "address": "577",
+          "priv_mode": "VS",
+          "length": 64,
+          "desc": "Virtual Supervisor Exception Program Counter"
+        },
+        "vsstatus": {
+          "address": "512",
+          "priv_mode": "VS",
+          "length": "MXLEN",
+          "desc": "Virtual Supervisor Status"
+        },
+        "vstval": {
+          "address": "579",
+          "priv_mode": "S",
+          "length": "MXLEN",
+          "desc": "Virtual supervisor Trap Value"
+        },
+        "vstvec": {
+          "address": "517",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Supervisor Trap Vector"
+        }
+      }
     },
     {
       "id": "K",
@@ -6325,7 +6515,105 @@
           "mask": "0xffffffff"
         }
       },
-      "url": "https://docs.riscv.org/reference/isa/priv/supervisor.html"
+      "url": "https://docs.riscv.org/reference/isa/priv/supervisor.html",
+      "csrs": {
+        "medeleg": {
+          "address": "770",
+          "priv_mode": "M",
+          "length": 64,
+          "desc": "Machine Exception Delegation"
+        },
+        "medelegh": {
+          "address": "786",
+          "priv_mode": "M",
+          "length": 32,
+          "desc": "Machine Exception Delegation, High bits"
+        },
+        "mideleg": {
+          "address": "771",
+          "priv_mode": "M",
+          "length": "MXLEN",
+          "desc": "Machine Interrupt Delegation"
+        },
+        "mscontext": {
+          "address": "1962",
+          "priv_mode": "S",
+          "length": "MXLEN",
+          "desc": "Machine Supervisor Context"
+        },
+        "satp": {
+          "address": "384",
+          "priv_mode": "S",
+          "length": "MXLEN",
+          "desc": "Supervisor Address Translation and Protection"
+        },
+        "scause": {
+          "address": "322",
+          "priv_mode": "S",
+          "length": "MXLEN",
+          "desc": "Supervisor Cause"
+        },
+        "scontext": {
+          "address": "1448",
+          "priv_mode": "S",
+          "length": "MXLEN",
+          "desc": "Supervisor Context"
+        },
+        "scounteren": {
+          "address": "262",
+          "priv_mode": "S",
+          "length": 32,
+          "desc": "Supervisor Counter Enable"
+        },
+        "senvcfg": {
+          "address": "266",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Supervisor Environment Configuration"
+        },
+        "sepc": {
+          "address": "321",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Supervisor Exception Program Counter"
+        },
+        "sie": {
+          "address": "260",
+          "priv_mode": "S",
+          "length": "MXLEN",
+          "desc": "Supervisor interrupt-enable register"
+        },
+        "sip": {
+          "address": "324",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Supervisor Interrupt Pending"
+        },
+        "sscratch": {
+          "address": "320",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Supervisor Scratch Register"
+        },
+        "sstatus": {
+          "address": "256",
+          "priv_mode": "S",
+          "length": "MXLEN",
+          "desc": "Supervisor Status"
+        },
+        "stval": {
+          "address": "323",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Supervisor Trap Value"
+        },
+        "stvec": {
+          "address": "261",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Supervisor Trap Vector"
+        }
+      }
     },
     {
       "id": "U",
@@ -6347,7 +6635,33 @@
           "mask": "0xffffffff"
         }
       },
-      "url": "https://docs.riscv.org/reference/isa/priv/machine.html"
+      "url": "https://docs.riscv.org/reference/isa/priv/machine.html",
+      "csrs": {
+        "mcounteren": {
+          "address": "774",
+          "priv_mode": "M",
+          "length": 32,
+          "desc": "Machine Counter Enable"
+        },
+        "menvcfg": {
+          "address": "778",
+          "priv_mode": "M",
+          "length": 64,
+          "desc": "Machine Environment Configuration"
+        },
+        "menvcfgh": {
+          "address": "794",
+          "priv_mode": "M",
+          "length": 32,
+          "desc": "Machine Environment Configuration"
+        },
+        "senvcfg": {
+          "address": "266",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "Supervisor Environment Configuration"
+        }
+      }
     },
     {
       "id": "V",
@@ -14904,7 +15218,51 @@
           "mask": "0xfc0ff07f"
         }
       },
-      "url": "https://docs.riscv.org/reference/isa/unpriv/v-st-ext.html"
+      "url": "https://docs.riscv.org/reference/isa/unpriv/v-st-ext.html",
+      "csrs": {
+        "vcsr": {
+          "address": "15",
+          "priv_mode": "U",
+          "length": "MXLEN",
+          "desc": "Vector Control and Status Register"
+        },
+        "vl": {
+          "address": "3104",
+          "priv_mode": "U",
+          "length": "MXLEN",
+          "desc": "Vector Length"
+        },
+        "vlenb": {
+          "address": "3106",
+          "priv_mode": "U",
+          "length": "MXLEN",
+          "desc": "Vector Byte Length"
+        },
+        "vstart": {
+          "address": "8",
+          "priv_mode": "U",
+          "length": "MXLEN",
+          "desc": "Vector Start Index"
+        },
+        "vtype": {
+          "address": "3105",
+          "priv_mode": "U",
+          "length": "MXLEN",
+          "desc": "Vector Type"
+        },
+        "vxrm": {
+          "address": "10",
+          "priv_mode": "U",
+          "length": "MXLEN",
+          "desc": "Vector Fixed-Point Rounding Mode"
+        },
+        "vxsat": {
+          "address": "9",
+          "priv_mode": "U",
+          "length": "MXLEN",
+          "desc": "Vector Fixed-Point Saturate Flag"
+        }
+      }
     }
   ],
   "z_bit": [
@@ -17003,6 +17361,14 @@
           ],
           "match": "0xa002",
           "mask": "0xfc03"
+        }
+      },
+      "csrs": {
+        "jvt": {
+          "address": "23",
+          "priv_mode": "U",
+          "length": "MXLEN",
+          "desc": "Table Jump Base Vector and Control Register"
         }
       }
     },
@@ -21477,7 +21843,21 @@
       "desc": "CFI Landing Pads",
       "use": "Forward-edge CFI for calls",
       "url": "https://docs.riscv.org/reference/isa/unpriv/unpriv-cfi.html",
-      "instructions": {}
+      "instructions": {},
+      "csrs": {
+        "mseccfg": {
+          "address": "1863",
+          "priv_mode": "M",
+          "length": 64,
+          "desc": "Machine Security Configuration"
+        },
+        "mseccfgh": {
+          "address": "1879",
+          "priv_mode": "M",
+          "length": 32,
+          "desc": "Most significant 32 bits of Machine Security Configuration"
+        }
+      }
     },
     {
       "id": "Zicfiss",
@@ -21518,6 +21898,14 @@
           ],
           "match": "0x4800202f",
           "mask": "0xf800707f"
+        }
+      },
+      "csrs": {
+        "ssp": {
+          "address": "17",
+          "priv_mode": "U",
+          "length": "MXLEN",
+          "desc": "Shadow Stack Pointer"
         }
       }
     },
@@ -23889,6 +24277,20 @@
           "match": "0x1502073",
           "mask": "0xfffff07f"
         }
+      },
+      "csrs": {
+        "mseccfg": {
+          "address": "1863",
+          "priv_mode": "M",
+          "length": 64,
+          "desc": "Machine Security Configuration"
+        },
+        "mseccfgh": {
+          "address": "1879",
+          "priv_mode": "M",
+          "length": 32,
+          "desc": "Most significant 32 bits of Machine Security Configuration"
+        }
       }
     },
     {
@@ -25817,7 +26219,51 @@
       "desc": "Base Counters/Timers",
       "use": "cycle/instret + timers",
       "url": "https://docs.riscv.org/reference/isa/unpriv/counters.html",
-      "instructions": {}
+      "instructions": {},
+      "csrs": {
+        "cycle": {
+          "address": "3072",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Cycle counter for RDCYCLE Instruction"
+        },
+        "cycleh": {
+          "address": "3200",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "High-half cycle counter for RDCYCLE Instruction"
+        },
+        "instret": {
+          "address": "3074",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Instructions retired counter for RDINSTRET Instruction"
+        },
+        "instreth": {
+          "address": "3202",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Instructions retired counter, high bits"
+        },
+        "minstreth": {
+          "address": "2946",
+          "priv_mode": "M",
+          "length": 32,
+          "desc": "Machine Instructions Retired Counter"
+        },
+        "time": {
+          "address": "3073",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Timer for RDTIME Instruction"
+        },
+        "timeh": {
+          "address": "3201",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "High-half timer for RDTIME Instruction"
+        }
+      }
     },
     {
       "id": "Zicntrpmf",
@@ -25968,7 +26414,357 @@
       "desc": "Perf Counters",
       "use": "Hardware performance monitors",
       "url": "https://docs.riscv.org/reference/isa/unpriv/counters.html",
-      "instructions": {}
+      "instructions": {},
+      "csrs": {
+        "hpmcounter10": {
+          "address": "3082",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 10"
+        },
+        "hpmcounter10h": {
+          "address": "3210",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 10, high half"
+        },
+        "hpmcounter11": {
+          "address": "3083",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 11"
+        },
+        "hpmcounter11h": {
+          "address": "3211",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 11, high half"
+        },
+        "hpmcounter12": {
+          "address": "3084",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 12"
+        },
+        "hpmcounter12h": {
+          "address": "3212",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 12, high half"
+        },
+        "hpmcounter13": {
+          "address": "3085",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 13"
+        },
+        "hpmcounter13h": {
+          "address": "3213",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 13, high half"
+        },
+        "hpmcounter14": {
+          "address": "3086",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 14"
+        },
+        "hpmcounter14h": {
+          "address": "3214",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 14, high half"
+        },
+        "hpmcounter15": {
+          "address": "3087",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 15"
+        },
+        "hpmcounter15h": {
+          "address": "3215",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 15, high half"
+        },
+        "hpmcounter16": {
+          "address": "3088",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 16"
+        },
+        "hpmcounter16h": {
+          "address": "3216",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 16, high half"
+        },
+        "hpmcounter17": {
+          "address": "3089",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 17"
+        },
+        "hpmcounter17h": {
+          "address": "3217",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 17, high half"
+        },
+        "hpmcounter18": {
+          "address": "3090",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 18"
+        },
+        "hpmcounter18h": {
+          "address": "3218",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 18, high half"
+        },
+        "hpmcounter19": {
+          "address": "3091",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 19"
+        },
+        "hpmcounter19h": {
+          "address": "3219",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 19, high half"
+        },
+        "hpmcounter20": {
+          "address": "3092",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 20"
+        },
+        "hpmcounter20h": {
+          "address": "3220",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 20, high half"
+        },
+        "hpmcounter21": {
+          "address": "3093",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 21"
+        },
+        "hpmcounter21h": {
+          "address": "3221",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 21, high half"
+        },
+        "hpmcounter22": {
+          "address": "3094",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 22"
+        },
+        "hpmcounter22h": {
+          "address": "3222",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 22, high half"
+        },
+        "hpmcounter23": {
+          "address": "3095",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 23"
+        },
+        "hpmcounter23h": {
+          "address": "3223",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 23, high half"
+        },
+        "hpmcounter24": {
+          "address": "3096",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 24"
+        },
+        "hpmcounter24h": {
+          "address": "3224",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 24, high half"
+        },
+        "hpmcounter25": {
+          "address": "3097",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 25"
+        },
+        "hpmcounter25h": {
+          "address": "3225",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 25, high half"
+        },
+        "hpmcounter26": {
+          "address": "3098",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 26"
+        },
+        "hpmcounter26h": {
+          "address": "3226",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 26, high half"
+        },
+        "hpmcounter27": {
+          "address": "3099",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 27"
+        },
+        "hpmcounter27h": {
+          "address": "3227",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 27, high half"
+        },
+        "hpmcounter28": {
+          "address": "3100",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 28"
+        },
+        "hpmcounter28h": {
+          "address": "3228",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 28, high half"
+        },
+        "hpmcounter29": {
+          "address": "3101",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 29"
+        },
+        "hpmcounter29h": {
+          "address": "3229",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 29, high half"
+        },
+        "hpmcounter3": {
+          "address": "3075",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 3"
+        },
+        "hpmcounter30": {
+          "address": "3102",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 30"
+        },
+        "hpmcounter30h": {
+          "address": "3230",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 30, high half"
+        },
+        "hpmcounter31": {
+          "address": "3103",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 31"
+        },
+        "hpmcounter31h": {
+          "address": "3231",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 31, high half"
+        },
+        "hpmcounter3h": {
+          "address": "3203",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 3, high half"
+        },
+        "hpmcounter4": {
+          "address": "3076",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 4"
+        },
+        "hpmcounter4h": {
+          "address": "3204",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 4, high half"
+        },
+        "hpmcounter5": {
+          "address": "3077",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 5"
+        },
+        "hpmcounter5h": {
+          "address": "3205",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 5, high half"
+        },
+        "hpmcounter6": {
+          "address": "3078",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 6"
+        },
+        "hpmcounter6h": {
+          "address": "3206",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 6, high half"
+        },
+        "hpmcounter7": {
+          "address": "3079",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 7"
+        },
+        "hpmcounter7h": {
+          "address": "3207",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 7, high half"
+        },
+        "hpmcounter8": {
+          "address": "3080",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 8"
+        },
+        "hpmcounter8h": {
+          "address": "3208",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 8, high half"
+        },
+        "hpmcounter9": {
+          "address": "3081",
+          "priv_mode": "U",
+          "length": 64,
+          "desc": "Unprivileged Hardware Performance Counter 9"
+        },
+        "hpmcounter9h": {
+          "address": "3209",
+          "priv_mode": "U",
+          "length": 32,
+          "desc": "Unprivileged Hardware Performance Counter 9, high half"
+        }
+      }
     },
     {
       "id": "Zilsm*",
@@ -26772,6 +27568,32 @@
           "match": "0x70200073",
           "mask": "0xffffffff"
         }
+      },
+      "csrs": {
+        "mncause": {
+          "address": "1858",
+          "priv_mode": "M",
+          "length": "MXLEN",
+          "desc": "Resumable NMI cause"
+        },
+        "mnepc": {
+          "address": "1857",
+          "priv_mode": "M",
+          "length": "MXLEN",
+          "desc": "Machine Exception Program Counter"
+        },
+        "mnscratch": {
+          "address": "1856",
+          "priv_mode": "M",
+          "length": "MXLEN",
+          "desc": "Machine Scratch Register"
+        },
+        "mnstatus": {
+          "address": "1860",
+          "priv_mode": "M",
+          "length": "MXLEN",
+          "desc": "Machine NMI Status"
+        }
       }
     }
   ],
@@ -26794,6 +27616,32 @@
           ],
           "match": "0x7b200073",
           "mask": "0xffffffff"
+        }
+      },
+      "csrs": {
+        "dcsr": {
+          "address": "1968",
+          "priv_mode": "D",
+          "length": 32,
+          "desc": "Debug Control and Status Register"
+        },
+        "dpc": {
+          "address": "1969",
+          "priv_mode": "D",
+          "length": "MXLEN",
+          "desc": "Debug PC Register"
+        },
+        "dscratch0": {
+          "address": "1970",
+          "priv_mode": "D",
+          "length": "MXLEN",
+          "desc": "Debug scratch register"
+        },
+        "dscratch1": {
+          "address": "1971",
+          "priv_mode": "D",
+          "length": "MXLEN",
+          "desc": "Debug scratch register"
         }
       }
     },

--- a/tests/catalog-coverage.test.mjs
+++ b/tests/catalog-coverage.test.mjs
@@ -1,0 +1,134 @@
+/**
+ * Coverage invariants for the extension catalogue.
+ *
+ * Context, because the raw numbers mislead: 125 of 227 entries have neither
+ * instructions nor CSRs, and that is mostly correct. Umbrellas and aliases
+ * (K, N, P, Zve, Zvf), VLEN parameter entries (Zvl32b ... Zvl1024b) and
+ * behavioural guarantees (Zkt, which promises data-independent timing and
+ * defines nothing) all legitimately carry no encodings.
+ *
+ * So this does not assert "every extension has content", which would be false,
+ * and it does not carry a 125-entry allowlist, which would be unmaintainable
+ * fiction. It asserts what is actually knowable, each case having caught or
+ * being able to catch a real defect:
+ *
+ *   1. A tag that yields nothing is a broken mapping, not an empty extension.
+ *   2. An umbrella that resolves to nothing means its members went stale.
+ *   3. CSR coverage is a ratchet, so a sync regression cannot pass silently.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const here = path.dirname(new URL(import.meta.url).pathname);
+const catalog = JSON.parse(
+  fs.readFileSync(path.join(here, '..', 'src', 'riscv_extensions.json'), 'utf8'),
+);
+
+const entries = [];
+(function collect(node) {
+  if (Array.isArray(node)) node.forEach(collect);
+  else if (node && typeof node === 'object') {
+    if (node.id && node.desc) entries.push(node);
+    Object.values(node).forEach(collect);
+  }
+}(catalog));
+
+const instructionCount = (e) => Object.keys(e.instructions || {}).length;
+const csrCount = (e) => Object.keys(e.csrs || {}).length;
+
+test('the catalogue is non-trivial', () => {
+  assert.ok(entries.length > 200, `expected the full catalogue, found ${entries.length} entries`);
+});
+
+test('every tagged extension yields instructions or CSRs', () => {
+  // A tag exists to route upstream data onto an entry. One that routes nothing
+  // is either a typo or a tag upstream has since renamed, and it fails
+  // silently: the extension just looks empty. This is the #8 / #107 failure.
+  const barren = entries
+    .filter((e) => (e.tags || []).length > 0)
+    .filter((e) => instructionCount(e) === 0 && csrCount(e) === 0)
+    .map((e) => `${e.id} [${e.tags.join(', ')}]`);
+
+  assert.deepEqual(
+    barren, [],
+    'these entries carry tags that resolved to nothing, so the tag is wrong or upstream renamed it:\n  '
+      + barren.join('\n  '),
+  );
+});
+
+test('every umbrella resolves to instructions', () => {
+  // Umbrellas take their content from `members`. One resolving to nothing means
+  // a member id no longer exists, which the sync cannot detect by itself.
+  const hollow = entries
+    .filter((e) => (e.members || []).length > 0)
+    .filter((e) => instructionCount(e) === 0)
+    .map((e) => `${e.id} <- ${e.members.join(', ')}`);
+
+  assert.deepEqual(hollow, [], `umbrella extensions resolved to no instructions:\n  ${hollow.join('\n  ')}`);
+});
+
+test('umbrella members all exist', () => {
+  const ids = new Set(entries.map((e) => e.id));
+  const dangling = [];
+  for (const e of entries) {
+    for (const m of e.members || []) if (!ids.has(m)) dangling.push(`${e.id} -> ${m}`);
+  }
+  assert.deepEqual(dangling, [], `umbrella members that are not catalogue entries:\n  ${dangling.join('\n  ')}`);
+});
+
+test('CSR coverage does not regress', () => {
+  // Ratchet. CSRs come from riscv-unified-db via scripts/sync_udb_extensions.cjs,
+  // and the two ways that sync silently under-delivered are worth pinning:
+  // reading only the top level of csr/ (85 of 396 files, so F, V and Zihpm came
+  // back empty), and matching definedBy as text rather than as structure (which
+  // filed mstatus under both V and F).
+  const withCsrs = entries.filter((e) => csrCount(e) > 0);
+  const total = withCsrs.reduce((n, e) => n + csrCount(e), 0);
+
+  assert.ok(
+    withCsrs.length >= 30,
+    `expected at least 30 extensions with CSRs, found ${withCsrs.length}`,
+  );
+  assert.ok(total >= 234, `expected at least 234 CSRs in total, found ${total}`);
+});
+
+test('CSRs land on the extension a reader would look under', () => {
+  // Spot checks with unambiguous answers. Each of these was wrong at some point
+  // during the sync work, so they are worth naming explicitly.
+  const byId = new Map(entries.map((e) => [e.id, e]));
+  const expected = {
+    F: ['fcsr', 'fflags', 'frm'],
+    V: ['vl', 'vtype', 'vlenb'],
+    Zicntr: ['cycle', 'instret', 'time'],
+    S: ['satp'],
+  };
+
+  for (const [id, names] of Object.entries(expected)) {
+    const entry = byId.get(id);
+    assert.ok(entry, `${id} is missing from the catalogue`);
+    const have = new Set(Object.keys(entry.csrs || {}).map((n) => n.toLowerCase()));
+    for (const n of names) {
+      assert.ok(have.has(n), `${id} should list the ${n.toUpperCase()} CSR`);
+    }
+  }
+
+  // And the inverse. MSTATUS is a machine CSR; it declares a conditional
+  // relationship to V and F because it carries the VS and FS fields, which a
+  // text-matching parser mistook for ownership.
+  for (const id of ['V', 'F']) {
+    const have = new Set(Object.keys(byId.get(id)?.csrs || {}).map((n) => n.toLowerCase()));
+    assert.ok(!have.has('mstatus'), `${id} must not claim the MSTATUS CSR`);
+  }
+});
+
+test('extension ids are unique', () => {
+  const seen = new Set();
+  const dupes = [];
+  for (const e of entries) {
+    if (seen.has(e.id)) dupes.push(e.id);
+    seen.add(e.id);
+  }
+  assert.deepEqual(dupes, [], `duplicate extension ids: ${dupes.join(', ')}`);
+});


### PR DESCRIPTION
Closes #130

CSR coverage: **17 extensions / 97 CSRs → 30 / 234**.

F, V, Zicntr, Zihpm, H, U and Smstateen had none, which is why searching `mstatus`, `mcycle`, `fcsr`, `vtype` or `hpmcounter3` returned nothing at all. All of those now resolve.

### Extends the existing sync rather than adding a parallel one

The catalogue already had a `csrs` field and `sync_udb_extensions.cjs` already read UDB's CSR directory. The scope was just narrow: supervisor-prefixed extensions with no structured data. A second pass now indexes the whole CSR tree once and fills entries still missing CSRs, leaving curated ones untouched.

I started down the wrong path here and backed out of it: my first attempt added a separate `extension_csrs.json` plus a new `sync_csrs.mjs`, which would have meant two scripts reading the same source with two parsers. Reverted in favour of the field that already existed.

### Two bugs found by checking the output rather than trusting it

**The CSR directory is not flat.** Alongside 85 loose files it holds per-extension subdirectories (`F/`, `V/`, `Zicntr/`, …). Reading only the top level saw **85 of 396 files**, and reported F, V and Zihpm as having no CSRs.

**`definedBy` must be parsed as structure, not matched as text.** The existing matcher scans the indented block for any `name:`, which suits the simple supervisor entries it was written for. At catalogue scale it filed `mstatus`, `misa` and `sstatus` under **both V and F** — because `mstatus` declares a conditional relationship to them through its VS and FS fields — while Zihpm's 58 counters matched nothing.

Both are now pinned by tests.

### Ownership follows our model where the two disagree

UDB attributes vector CSRs to `Zvl32b`, the minimum VLEN extension, since any V implementation has VLEN ≥ 32. We file them under **V**, exactly as we already do for vector instructions, so VL and VTYPE appear where a reader looks for them.

### The new test states what is knowable

It deliberately does **not** assert that every extension has content — that is false. 125 entries are umbrellas, aliases, VLEN parameter entries or behavioural guarantees (Zkt promises data-independent timing and defines nothing). Nor does it carry a 125-entry allowlist, which would be unmaintainable fiction.

It asserts instead: a tag never resolves to nothing (the #8/#107 failure mode), umbrellas resolve and their members exist, CSR coverage ratchets, and F/V/Zicntr/S carry the right CSRs while V and F do **not** claim MSTATUS.

Verified by stripping F's CSRs, watching two tests fail, and restoring them with the sync.

### Verification

| check | result |
|---|---|
| tests | **121** pass (114 + 7 new) |
| lint | exit 0 |
| instruction totals | unchanged at 1811 |
| catalogue diff | CSR blocks only |
| CSR search | `mstatus`, `mcycle`, `fcsr`, `vtype`, `hpmcounter3`, `satp` all resolve |

### Not included

The instruction-side gaps in #8, #12 and #107. They turn out to be **pseudo-ops**, and `rv32_zclsd` in particular redefines `c.ld`/`c.sd` onto the C.FLW/C.FSW encodings, which would collide with the existing RV64 mnemonics. That needs a decision about how to represent aliases, not a quiet import.