### PR TITLE
chore: point URLs at the riscv organisation ahead of the transfer

### DIFF
--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -389,7 +389,7 @@ npm run deploy
 
 This runs `npm run build` (producing `dist/`), then publishes to the `gh-pages`
 branch. The site is available at:
-`https://rpsene.github.io/riscv-extensions-landscape/`
+`https://riscv.github.io/riscv-extensions-landscape/`
 
 ### Docker (alternative)
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ An interactive reference for RISC-V extensions, profiles, and per-instruction
 encodings. Pick a base ISA or start from a ratified profile, add extensions, and
 get a dependency-resolved configuration with a valid `-march` string.
 
-**[Open the live site](https://rpsene.github.io/riscv-extensions-landscape/)**
+**[Open the live site](https://riscv.github.io/riscv-extensions-landscape/)**
 
-[![CI](https://github.com/rpsene/riscv-extensions-landscape/actions/workflows/ci.yml/badge.svg)](https://github.com/rpsene/riscv-extensions-landscape/actions/workflows/ci.yml)
+[![CI](https://github.com/riscv/riscv-extensions-landscape/actions/workflows/ci.yml/badge.svg)](https://github.com/riscv/riscv-extensions-landscape/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![DCO](https://img.shields.io/badge/DCO-required-brightgreen.svg)](DCO)
 
@@ -93,7 +93,7 @@ npm run links:check
 ## Tests
 
 ```bash
-npm test        # 114 tests
+npm test        # 127 tests
 ```
 
 CI runs the tests, builds, then validates every generated `-march` string against

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Please report security issues privately rather than in a public issue.
 Use GitHub's [private vulnerability reporting][ghsa] on this repository, or
 email **rsene@linuxfoundation.org**.
 
-[ghsa]: https://github.com/rpsene/riscv-extensions-landscape/security/advisories/new
+[ghsa]: https://github.com/riscv/riscv-extensions-landscape/security/advisories/new
 
 Please include what you found, how to reproduce it, and what an attacker could
 do with it. You will get an acknowledgement within a few working days, and an

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "homepage": "https://rpsene.github.io/riscv-extensions-landscape/",
+  "homepage": "https://riscv.github.io/riscv-extensions-landscape/",
   "scripts": {
     "build": "webpack",
     "deploy": "gh-pages -d dist --branch gh-pages --dotfiles",

--- a/public/index.html
+++ b/public/index.html
@@ -9,13 +9,13 @@
        Graph and Twitter consumers do not resolve relative paths, so a relative
        og:url yields no preview at all. -->
   <meta name="description" content="Interactive reference for RISC-V extensions, profiles and per-instruction encodings. Build an ISA configuration with dependencies resolved automatically and export a valid -march string.">
-  <link rel="canonical" href="https://rpsene.github.io/riscv-extensions-landscape/">
+  <link rel="canonical" href="https://riscv.github.io/riscv-extensions-landscape/">
 
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="RISC-V Extension Landscape">
   <meta property="og:title" content="RISC-V Extension Landscape">
   <meta property="og:description" content="Interactive reference for RISC-V extensions, profiles and per-instruction encodings, with dependency-resolved ISA configuration and -march export.">
-  <meta property="og:url" content="https://rpsene.github.io/riscv-extensions-landscape/">
+  <meta property="og:url" content="https://riscv.github.io/riscv-extensions-landscape/">
 
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="RISC-V Extension Landscape">


### PR DESCRIPTION
Prepares for moving the repository to the `riscv` org.

Landing this **before** the transfer so the window where a documented link is dead is as short as possible. After a transfer GitHub redirects *repository* URLs, but **Pages URLs are not reliably redirected**, so the live-site links would otherwise point nowhere.

Seven references move from `rpsene` to `riscv`:

| file | what |
|---|---|
| `package.json` | `homepage` |
| `README.md` | live-site link, CI badge |
| `SECURITY.md` | security advisory link |
| `public/index.html` | `canonical`, `og:url` |
| `PROPOSAL.md` | one reference |

Also corrects the README test count, which still said 114 and is now 127.

**These URLs are dead until the transfer completes.** That is the intended order.

127 tests pass, build clean.