### PR TITLE
data: remove instructions withdrawn before ratification

### DIFF
--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -307,7 +307,14 @@ for (const entry of umbrellaEntries) {
 // These counts rose when the ratified bitmanip instructions were added. Zbb
 // gained ORC.B and REV8 (+2), and Zbkb gained BREV8, ZIP, UNZIP and REV8.RV32,
 // which carries +4 into every umbrella that includes Zbkb.
-assertExtension('B', { count: 44 });
+// B then fell from 44 to 40 when SLO, SRO, SLOI and SROI were removed. Those are
+// draft bitmanip shift-ones operations, dropped before ratification, which our
+// vendored instr_dict still tagged rv_zbb and rv64_zbb, so they surfaced inside
+// a ratified extension.
+assertExtension('B', { count: 40 });
+// Pinned explicitly because this is the count that was wrong: ratified Zbb has
+// 24 instructions across RV32 and RV64, and the four draft ops made it read 28.
+assertExtension('Zbb', { count: 24 });
 assertExtension('Zk', { count: 51 }); // Zkn(45) ∪ Zks(24) minus shared Zbkb/Zbkc/Zbkx = 51 unique
 
 const zkExt = extMap.get('Zk');

--- a/src/instr_dict.json
+++ b/src/instr_dict.json
@@ -4494,32 +4494,6 @@
     "match": "0x2027",
     "mask": "0x707f"
   },
-  "gorci": {
-    "encoding": "001010-----------101-----0010011",
-    "variable_fields": [
-      "rd",
-      "rs1",
-      "shamtd"
-    ],
-    "extension": [
-      "rv64_zbp"
-    ],
-    "match": "0x28005013",
-    "mask": "0xfc00707f"
-  },
-  "grevi": {
-    "encoding": "011010-----------101-----0010011",
-    "variable_fields": [
-      "rd",
-      "rs1",
-      "shamtd"
-    ],
-    "extension": [
-      "rv64_zbp"
-    ],
-    "match": "0x68005013",
-    "mask": "0xfc00707f"
-  },
   "hfence_gvma": {
     "encoding": "0110001----------000000001110011",
     "variable_fields": [
@@ -5806,19 +5780,6 @@
     "match": "0x52000033",
     "mask": "0xfe00707f"
   },
-  "shfli": {
-    "encoding": "0000100----------001-----0010011",
-    "variable_fields": [
-      "rd",
-      "rs1",
-      "shamtw"
-    ],
-    "extension": [
-      "rv64_zbp"
-    ],
-    "match": "0x8001013",
-    "mask": "0xfe00707f"
-  },
   "sinval_vma": {
     "encoding": "0001011----------000000001110011",
     "variable_fields": [
@@ -5856,34 +5817,6 @@
     ],
     "match": "0x1013",
     "mask": "0xfc00707f"
-  },
-  "slo": {
-    "encoding": "0010000----------001-----0110011",
-    "variable_fields": [
-      "rd",
-      "rs1",
-      "rs2"
-    ],
-    "extension": [
-      "rv_zbb"
-    ],
-    "match": "0x20001033",
-    "mask": "0xfe00707f",
-    "deprecated": true
-  },
-  "sloi": {
-    "encoding": "001000-----------001-----0010011",
-    "variable_fields": [
-      "rd",
-      "rs1",
-      "shamtd"
-    ],
-    "extension": [
-      "rv64_zbb"
-    ],
-    "match": "0x20001013",
-    "mask": "0xfc00707f",
-    "deprecated": true
   },
   "slli_uw": {
     "encoding": "000010-----------001-----0011011",
@@ -6119,34 +6052,6 @@
     "match": "0x5013",
     "mask": "0xfc00707f"
   },
-  "sro": {
-    "encoding": "0010000----------101-----0110011",
-    "variable_fields": [
-      "rd",
-      "rs1",
-      "rs2"
-    ],
-    "extension": [
-      "rv_zbb"
-    ],
-    "match": "0x20005033",
-    "mask": "0xfe00707f",
-    "deprecated": true
-  },
-  "sroi": {
-    "encoding": "001000-----------101-----0010011",
-    "variable_fields": [
-      "rd",
-      "rs1",
-      "shamtd"
-    ],
-    "extension": [
-      "rv64_zbb"
-    ],
-    "match": "0x20005013",
-    "mask": "0xfc00707f",
-    "deprecated": true
-  },
   "srliw": {
     "encoding": "0000000----------101-----0011011",
     "variable_fields": [
@@ -6255,19 +6160,6 @@
     ],
     "match": "0x3a00202f",
     "mask": "0xfa007fff"
-  },
-  "unshfli": {
-    "encoding": "0000100----------101-----0010011",
-    "variable_fields": [
-      "rd",
-      "rs1",
-      "shamtw"
-    ],
-    "extension": [
-      "rv64_zbp"
-    ],
-    "match": "0x8005013",
-    "mask": "0xfe00707f"
   },
   "uret": {
     "encoding": "00000000001000000000000001110011",
@@ -15962,32 +15854,6 @@
     ],
     "match": "0x4013",
     "mask": "0x707f"
-  },
-  "xperm16": {
-    "encoding": "0010100----------110-----0110011",
-    "variable_fields": [
-      "rd",
-      "rs1",
-      "rs2"
-    ],
-    "extension": [
-      "rv_zbp"
-    ],
-    "match": "0x28006033",
-    "mask": "0xfe00707f"
-  },
-  "xperm32": {
-    "encoding": "0010100----------000-----0110011",
-    "variable_fields": [
-      "rd",
-      "rs1",
-      "rs2"
-    ],
-    "extension": [
-      "rv64_zbp"
-    ],
-    "match": "0x28000033",
-    "mask": "0xfe00707f"
   },
   "xperm4": {
     "encoding": "0010100----------010-----0110011",

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -3694,34 +3694,6 @@
           "match": "0x6000503b",
           "mask": "0xfe00707f"
         },
-        "SLOI": {
-          "encoding": "001000-----------001-----0010011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "shamtd"
-          ],
-          "extension": [
-            "rv64_zbb"
-          ],
-          "match": "0x20001013",
-          "mask": "0xfc00707f",
-          "deprecated": true
-        },
-        "SROI": {
-          "encoding": "001000-----------101-----0010011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "shamtd"
-          ],
-          "extension": [
-            "rv64_zbb"
-          ],
-          "match": "0x20005013",
-          "mask": "0xfc00707f",
-          "deprecated": true
-        },
         "REV8": {
           "encoding": "011010111000-----101-----0010011",
           "variable_fields": [
@@ -3925,34 +3897,6 @@
           ],
           "match": "0x60501013",
           "mask": "0xfff0707f"
-        },
-        "SLO": {
-          "encoding": "0010000----------001-----0110011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2"
-          ],
-          "extension": [
-            "rv_zbb"
-          ],
-          "match": "0x20001033",
-          "mask": "0xfe00707f",
-          "deprecated": true
-        },
-        "SRO": {
-          "encoding": "0010000----------101-----0110011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2"
-          ],
-          "extension": [
-            "rv_zbb"
-          ],
-          "match": "0x20005033",
-          "mask": "0xfe00707f",
-          "deprecated": true
         },
         "XNOR": {
           "encoding": "0100000----------100-----0110011",
@@ -15497,34 +15441,6 @@
           "match": "0x6000503b",
           "mask": "0xfe00707f"
         },
-        "SLOI": {
-          "encoding": "001000-----------001-----0010011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "shamtd"
-          ],
-          "extension": [
-            "rv64_zbb"
-          ],
-          "match": "0x20001013",
-          "mask": "0xfc00707f",
-          "deprecated": true
-        },
-        "SROI": {
-          "encoding": "001000-----------101-----0010011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "shamtd"
-          ],
-          "extension": [
-            "rv64_zbb"
-          ],
-          "match": "0x20005013",
-          "mask": "0xfc00707f",
-          "deprecated": true
-        },
         "REV8": {
           "encoding": "011010111000-----101-----0010011",
           "variable_fields": [
@@ -15728,34 +15644,6 @@
           ],
           "match": "0x60501013",
           "mask": "0xfff0707f"
-        },
-        "SLO": {
-          "encoding": "0010000----------001-----0110011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2"
-          ],
-          "extension": [
-            "rv_zbb"
-          ],
-          "match": "0x20001033",
-          "mask": "0xfe00707f",
-          "deprecated": true
-        },
-        "SRO": {
-          "encoding": "0010000----------101-----0110011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2"
-          ],
-          "extension": [
-            "rv_zbb"
-          ],
-          "match": "0x20005033",
-          "mask": "0xfe00707f",
-          "deprecated": true
         },
         "XNOR": {
           "encoding": "0100000----------100-----0110011",

--- a/tests/catalog-coverage.test.mjs
+++ b/tests/catalog-coverage.test.mjs
@@ -123,6 +123,39 @@ test('CSRs land on the extension a reader would look under', () => {
   }
 });
 
+test('no unratified draft instructions are published', () => {
+  // Wrong data is worse than missing data in a reference: a fabricated encoding
+  // can be implemented against. These are draft bitmanip operations that were
+  // dropped before ratification, and our vendored instr_dict still tagged the
+  // first four rv_zbb / rv64_zbb, so they appeared inside a ratified extension.
+  // Zbp was never ratified at all: it is 404 upstream and absent from UDB.
+  const withdrawn = [
+    'SLO', 'SLOI', 'SRO', 'SROI',                       // draft Zbb shift-ones
+    'GORCI', 'GREVI', 'SHFLI', 'UNSHFLI',               // draft Zbp
+    'XPERM16', 'XPERM32',                               // draft Zbp
+  ];
+  const published = [];
+  for (const e of entries) {
+    for (const m of Object.keys(e.instructions || {})) {
+      if (withdrawn.includes(m.toUpperCase())) published.push(`${e.id}.${m}`);
+    }
+  }
+  assert.deepEqual(
+    published, [],
+    `these instructions were withdrawn before ratification and must not ship:\n  ${published.join('\n  ')}`,
+  );
+});
+
+test('Zbb matches the ratified instruction set', () => {
+  // The concrete symptom of the above: Zbb read 28 instructions instead of 24.
+  const zbb = entries.find((e) => e.id === 'Zbb');
+  assert.ok(zbb, 'Zbb is missing from the catalogue');
+  assert.equal(
+    Object.keys(zbb.instructions || {}).length, 24,
+    'ratified Zbb has 24 instructions across RV32 and RV64',
+  );
+});
+
 test('extension ids are unique', () => {
   const seen = new Set();
   const dupes = [];


### PR DESCRIPTION
The catalogue was publishing **10 instructions that do not exist in ratified RISC-V**.

Wrong data is worse than missing data in a reference tool: a missing instruction makes it incomplete, a fabricated encoding can be implemented against.

### What was wrong

**SLO, SRO, SLOI, SROI** — draft bitmanip shift-ones ops, dropped before ratification. Our vendored `instr_dict` still tagged them `rv_zbb` / `rv64_zbb`, so they appeared **inside a ratified extension**, making Zbb report 28 instructions where the ratified set has 24. Upstream `rv_zbb` and `rv64_zbb` no longer list them.

**GORCI, GREVI, SHFLI, UNSHFLI, XPERM16, XPERM32** — Zbp, which was never ratified. `rv_zbp` is **404 upstream** and the extension is absent from UDB. No catalogue entry carried a `zbp` tag so these never reached the browser, but they did sit in the **Encoder Validator's conflict database**, where a proposed encoding could be reported as clashing with an instruction that does not exist.

Zbb is now exactly the ratified set:

```
ANDN CLZ CLZW CPOP CPOPW CTZ CTZW MAX MAXU MIN MINU ORC.B
ORN REV8 ROL ROLW ROR RORI RORIW RORW SEXT.B SEXT.H XNOR ZEXT.H
```

B falls 44 → 40 accordingly. Both counts are asserted in the sync script, and two new tests pin the withdrawn mnemonics and the Zbb count.

### Deliberately scoped — and this is the important part

**"Absent from upstream" is not the same as "not ratified."**

My first reconciliation flagged **313** instructions as missing upstream, including all **252 vector segment loads** (`vlseg2e16.v` and friends). Those are real, ratified V instructions — riscv-opcodes simply carries no `vlseg` encodings at all. A blanket purge would have deleted correct data and gutted the V extension.

A second heuristic then flagged 95 instructions via "extension not in UDB", which was also wrong: `rv_d_zfa`, `rv_c_d`, `rv_zicbo` and `rv_system` are intersection and file tags, not extension names, so it condemned MRET, WFI and the CBO instructions. And checking properly showed **Zalasr is ratified (2025-10)**, so removing its 8 instructions would have been a mistake too.

Only instructions with **direct evidence of withdrawal** are removed here.

### Draft extensions are left alone, on purpose

Zvabd, Zibi and the vector dot-product proposals are genuinely unratified. But the catalogue already has `state` and `ratification_date` fields, so the right treatment is to **populate and label** them rather than delete work people may be tracking deliberately. That is a follow-up, not this PR.

### Verification

123 tests pass, lint clean, build clean, no withdrawn mnemonic remains anywhere in the catalogue.