### PR TITLE
chore: add editorconfig, and a prettier config that matches the code (#96)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "printWidth": 100,
+  "trailingComma": "all",
+  "arrowParens": "always"
+}

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "test": "node --test tests/*.test.mjs",
     "dev": "webpack serve --mode development",
     "lint": "eslint .",
-    "format": "prettier --write \"src/**/*.{js,jsx,css}\"",
-    "format:check": "prettier --check \"src/**/*.{js,jsx,css}\""
+    "format": "prettier --write \"src/**/*.{js,jsx,css}\""
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Closes #96

The `.editorconfig` is @Veekshitha11's from #96, unchanged.

That PR could not be merged as it stood: it predates the DCO gate, so its commits carry no sign-off, and adding one on their behalf would defeat the entire point of the certificate. Rather than leave a nine-line file waiting indefinitely on a round trip, it lands here with the credit stated.

### Two problems came with it, both mine from #172

**There was no prettier config**, so `npm run format` ran on defaults. Those use double quotes where this codebase uses single — **1689 single-quoted strings against 623 double** — so running it would have rewritten essentially every string in the project. Defaults also wrap at 80, reflowing lines that are deliberately one line.

The config now matches what the code actually does: `singleQuote`, `printWidth: 100`, `trailingComma: all`, `arrowParens: always`.

| | before config | after |
|---|---|---|
| `tileMemo.js` | reflowed by Prettier | **byte-identical** |
| files Prettier would change | 9 | 7 |
| quote conversion in `marchUtils.js` | 21 → 21 | none |

**`format:check` is removed.** The codebase has 312 lines over 100 characters and 173 over 120, including one at 703 inside a Tailwind class string. No width setting makes `--check` pass without a mass reformat, so a check that can only fail is noise, and keeping it implied a guarantee we do not meet.

`format` stays, for deliberate use on a file being worked on.

### Verification

125 tests pass, lint clean, build clean.