### PR TITLE
data: carry pseudo-instructions for extensions with no new opcodes (#178)

### DIFF
--- a/src/instr_dict.json
+++ b/src/instr_dict.json
@@ -16477,5 +16477,178 @@
     ],
     "match": "0x6781",
     "mask": "0xffff"
+  },
+  "pause": {
+    "encoding": "00000001000000000000000000001111",
+    "variable_fields": [],
+    "extension": [
+      "rv_zihintpause"
+    ],
+    "match": "0x0100000f",
+    "mask": "0xffffffff",
+    "alias_of": "FENCE"
+  },
+  "ntl_p1": {
+    "encoding": "00000000001000000000000000110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_zihintntl"
+    ],
+    "match": "0x00200033",
+    "mask": "0xffffffff",
+    "alias_of": "ADD"
+  },
+  "ntl_pall": {
+    "encoding": "00000000001100000000000000110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_zihintntl"
+    ],
+    "match": "0x00300033",
+    "mask": "0xffffffff",
+    "alias_of": "ADD"
+  },
+  "ntl_s1": {
+    "encoding": "00000000010000000000000000110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_zihintntl"
+    ],
+    "match": "0x00400033",
+    "mask": "0xffffffff",
+    "alias_of": "ADD"
+  },
+  "ntl_all": {
+    "encoding": "00000000010100000000000000110011",
+    "variable_fields": [],
+    "extension": [
+      "rv_zihintntl"
+    ],
+    "match": "0x00500033",
+    "mask": "0xffffffff",
+    "alias_of": "ADD"
+  },
+  "rdcycle": {
+    "encoding": "11000000000000000010-----1110011",
+    "variable_fields": [
+      "rd"
+    ],
+    "extension": [
+      "rv_zicntr"
+    ],
+    "match": "0xc0002073",
+    "mask": "0xfffff07f",
+    "alias_of": "CSRRS"
+  },
+  "rdtime": {
+    "encoding": "11000000000100000010-----1110011",
+    "variable_fields": [
+      "rd"
+    ],
+    "extension": [
+      "rv_zicntr"
+    ],
+    "match": "0xc0102073",
+    "mask": "0xfffff07f",
+    "alias_of": "CSRRS"
+  },
+  "rdinstret": {
+    "encoding": "11000000001000000010-----1110011",
+    "variable_fields": [
+      "rd"
+    ],
+    "extension": [
+      "rv_zicntr"
+    ],
+    "match": "0xc0202073",
+    "mask": "0xfffff07f",
+    "alias_of": "CSRRS"
+  },
+  "rdcycleh": {
+    "encoding": "11001000000000000010-----1110011",
+    "variable_fields": [
+      "rd"
+    ],
+    "extension": [
+      "rv32_zicntr"
+    ],
+    "match": "0xc8002073",
+    "mask": "0xfffff07f",
+    "alias_of": "CSRRS"
+  },
+  "rdtimeh": {
+    "encoding": "11001000000100000010-----1110011",
+    "variable_fields": [
+      "rd"
+    ],
+    "extension": [
+      "rv32_zicntr"
+    ],
+    "match": "0xc8102073",
+    "mask": "0xfffff07f",
+    "alias_of": "CSRRS"
+  },
+  "rdinstreth": {
+    "encoding": "11001000001000000010-----1110011",
+    "variable_fields": [
+      "rd"
+    ],
+    "extension": [
+      "rv32_zicntr"
+    ],
+    "match": "0xc8202073",
+    "mask": "0xfffff07f",
+    "alias_of": "CSRRS"
+  },
+  "lpad": {
+    "encoding": "--------------------000000010111",
+    "variable_fields": [
+      "imm20"
+    ],
+    "extension": [
+      "rv_zicfilp"
+    ],
+    "match": "0x00000017",
+    "mask": "0x00000fff",
+    "alias_of": "AUIPC"
+  },
+  "prefetch_i": {
+    "encoding": "-------00000-----110000000010011",
+    "variable_fields": [
+      "rs1",
+      "imm12hi"
+    ],
+    "extension": [
+      "rv_zicbop"
+    ],
+    "match": "0x00006013",
+    "mask": "0x01f07fff",
+    "alias_of": "ORI"
+  },
+  "prefetch_r": {
+    "encoding": "-------00001-----110000000010011",
+    "variable_fields": [
+      "rs1",
+      "imm12hi"
+    ],
+    "extension": [
+      "rv_zicbop"
+    ],
+    "match": "0x00106013",
+    "mask": "0x01f07fff",
+    "alias_of": "ORI"
+  },
+  "prefetch_w": {
+    "encoding": "-------00011-----110000000010011",
+    "variable_fields": [
+      "rs1",
+      "imm12hi"
+    ],
+    "extension": [
+      "rv_zicbop"
+    ],
+    "match": "0x00306013",
+    "mask": "0x01f07fff",
+    "alias_of": "ORI"
   }
 }

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -2663,6 +2663,24 @@ const RISCVExplorer = () => {
                           <div className="flex items-start justify-between gap-3 mb-2">
                             <h4 className="text-[11px] uppercase tracking-wider text-purple-300 font-bold flex items-center gap-1">
                               <ArrowRight size={10} /> Instruction Details
+                              {/* Some extensions define no new opcode: they name a
+                                  specific encoding of an existing instruction. PAUSE is
+                                  a FENCE, NTL.* are ADDs, RDCYCLE is a CSRRS. Saying so
+                                  explains why the encoding below looks like something
+                                  else, and why the validator reports an overlap. */}
+                              {selectedInstruction.alias_of && (
+                                <span
+                                  className="ml-1 px-1.5 py-0.5 rounded font-mono normal-case tracking-normal text-[10px]"
+                                  style={{
+                                    background: 'var(--riscv-tint-3)',
+                                    color: 'var(--riscv-text-2)',
+                                    border: '1px solid var(--riscv-tint-4)',
+                                  }}
+                                  title={`Defines no new opcode: this is a specific encoding of ${selectedInstruction.alias_of}`}
+                                >
+                                  alias of {selectedInstruction.alias_of}
+                                </span>
+                              )}
                             </h4>
                             <div className="flex items-center gap-2">
                               <button

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -21788,11 +21788,26 @@
     {
       "id": "Zicfilp",
       "name": "Zicfilp",
-      "tags": [],
+      "tags": [
+        "rv_zicfilp"
+      ],
       "desc": "CFI Landing Pads",
       "use": "Forward-edge CFI for calls",
       "url": "https://docs.riscv.org/reference/isa/unpriv/unpriv-cfi.html",
-      "instructions": {},
+      "instructions": {
+        "LPAD": {
+          "encoding": "--------------------000000010111",
+          "variable_fields": [
+            "imm20"
+          ],
+          "extension": [
+            "rv_zicfilp"
+          ],
+          "match": "0x00000017",
+          "mask": "0x00000fff",
+          "alias_of": "AUIPC"
+        }
+      },
       "csrs": {
         "mseccfg": {
           "address": "1863",
@@ -26622,11 +26637,87 @@
     {
       "id": "Zicntr",
       "name": "Zicntr",
-      "tags": [],
+      "tags": [
+        "rv_zicntr",
+        "rv32_zicntr"
+      ],
       "desc": "Base Counters/Timers",
       "use": "cycle/instret + timers",
       "url": "https://docs.riscv.org/reference/isa/unpriv/counters.html",
-      "instructions": {},
+      "instructions": {
+        "RDCYCLE": {
+          "encoding": "11000000000000000010-----1110011",
+          "variable_fields": [
+            "rd"
+          ],
+          "extension": [
+            "rv_zicntr"
+          ],
+          "match": "0xc0002073",
+          "mask": "0xfffff07f",
+          "alias_of": "CSRRS"
+        },
+        "RDTIME": {
+          "encoding": "11000000000100000010-----1110011",
+          "variable_fields": [
+            "rd"
+          ],
+          "extension": [
+            "rv_zicntr"
+          ],
+          "match": "0xc0102073",
+          "mask": "0xfffff07f",
+          "alias_of": "CSRRS"
+        },
+        "RDINSTRET": {
+          "encoding": "11000000001000000010-----1110011",
+          "variable_fields": [
+            "rd"
+          ],
+          "extension": [
+            "rv_zicntr"
+          ],
+          "match": "0xc0202073",
+          "mask": "0xfffff07f",
+          "alias_of": "CSRRS"
+        },
+        "RDCYCLEH": {
+          "encoding": "11001000000000000010-----1110011",
+          "variable_fields": [
+            "rd"
+          ],
+          "extension": [
+            "rv32_zicntr"
+          ],
+          "match": "0xc8002073",
+          "mask": "0xfffff07f",
+          "alias_of": "CSRRS"
+        },
+        "RDTIMEH": {
+          "encoding": "11001000000100000010-----1110011",
+          "variable_fields": [
+            "rd"
+          ],
+          "extension": [
+            "rv32_zicntr"
+          ],
+          "match": "0xc8102073",
+          "mask": "0xfffff07f",
+          "alias_of": "CSRRS"
+        },
+        "RDINSTRETH": {
+          "encoding": "11001000001000000010-----1110011",
+          "variable_fields": [
+            "rd"
+          ],
+          "extension": [
+            "rv32_zicntr"
+          ],
+          "match": "0xc8202073",
+          "mask": "0xfffff07f",
+          "alias_of": "CSRRS"
+        }
+      },
       "csrs": {
         "cycle": {
           "address": "3072",
@@ -26799,20 +26890,76 @@
     {
       "id": "Zihintntl",
       "name": "Zihintntl",
-      "tags": [],
+      "tags": [
+        "rv_zihintntl"
+      ],
       "desc": "Non-Temporal Locality Hints",
       "use": "NT load/store hints",
       "url": "https://docs.riscv.org/reference/isa/unpriv/zihintntl.html",
-      "instructions": {}
+      "instructions": {
+        "NTL.P1": {
+          "encoding": "00000000001000000000000000110011",
+          "variable_fields": [],
+          "extension": [
+            "rv_zihintntl"
+          ],
+          "match": "0x00200033",
+          "mask": "0xffffffff",
+          "alias_of": "ADD"
+        },
+        "NTL.PALL": {
+          "encoding": "00000000001100000000000000110011",
+          "variable_fields": [],
+          "extension": [
+            "rv_zihintntl"
+          ],
+          "match": "0x00300033",
+          "mask": "0xffffffff",
+          "alias_of": "ADD"
+        },
+        "NTL.S1": {
+          "encoding": "00000000010000000000000000110011",
+          "variable_fields": [],
+          "extension": [
+            "rv_zihintntl"
+          ],
+          "match": "0x00400033",
+          "mask": "0xffffffff",
+          "alias_of": "ADD"
+        },
+        "NTL.ALL": {
+          "encoding": "00000000010100000000000000110011",
+          "variable_fields": [],
+          "extension": [
+            "rv_zihintntl"
+          ],
+          "match": "0x00500033",
+          "mask": "0xffffffff",
+          "alias_of": "ADD"
+        }
+      }
     },
     {
       "id": "Zihintpause",
       "name": "Zihintpause",
-      "tags": [],
+      "tags": [
+        "rv_zihintpause"
+      ],
       "desc": "Pause Hint",
       "use": "Power-friendly spin-wait",
       "url": "https://docs.riscv.org/reference/isa/unpriv/zihintpause.html",
-      "instructions": {}
+      "instructions": {
+        "PAUSE": {
+          "encoding": "00000001000000000000000000001111",
+          "variable_fields": [],
+          "extension": [
+            "rv_zihintpause"
+          ],
+          "match": "0x0100000f",
+          "mask": "0xffffffff",
+          "alias_of": "FENCE"
+        }
+      }
     },
     {
       "id": "Zihpm",
@@ -27320,11 +27467,53 @@
     {
       "id": "Zicbop",
       "name": "Zicbop",
-      "tags": [],
+      "tags": [
+        "rv_zicbop"
+      ],
       "desc": "Cache Prefetch",
       "use": "Prefetch cache blocks",
       "url": "https://docs.riscv.org/reference/isa/unpriv/cmo.html",
-      "instructions": {}
+      "instructions": {
+        "PREFETCH.I": {
+          "encoding": "-------00000-----110000000010011",
+          "variable_fields": [
+            "rs1",
+            "imm12hi"
+          ],
+          "extension": [
+            "rv_zicbop"
+          ],
+          "match": "0x00006013",
+          "mask": "0x01f07fff",
+          "alias_of": "ORI"
+        },
+        "PREFETCH.R": {
+          "encoding": "-------00001-----110000000010011",
+          "variable_fields": [
+            "rs1",
+            "imm12hi"
+          ],
+          "extension": [
+            "rv_zicbop"
+          ],
+          "match": "0x00106013",
+          "mask": "0x01f07fff",
+          "alias_of": "ORI"
+        },
+        "PREFETCH.W": {
+          "encoding": "-------00011-----110000000010011",
+          "variable_fields": [
+            "rs1",
+            "imm12hi"
+          ],
+          "extension": [
+            "rv_zicbop"
+          ],
+          "match": "0x00306013",
+          "mask": "0x01f07fff",
+          "alias_of": "ORI"
+        }
+      }
     },
     {
       "id": "Zicboz",

--- a/tests/catalog-coverage.test.mjs
+++ b/tests/catalog-coverage.test.mjs
@@ -156,6 +156,72 @@ test('Zbb matches the ratified instruction set', () => {
   );
 });
 
+test('extensions that define no new opcodes carry their pseudo-instructions', () => {
+  // Zihintpause, Zihintntl, Zicntr, Zicfilp and Zicbop introduce no encodings of
+  // their own; they name specific encodings of existing instructions. They read
+  // as empty extensions unless those aliases are carried explicitly.
+  const byId = new Map(entries.map((e) => [e.id, e]));
+  const expected = {
+    Zihintpause: { count: 1, alias: 'FENCE' },
+    Zihintntl: { count: 4, alias: 'ADD' },
+    Zicntr: { count: 6, alias: 'CSRRS' },
+    Zicfilp: { count: 1, alias: 'AUIPC' },
+    Zicbop: { count: 3, alias: 'ORI' },
+  };
+
+  for (const [id, { count, alias }] of Object.entries(expected)) {
+    const entry = byId.get(id);
+    assert.ok(entry, `${id} is missing from the catalogue`);
+    const instructions = Object.entries(entry.instructions || {});
+    assert.equal(instructions.length, count, `${id} should carry ${count} instruction(s)`);
+
+    // Each must record what it aliases. Without that the encoding looks wrong,
+    // since PAUSE decodes as a FENCE, and the validator's overlap against the
+    // base instruction reads as a data error rather than as a fact.
+    for (const [mnemonic, details] of instructions) {
+      assert.equal(
+        details.alias_of, alias,
+        `${id}.${mnemonic} should record alias_of ${alias}, got ${details.alias_of ?? 'nothing'}`,
+      );
+    }
+  }
+});
+
+test('a mnemonic never carries two different encodings', () => {
+  // Guards the case deliberately left out: rv32_zclsd redefines c.ld and c.sd
+  // onto the C.FLW/C.FSW encodings for RV32, while Zca already defines those
+  // mnemonics for RV64. Importing that pair would leave one mnemonic meaning
+  // two different things depending on XLEN, so it stays out until represented
+  // properly. This fails if someone imports it without making that decision.
+  // One legitimate exception, and it is worth naming rather than loosening the
+  // rule around. The shift-immediate instructions genuinely differ by XLEN:
+  // RV32 takes a 5-bit shamt so bit 25 must be zero (mask 0xfe00707f), RV64
+  // takes 6 bits (0xfc00707f). Same mnemonic, same meaning, different width.
+  // See the RV32 shift-mask injection in scripts/sync_instructions.mjs and
+  // ISA Vol I section 2.6. That is different in kind from the Zclsd case, where
+  // the mnemonic would mean a different operation depending on XLEN.
+  const XLEN_VARIANTS = new Set(['SLLI', 'SRLI', 'SRAI']);
+
+  const byMnemonic = new Map();
+  for (const e of entries) {
+    for (const [m, d] of Object.entries(e.instructions || {})) {
+      if (!d.match || !d.mask) continue;
+      const prev = byMnemonic.get(m);
+      if (prev && (prev.match !== d.match || prev.mask !== d.mask)) {
+        // A width-only difference on a known shift instruction is expected.
+        const widthOnly = XLEN_VARIANTS.has(m.toUpperCase()) && prev.match === d.match;
+        assert.ok(
+          widthOnly,
+          `${m} has two different encodings: ${prev.ext} says ${prev.match}/${prev.mask}, `
+          + `${e.id} says ${d.match}/${d.mask}`,
+        );
+        continue;
+      }
+      if (!prev) byMnemonic.set(m, { match: d.match, mask: d.mask, ext: e.id });
+    }
+  }
+});
+
 test('extension ids are unique', () => {
   const seen = new Set();
   const dupes = [];


### PR DESCRIPTION
Closes #178

Five ratified extensions introduce no encodings of their own. They name specific encodings of existing instructions, which riscv-opcodes expresses as `$pseudo_op`, and our vendored `instr_dict` did not carry them. So five extensions looked empty when they are not.

| extension | instructions | alias of |
|---|---|---|
| Zihintpause | PAUSE | FENCE |
| Zihintntl | NTL.P1, NTL.PALL, NTL.S1, NTL.ALL | ADD |
| Zicntr | RDCYCLE, RDTIME, RDINSTRET + H variants | CSRRS |
| Zicfilp | LPAD | AUIPC |
| Zicbop | PREFETCH.I, PREFETCH.R, PREFETCH.W | ORI |

Coverage goes 82 → 87 extensions. Credit to @Divyateja2709, whose #64 identified this.

### The three decisions the issue asked for

**Representation.** Each entry carries `alias_of`, and the details panel shows it as a badge with a tooltip. This matters: without it, PAUSE decoding as a FENCE looks like a data error rather than the entire point of the extension.

**Routing.** `pause` lives in `rv_i` upstream, so tagging Zihintpause `rv_i` would have pulled in *every* base integer instruction. Each pseudo-op is instead tagged with the extension that defines it semantically, so plain tag routing works and no new mechanism was needed.

**The XLEN case stays excluded, on purpose.** `rv32_zclsd` redefines `c.ld`/`c.sd` onto the C.FLW/C.FSW encodings for RV32, while Zca already defines those mnemonics for RV64. Importing them would leave one mnemonic meaning two different operations depending on XLEN. There is now a test that fails if anyone imports it without deciding how to represent that.

### Writing that test found something

The first version failed against **correct** data: SLLI, SRLI and SRAI genuinely carry two encodings, because RV32 takes a 5-bit shamt (mask `0xfe00707f`) and RV64 takes 6 (`0xfc00707f`). That is the documented RV32 shift-mask injection, ISA Vol I §2.6.

So the rule now distinguishes a **width-only** difference on a known shift from a mnemonic that would mean two different things. Same match, different mask, is fine; different match is not.

### On the validator

It still reports these as overlapping their base instruction, and that is correct. A pseudo-instruction shares encoding space with what it aliases, so a user proposing that encoding genuinely does collide with PAUSE. The badge now explains why the overlap exists.

### Verification

- All five resolve by search; each shows the correct alias badge and tooltip ("Defines no new opcode: this is a specific encoding of FENCE")
- A normal instruction such as ADDI correctly shows no badge
- Guard proven by simulating the Zclsd hazard: 2 tests fail, then pass once reverted
- 125 tests pass, lint clean, build clean