### PR TITLE
data: expand MOP template placeholders into real instructions (#27 #116 #117)

### DIFF
--- a/src/instr_dict.json
+++ b/src/instr_dict.json
@@ -1521,17 +1521,6 @@
     "match": "0x4002",
     "mask": "0xe003"
   },
-  "c_mop_N": {
-    "encoding": "----------------01100---10000001",
-    "variable_fields": [
-      "c_mop_t"
-    ],
-    "extension": [
-      "rv_zcmop"
-    ],
-    "match": "0x6081",
-    "mask": "0xf8ff"
-  },
   "c_mul": {
     "encoding": "----------------100111---10---01",
     "variable_fields": [
@@ -4976,36 +4965,6 @@
     ],
     "match": "0x70200073",
     "mask": "0xffffffff"
-  },
-  "mop_r_N": {
-    "encoding": "1-00--0111-------100-----1110011",
-    "variable_fields": [
-      "mop_r_t_30",
-      "mop_r_t_27_26",
-      "mop_r_t_21_20",
-      "rd",
-      "rs1"
-    ],
-    "extension": [
-      "rv_zimop"
-    ],
-    "match": "0x81c04073",
-    "mask": "0xb3c0707f"
-  },
-  "mop_rr_N": {
-    "encoding": "1-00--1----------100-----1110011",
-    "variable_fields": [
-      "mop_rr_t_30",
-      "mop_rr_t_27_26",
-      "rd",
-      "rs1",
-      "rs2"
-    ],
-    "extension": [
-      "rv_zimop"
-    ],
-    "match": "0x82004073",
-    "mask": "0xb200707f"
   },
   "mret": {
     "encoding": "00110000001000000000000001110011",
@@ -15958,5 +15917,565 @@
     ],
     "match": "0x69805013",
     "mask": "0xfff0707f"
+  },
+  "mop_r_0": {
+    "encoding": "100000011100-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x81c04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_1": {
+    "encoding": "100000011101-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x81d04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_2": {
+    "encoding": "100000011110-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x81e04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_3": {
+    "encoding": "100000011111-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x81f04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_4": {
+    "encoding": "100001011100-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x85c04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_5": {
+    "encoding": "100001011101-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x85d04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_6": {
+    "encoding": "100001011110-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x85e04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_7": {
+    "encoding": "100001011111-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x85f04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_8": {
+    "encoding": "100010011100-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x89c04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_9": {
+    "encoding": "100010011101-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x89d04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_10": {
+    "encoding": "100010011110-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x89e04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_11": {
+    "encoding": "100010011111-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x89f04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_12": {
+    "encoding": "100011011100-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x8dc04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_13": {
+    "encoding": "100011011101-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x8dd04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_14": {
+    "encoding": "100011011110-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x8de04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_15": {
+    "encoding": "100011011111-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x8df04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_16": {
+    "encoding": "110000011100-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc1c04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_17": {
+    "encoding": "110000011101-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc1d04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_18": {
+    "encoding": "110000011110-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc1e04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_19": {
+    "encoding": "110000011111-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc1f04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_20": {
+    "encoding": "110001011100-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc5c04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_21": {
+    "encoding": "110001011101-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc5d04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_22": {
+    "encoding": "110001011110-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc5e04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_23": {
+    "encoding": "110001011111-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc5f04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_24": {
+    "encoding": "110010011100-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc9c04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_25": {
+    "encoding": "110010011101-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc9d04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_26": {
+    "encoding": "110010011110-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc9e04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_27": {
+    "encoding": "110010011111-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc9f04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_28": {
+    "encoding": "110011011100-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xcdc04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_29": {
+    "encoding": "110011011101-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xcdd04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_30": {
+    "encoding": "110011011110-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xcde04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_r_31": {
+    "encoding": "110011011111-----100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xcdf04073",
+    "mask": "0xfff0707f"
+  },
+  "mop_rr_0": {
+    "encoding": "1000001----------100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x82004073",
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_1": {
+    "encoding": "1000011----------100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x86004073",
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_2": {
+    "encoding": "1000101----------100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x8a004073",
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_3": {
+    "encoding": "1000111----------100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0x8e004073",
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_4": {
+    "encoding": "1100001----------100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc2004073",
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_5": {
+    "encoding": "1100011----------100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xc6004073",
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_6": {
+    "encoding": "1100101----------100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xca004073",
+    "mask": "0xfe00707f"
+  },
+  "mop_rr_7": {
+    "encoding": "1100111----------100-----1110011",
+    "variable_fields": [
+      "rd",
+      "rs1",
+      "rs2"
+    ],
+    "extension": [
+      "rv_zimop"
+    ],
+    "match": "0xce004073",
+    "mask": "0xfe00707f"
+  },
+  "c_mop_1": {
+    "encoding": "----------------0110000010000001",
+    "variable_fields": [],
+    "extension": [
+      "rv_zcmop"
+    ],
+    "match": "0x6081",
+    "mask": "0xffff"
+  },
+  "c_mop_3": {
+    "encoding": "----------------0110000110000001",
+    "variable_fields": [],
+    "extension": [
+      "rv_zcmop"
+    ],
+    "match": "0x6181",
+    "mask": "0xffff"
+  },
+  "c_mop_5": {
+    "encoding": "----------------0110001010000001",
+    "variable_fields": [],
+    "extension": [
+      "rv_zcmop"
+    ],
+    "match": "0x6281",
+    "mask": "0xffff"
+  },
+  "c_mop_7": {
+    "encoding": "----------------0110001110000001",
+    "variable_fields": [],
+    "extension": [
+      "rv_zcmop"
+    ],
+    "match": "0x6381",
+    "mask": "0xffff"
+  },
+  "c_mop_9": {
+    "encoding": "----------------0110010010000001",
+    "variable_fields": [],
+    "extension": [
+      "rv_zcmop"
+    ],
+    "match": "0x6481",
+    "mask": "0xffff"
+  },
+  "c_mop_11": {
+    "encoding": "----------------0110010110000001",
+    "variable_fields": [],
+    "extension": [
+      "rv_zcmop"
+    ],
+    "match": "0x6581",
+    "mask": "0xffff"
+  },
+  "c_mop_13": {
+    "encoding": "----------------0110011010000001",
+    "variable_fields": [],
+    "extension": [
+      "rv_zcmop"
+    ],
+    "match": "0x6681",
+    "mask": "0xffff"
+  },
+  "c_mop_15": {
+    "encoding": "----------------0110011110000001",
+    "variable_fields": [],
+    "extension": [
+      "rv_zcmop"
+    ],
+    "match": "0x6781",
+    "mask": "0xffff"
   }
 }

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -17270,16 +17270,77 @@
       "use": "Reserved 16-bit NOP/future ops",
       "url": "https://docs.riscv.org/reference/isa/unpriv/zimop.html",
       "instructions": {
-        "C.MOP.N": {
-          "encoding": "----------------01100---10000001",
-          "variable_fields": [
-            "c_mop_t"
-          ],
+        "C.MOP.1": {
+          "encoding": "----------------0110000010000001",
+          "variable_fields": [],
           "extension": [
             "rv_zcmop"
           ],
           "match": "0x6081",
-          "mask": "0xf8ff"
+          "mask": "0xffff"
+        },
+        "C.MOP.3": {
+          "encoding": "----------------0110000110000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6181",
+          "mask": "0xffff"
+        },
+        "C.MOP.5": {
+          "encoding": "----------------0110001010000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6281",
+          "mask": "0xffff"
+        },
+        "C.MOP.7": {
+          "encoding": "----------------0110001110000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6381",
+          "mask": "0xffff"
+        },
+        "C.MOP.9": {
+          "encoding": "----------------0110010010000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6481",
+          "mask": "0xffff"
+        },
+        "C.MOP.11": {
+          "encoding": "----------------0110010110000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6581",
+          "mask": "0xffff"
+        },
+        "C.MOP.13": {
+          "encoding": "----------------0110011010000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6681",
+          "mask": "0xffff"
+        },
+        "C.MOP.15": {
+          "encoding": "----------------0110011110000001",
+          "variable_fields": [],
+          "extension": [
+            "rv_zcmop"
+          ],
+          "match": "0x6781",
+          "mask": "0xffff"
         }
       }
     },
@@ -21807,12 +21868,9 @@
       "use": "Reserved NOP encodings for future",
       "url": "https://docs.riscv.org/reference/isa/unpriv/zimop.html",
       "instructions": {
-        "MOP.R.N": {
-          "encoding": "1-00--0111-------100-----1110011",
+        "MOP.R.0": {
+          "encoding": "100000011100-----100-----1110011",
           "variable_fields": [
-            "mop_r_t_30",
-            "mop_r_t_27_26",
-            "mop_r_t_21_20",
             "rd",
             "rs1"
           ],
@@ -21820,13 +21878,383 @@
             "rv_zimop"
           ],
           "match": "0x81c04073",
-          "mask": "0xb3c0707f"
+          "mask": "0xfff0707f"
         },
-        "MOP.RR.N": {
-          "encoding": "1-00--1----------100-----1110011",
+        "MOP.R.1": {
+          "encoding": "100000011101-----100-----1110011",
           "variable_fields": [
-            "mop_rr_t_30",
-            "mop_rr_t_27_26",
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x81d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.2": {
+          "encoding": "100000011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x81e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.3": {
+          "encoding": "100000011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x81f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.4": {
+          "encoding": "100001011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x85c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.5": {
+          "encoding": "100001011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x85d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.6": {
+          "encoding": "100001011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x85e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.7": {
+          "encoding": "100001011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x85f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.8": {
+          "encoding": "100010011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x89c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.9": {
+          "encoding": "100010011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x89d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.10": {
+          "encoding": "100010011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x89e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.11": {
+          "encoding": "100010011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x89f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.12": {
+          "encoding": "100011011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8dc04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.13": {
+          "encoding": "100011011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8dd04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.14": {
+          "encoding": "100011011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8de04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.15": {
+          "encoding": "100011011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8df04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.16": {
+          "encoding": "110000011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc1c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.17": {
+          "encoding": "110000011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc1d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.18": {
+          "encoding": "110000011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc1e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.19": {
+          "encoding": "110000011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc1f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.20": {
+          "encoding": "110001011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc5c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.21": {
+          "encoding": "110001011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc5d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.22": {
+          "encoding": "110001011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc5e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.23": {
+          "encoding": "110001011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc5f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.24": {
+          "encoding": "110010011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc9c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.25": {
+          "encoding": "110010011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc9d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.26": {
+          "encoding": "110010011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc9e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.27": {
+          "encoding": "110010011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc9f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.28": {
+          "encoding": "110011011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xcdc04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.29": {
+          "encoding": "110011011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xcdd04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.30": {
+          "encoding": "110011011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xcde04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.31": {
+          "encoding": "110011011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xcdf04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.RR.0": {
+          "encoding": "1000001----------100-----1110011",
+          "variable_fields": [
             "rd",
             "rs1",
             "rs2"
@@ -21835,7 +22263,98 @@
             "rv_zimop"
           ],
           "match": "0x82004073",
-          "mask": "0xb200707f"
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.1": {
+          "encoding": "1000011----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x86004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.2": {
+          "encoding": "1000101----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8a004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.3": {
+          "encoding": "1000111----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8e004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.4": {
+          "encoding": "1100001----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc2004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.5": {
+          "encoding": "1100011----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc6004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.6": {
+          "encoding": "1100101----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xca004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.7": {
+          "encoding": "1100111----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xce004073",
+          "mask": "0xfe00707f"
         }
       }
     }


### PR DESCRIPTION
Closes #27
Closes #116
Closes #117

The catalogue was displaying **`MOP.R.N`, `MOP.RR.N` and `C.MOP.N` as if they were mnemonics**. They are not. The `N` is a template parameter in riscv-opcodes, and our vendored `instr_dict` captured the template rather than the instructions it generates.

| extension | was | now |
|---|---|---|
| Zimop | `MOP.R.N`, `MOP.RR.N` | **40** — MOP.R.0–31, MOP.RR.0–7 |
| Zcmop | `C.MOP.N` | **8** — C.MOP.1–15, odd only |

Three fictional mnemonics replaced by 48 real ones.

### Sourcing

Encodings come from riscv-opcodes upstream, derived with a parser rather than by hand. **The parser was validated before being trusted**: it reproduces the three base entries already in `instr_dict` byte for byte —

```
mop_r_N   0x81c04073 / 0xb3c0707f
mop_rr_N  0x82004073 / 0xb200707f
c_mop_N   0x6081     / 0xf8ff
```

— so the 48 come from machinery already proven against known-good data.

### One consequence worth stating up front

The Encoder Validator now reports **8 overlaps between C.LUI and the C.MOP instructions**. That is architecturally correct, not a data error: Zcmop deliberately occupies encodings reserved within the C.LUI space, so the two genuinely share encoding space and the validator is right to report it.

### Supersedes three PRs

#27, #116 and #117 each addressed part of this same bug. All three conflicted with main and with each other, so the fix is done in one place rather than by untangling three branches.

Credit to @gayathri12devi and @AmitShah13 for finding and diagnosing it — the reports were accurate and the fix is theirs in substance.

### Verification

- Zimop 40 instructions, Zcmop 8
- No placeholder mnemonic (`*.N`) anywhere in the catalogue
- 123 tests pass, lint clean, build clean
- Sync validation passes with no count assertions disturbed