### PR TITLE
Add an encoding-space map

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ get a dependency-resolved configuration with a valid `-march` string.
   compatible file.
 - **Check an encoding.** The Encoder Validator tests a proposed instruction
   pattern against every existing one and reports overlaps.
+- **See the encoding space.** The Encoding Map draws the 32 base opcode slots,
+  shaded by how many instructions each holds, and shows what is still free.
 - **Link out to the specification.** Each extension links to its section on
   docs.riscv.org.
 
@@ -93,7 +95,7 @@ npm run links:check
 ## Tests
 
 ```bash
-npm test        # 127 tests
+npm test        # 135 tests
 ```
 
 CI runs the tests, builds, then validates every generated `-march` string against
@@ -162,6 +164,19 @@ each other.
 Overlaps are reported as `identical`, `proposed_subset_of_existing`,
 `existing_subset_of_proposed`, or `partial_overlap`, each with a plain-language
 reason and an example 32-bit word that satisfies both patterns.
+
+## Encoding Map
+
+The **Encoding Map**, also in the header, answers the question the extension
+list cannot: how much of the base encoding space is spoken for. It lays the 32
+opcode slots out as the ISA manual does, rows `inst[4:2]` and columns
+`inst[6:5]`, with every cell implying `inst[1:0]=11`, and shades each by
+occupancy on a log scale. Compressed instructions sit outside that grid and are
+summarised by quadrant. Selecting a cell lists its instructions and links
+through to the extensions that define them.
+
+It is computed from `src/riscv_extensions.json` at runtime, so there is nothing
+to regenerate: sync the catalogue and the map follows.
 
 ## Deployment
 

--- a/src/EncodingMap.jsx
+++ b/src/EncodingMap.jsx
@@ -1,0 +1,309 @@
+import React from 'react';
+import { Grid3x3, X } from 'lucide-react';
+import { buildEncodingMap } from './encodingMap.js';
+
+/**
+ * The RISC-V opcode map, drawn from the catalogue.
+ *
+ * Derived at runtime from src/riscv_extensions.json, the same source the tiles
+ * and the builder read. There is no generated asset behind this and nothing to
+ * regenerate: sync the catalogue and the map follows. That is deliberate. A
+ * separate data file would drift from the catalogue, which is exactly what made
+ * the earlier dependency-graph proposal unmergeable.
+ *
+ * Plain SVG-free markup and CSS grid, no charting library. The layout is a 4x8
+ * table and the only visual encoding is a colour ramp, so d3 would have added
+ * 87 KB or more to a 754 KB bundle to compute what a logarithm already does.
+ * Worth revisiting for a force-directed dependency view, where the maths is
+ * real. Not here.
+ */
+
+/**
+ * Occupancy to a gold ramp, log scaled.
+ *
+ * OP-V holds 349 instructions while the median occupied cell holds single
+ * digits. On a linear ramp almost every cell lands on the palest step and the
+ * distribution disappears.
+ */
+function densityStyle(count, max) {
+  if (count === 0) {
+    return {
+      background: 'var(--riscv-tint-1)',
+      borderColor: 'var(--riscv-border)',
+      color: 'var(--riscv-text-3)',
+    };
+  }
+  // Intensity only. The ramp itself lives in CSS (.heat-cell) so it can differ
+  // per theme: --riscv-gold is bright on dark and *dark* on light, so a single
+  // JS-computed mix made busy cells dark-on-dark in light mode, at 1.5:1.
+  return { '--heat': (Math.log(count + 1) / Math.log(max + 1)).toFixed(3) };
+}
+
+export default function EncodingMap({ open, onClose, catalog, onSelectExtension }) {
+  const map = React.useMemo(() => (open ? buildEncodingMap(catalog) : null), [open, catalog]);
+  const [selected, setSelected] = React.useState(null);
+  const dialogRef = React.useRef(null);
+  const triggerRef = React.useRef(null);
+
+  // Same keyboard contract as the Encoder Validator: Escape closes, focus is
+  // trapped and wraps, and it returns to whatever opened the dialog.
+  React.useEffect(() => {
+    if (!open) return undefined;
+    const opener = document.activeElement;
+    triggerRef.current = opener instanceof HTMLElement && opener !== document.body ? opener : null;
+
+    const FOCUSABLE =
+      'a[href], button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    const focusable = () =>
+      [...(dialogRef.current?.querySelectorAll(FOCUSABLE) ?? [])].filter(
+        (el) => el.offsetWidth > 0 || el.offsetHeight > 0,
+      );
+
+    focusable()[0]?.focus();
+
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      const items = focusable();
+      if (!items.length) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement;
+      const outside = !dialogRef.current?.contains(active);
+      if (e.shiftKey && (active === first || outside)) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || outside)) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, true);
+      triggerRef.current?.focus?.();
+    };
+  }, [open, onClose]);
+
+  React.useEffect(() => {
+    if (!open) setSelected(null);
+  }, [open]);
+
+  if (!open || !map) return null;
+
+  const { cells, quadrants, totals } = map;
+  const max = totals.busiest.count;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div
+        className="absolute inset-0"
+        style={{ background: 'rgba(7,7,14,0.85)', backdropFilter: 'blur(4px)' }}
+        onClick={onClose}
+        role="presentation"
+      />
+      <div className="absolute inset-0 p-3 md:p-8 flex items-start justify-center overflow-y-auto">
+        <div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="encoding-map-title"
+          aria-describedby="encoding-map-desc"
+          className="animate-scale-in w-full max-w-5xl riscv-card overflow-hidden"
+          style={{ boxShadow: '0 0 60px rgba(0,0,0,0.8), 0 0 0 1px rgba(245,197,66,0.15)' }}
+        >
+          <div
+            className="p-4 flex items-start justify-between gap-3"
+            style={{ borderBottom: '1px solid var(--riscv-border)' }}
+          >
+            <div className="min-w-0">
+              <h3
+                id="encoding-map-title"
+                className="font-bold flex items-center gap-2"
+                style={{ color: 'var(--riscv-text)', fontSize: 14 }}
+              >
+                <Grid3x3 size={15} style={{ color: 'var(--riscv-gold)' }} />
+                <span>Encoding Map</span>
+              </h3>
+              <p
+                id="encoding-map-desc"
+                className="text-[12px] mt-1"
+                style={{ color: 'var(--riscv-text-3)' }}
+              >
+                The base opcode map. Rows are <span className="font-mono">inst[4:2]</span>, columns
+                are <span className="font-mono">inst[6:5]</span>, and every cell implies{' '}
+                <span className="font-mono">inst[1:0]=11</span>. Darker means busier.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="riscv-btn p-1.5 shrink-0"
+              onClick={onClose}
+              aria-label="Close the encoding map"
+            >
+              <X size={15} />
+            </button>
+          </div>
+
+          <div className="p-4">
+            <div
+              className="flex flex-wrap gap-x-5 gap-y-1 text-[12px] mb-4"
+              style={{ color: 'var(--riscv-text-2)' }}
+            >
+              <span>
+                <strong style={{ color: 'var(--riscv-text)' }}>
+                  {totals.occupiedSlots}/{totals.totalSlots}
+                </strong>{' '}
+                opcode slots used
+              </span>
+              <span>
+                <strong style={{ color: 'var(--riscv-text)' }}>{totals.thirtyTwoBit}</strong> 32-bit
+              </span>
+              <span>
+                <strong style={{ color: 'var(--riscv-text)' }}>{totals.compressed}</strong>{' '}
+                compressed
+              </span>
+              <span>
+                busiest is{' '}
+                <strong style={{ color: 'var(--riscv-text)' }}>{totals.busiest.name}</strong> with{' '}
+                {totals.busiest.count}
+              </span>
+            </div>
+
+            <div
+              className="grid gap-1.5"
+              style={{ gridTemplateColumns: 'repeat(4, minmax(0,1fr))' }}
+            >
+              {[0, 1, 2, 3].map((col) => (
+                <div key={col} className="grid gap-1.5">
+                  {cells
+                    .filter((c) => c.col === col)
+                    .sort((a, b) => a.row - b.row)
+                    .map((cell) => {
+                      const isSel = selected?.opcode === cell.opcode;
+                      return (
+                        <button
+                          key={cell.opcode}
+                          type="button"
+                          onClick={() => setSelected(isSel ? null : cell)}
+                          title={`${cell.name} · opcode 0x${cell.opcode.toString(16).padStart(2, '0')} · ${cell.count} instruction${cell.count === 1 ? '' : 's'}`}
+                          className="heat-cell text-left rounded border px-2 py-1.5 transition-colors"
+                          style={{
+                            ...densityStyle(cell.count, max),
+                            ...(isSel
+                              ? { outline: '2px solid var(--riscv-gold)', outlineOffset: 1 }
+                              : null),
+                          }}
+                        >
+                          <div className="font-mono text-[10.5px] leading-tight truncate">
+                            {cell.name}
+                          </div>
+                          <div className="text-[10px] opacity-70 font-mono">
+                            {cell.count > 0 ? cell.count : '—'}
+                          </div>
+                        </button>
+                      );
+                    })}
+                </div>
+              ))}
+            </div>
+
+            <div
+              className="mt-4 flex flex-wrap gap-2 items-center text-[11px]"
+              style={{ color: 'var(--riscv-text-3)' }}
+            >
+              <span>Compressed, outside the 32-bit map:</span>
+              {quadrants.map((q) => (
+                <span
+                  key={q.quadrant}
+                  className="px-2 py-0.5 rounded border font-mono"
+                  style={{
+                    background: 'var(--riscv-tint-2)',
+                    borderColor: 'var(--riscv-border)',
+                    color: 'var(--riscv-text-2)',
+                  }}
+                >
+                  inst[1:0]={q.quadrant.toString(2).padStart(2, '0')} · {q.count}
+                </span>
+              ))}
+            </div>
+
+            {selected && (
+              <div
+                className="mt-4 rounded border p-3"
+                style={{ background: 'var(--riscv-surface-2)', borderColor: 'var(--riscv-border)' }}
+              >
+                <div className="flex items-baseline justify-between gap-3 mb-2">
+                  <h4
+                    className="font-mono text-[13px] font-bold"
+                    style={{ color: 'var(--riscv-gold)' }}
+                  >
+                    {selected.name}{' '}
+                    <span className="font-normal" style={{ color: 'var(--riscv-text-3)' }}>
+                      opcode 0x{selected.opcode.toString(16).padStart(2, '0')}
+                    </span>
+                  </h4>
+                  <span className="text-[11px]" style={{ color: 'var(--riscv-text-3)' }}>
+                    {selected.count} instruction{selected.count === 1 ? '' : 's'}
+                  </span>
+                </div>
+
+                {selected.count === 0 ? (
+                  <p className="text-[12px]" style={{ color: 'var(--riscv-text-2)' }}>
+                    Nothing in the catalogue uses this slot. Most unused slots are not spare
+                    capacity: they are reserved for vendor custom encodings, or for instructions
+                    longer than 32 bits.
+                  </p>
+                ) : (
+                  <>
+                    <div className="flex flex-wrap gap-1 mb-2">
+                      {selected.extensions.map((id) => (
+                        <button
+                          key={id}
+                          type="button"
+                          onClick={() => {
+                            onSelectExtension?.(id);
+                            onClose();
+                          }}
+                          title={`Open ${id}`}
+                          className="px-1.5 py-0.5 rounded border font-mono text-[11px] hover:opacity-80"
+                          style={{
+                            background: 'var(--riscv-gold-dim)',
+                            borderColor: 'var(--riscv-gold-glow)',
+                            color: 'var(--riscv-gold)',
+                          }}
+                        >
+                          {id}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="flex flex-wrap gap-1 max-h-40 overflow-y-auto">
+                      {selected.instructions.map((i) => (
+                        <span
+                          key={i.mnemonic}
+                          className="px-1.5 py-0.5 rounded border font-mono text-[11px]"
+                          style={{
+                            background: 'var(--riscv-tint-2)',
+                            borderColor: 'var(--riscv-border)',
+                            color: 'var(--riscv-text-2)',
+                          }}
+                        >
+                          {i.mnemonic}
+                        </span>
+                      ))}
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/encodingMap.js
+++ b/src/encodingMap.js
@@ -1,0 +1,172 @@
+/**
+ * The RISC-V opcode map, computed from the catalogue.
+ *
+ * Answers a question the extension list cannot: where the 32-bit encoding space
+ * is actually used, and what is still free. 23 of the 32 base opcode slots are
+ * occupied, so the map is about 72% full, and OP-V alone holds roughly a third
+ * of all distinct instructions.
+ *
+ * Laid out as the ISA manual lays it out: rows are inst[4:2], columns are
+ * inst[6:5], and every cell implies inst[1:0] = 11. Compressed instructions sit
+ * outside that grid, in the three quadrants where inst[1:0] != 11.
+ *
+ * Pure functions in a .js file rather than inside the component, so the
+ * arithmetic is testable without a DOM. Same reason tileMemo.js is separate:
+ * node's test runner cannot import .jsx.
+ */
+
+/** Canonical names from the ISA manual's opcode map, keyed by inst[6:0]. */
+export const OPCODE_NAMES = {
+  0x03: 'LOAD',
+  0x07: 'LOAD-FP',
+  0x0b: 'custom-0',
+  0x0f: 'MISC-MEM',
+  0x13: 'OP-IMM',
+  0x17: 'AUIPC',
+  0x1b: 'OP-IMM-32',
+  0x1f: '48b',
+  0x23: 'STORE',
+  0x27: 'STORE-FP',
+  0x2b: 'custom-1',
+  0x2f: 'AMO',
+  0x33: 'OP',
+  0x37: 'LUI',
+  0x3b: 'OP-32',
+  0x3f: '64b',
+  0x43: 'MADD',
+  0x47: 'MSUB',
+  0x4b: 'NMSUB',
+  0x4f: 'NMADD',
+  0x53: 'OP-FP',
+  0x57: 'OP-V',
+  0x5b: 'OP-P',
+  0x5f: '48b',
+  0x63: 'BRANCH',
+  0x67: 'JALR',
+  0x6b: 'reserved',
+  0x6f: 'JAL',
+  0x73: 'SYSTEM',
+  0x77: 'OP-VE',
+  0x7b: 'custom-3',
+  0x7f: '80b+',
+};
+
+/**
+ * Collapse the catalogue to distinct instructions.
+ *
+ * A mnemonic appears under several extensions (ADD is in RV32I and in every
+ * umbrella that includes it), so counting catalogue entries would inflate the
+ * occupancy figures. Keyed by mnemonic, first definition wins, and every
+ * extension offering it is recorded.
+ */
+export function distinctInstructions(catalog) {
+  const entries = [];
+  (function walk(node) {
+    if (Array.isArray(node)) node.forEach(walk);
+    else if (node && typeof node === 'object') {
+      if (node.id && node.desc) entries.push(node);
+      Object.values(node).forEach(walk);
+    }
+  })(catalog);
+
+  const byMnemonic = new Map();
+  for (const ext of entries) {
+    for (const [mnemonic, details] of Object.entries(ext.instructions || {})) {
+      if (!details || !details.match || !details.mask) continue;
+      const existing = byMnemonic.get(mnemonic);
+      if (existing) {
+        if (!existing.extensions.includes(ext.id)) existing.extensions.push(ext.id);
+        continue;
+      }
+      byMnemonic.set(mnemonic, {
+        mnemonic,
+        match: BigInt(details.match),
+        mask: BigInt(details.mask),
+        extensions: [ext.id],
+      });
+    }
+  }
+  return [...byMnemonic.values()];
+}
+
+/**
+ * Is this a 32-bit instruction?
+ *
+ * inst[1:0] == 11 means 32-bit; anything else is a 16-bit compressed
+ * instruction in quadrant 0, 1 or 2.
+ *
+ * Do NOT infer the width from the mask. An I-type mask of 0x707f is
+ * numerically below 0xffff, so a "mask fits in 16 bits" test files ordinary
+ * 32-bit instructions as compressed. That mistake put 47 of them into
+ * quadrant 3, which does not exist.
+ */
+export function isThirtyTwoBit(match) {
+  return Number(match & 0x3n) === 3;
+}
+
+/** Build the 32-slot opcode map plus the three compressed quadrants. */
+export function buildEncodingMap(catalog) {
+  const instructions = distinctInstructions(catalog);
+
+  const slots = new Map(); // inst[6:0] -> instructions
+  const quadrants = new Map([
+    [0, []],
+    [1, []],
+    [2, []],
+  ]);
+
+  for (const instruction of instructions) {
+    if (isThirtyTwoBit(instruction.match)) {
+      const opcode = Number(instruction.match & 0x7fn);
+      if (!slots.has(opcode)) slots.set(opcode, []);
+      slots.get(opcode).push(instruction);
+    } else {
+      const quadrant = Number(instruction.match & 0x3n);
+      quadrants.get(quadrant)?.push(instruction);
+    }
+  }
+
+  // Every valid 32-bit opcode, occupied or not. The empty ones are the point:
+  // they are what remains of the base encoding space.
+  const cells = [];
+  for (let col = 0; col < 4; col++) {
+    // inst[6:5]
+    for (let row = 0; row < 8; row++) {
+      // inst[4:2]
+      const opcode = (col << 5) | (row << 2) | 0x3;
+      const held = (slots.get(opcode) || [])
+        .slice()
+        .sort((a, b) => a.mnemonic.localeCompare(b.mnemonic));
+      cells.push({
+        opcode,
+        row,
+        col,
+        name: OPCODE_NAMES[opcode] || 'unassigned',
+        count: held.length,
+        instructions: held,
+        extensions: [...new Set(held.flatMap((i) => i.extensions))].sort(),
+      });
+    }
+  }
+
+  const occupiedSlots = cells.filter((c) => c.count > 0).length;
+  return {
+    cells,
+    quadrants: [0, 1, 2].map((q) => ({
+      quadrant: q,
+      count: quadrants.get(q).length,
+      instructions: quadrants
+        .get(q)
+        .slice()
+        .sort((a, b) => a.mnemonic.localeCompare(b.mnemonic)),
+    })),
+    totals: {
+      distinct: instructions.length,
+      thirtyTwoBit: instructions.filter((i) => isThirtyTwoBit(i.match)).length,
+      compressed: instructions.filter((i) => !isThirtyTwoBit(i.match)).length,
+      occupiedSlots,
+      totalSlots: cells.length,
+      busiest: cells.reduce((a, b) => (b.count > a.count ? b : a), cells[0]),
+    },
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,7 @@
   --riscv-muted: #414157;
 
   --riscv-gold: #f5c542;
+  --riscv-heat-span: 55%;
   --riscv-gold-dim: rgba(245, 197, 66, 0.12);
   --riscv-gold-glow: rgba(245, 197, 66, 0.20);
 
@@ -34,7 +35,10 @@
 
   --riscv-text: #e2e8f0;
   --riscv-text-2: #aab8ca;
-  --riscv-text-3: #6f7f95;
+  /* Nudged up from #6f7f95, which measured 4.17:1 against the card surface and
+     so missed the 4.5:1 floor for body text. It is the muted token, used for
+     section labels and empty-state text, so it has to clear the bar too. */
+  --riscv-text-3: #7d8da3;
 
   /* Overlay tints. Components paint subtle washes with rgba(255,255,255,0.0x),
      which is invisible on a light ground. Routing them through tokens lets one
@@ -485,6 +489,8 @@ pre,
      0.152. Only the text colour moved, so the dim and glow tints below keep
      the original warmth for borders and halos. */
   --riscv-gold: #8f6408;
+  /* Gentler on light: the mix darkens toward the ink rather than away from it. */
+  --riscv-heat-span: 24%;
   --riscv-gold-dim: rgba(168, 118, 10, 0.10);
   --riscv-gold-glow: rgba(168, 118, 10, 0.18);
 
@@ -700,6 +706,16 @@ pre,
 :root[data-theme='light'] .builder-badge-on {
   background: rgba(0, 0, 0, 0.3) !important;
   color: #fef3c7 !important;
+}
+
+/* Encoding-map heat cells.
+   The span differs per theme because --riscv-gold inverts: it is bright on the
+   dark ground and dark on the light one. A single mix percentage therefore
+   produces a dark cell with dark ink in light mode, which measured 1.5:1. */
+.heat-cell {
+  background: color-mix(in srgb, var(--riscv-gold) calc(12% + var(--heat, 0) * var(--riscv-heat-span)), transparent);
+  border-color: var(--riscv-gold-glow);
+  color: var(--riscv-text);
 }
 
 /* Builder Toolbar Container */

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -6,6 +6,7 @@ import {
   ArrowRight,
   ArrowUpRight,
   Copy,
+  Grid3x3,
   Link2,
   ChevronLeft,
   ChevronRight,
@@ -41,6 +42,7 @@ import {
   Moon,
 } from 'lucide-react';
 import extensions from './riscv_extensions.json';
+import EncodingMap from './EncodingMap.jsx';
 import WorkspacePanel from './WorkspacePanel.jsx';
 import ExtensionTile from './ExtensionTile.jsx';
 // INCOMPATIBLE_WITH is no longer imported here: conflicts now come back from
@@ -743,6 +745,7 @@ const RISCVExplorer = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchMatches, setSearchMatches] = useState(null);
   const [encoderValidatorOpen, setEncoderValidatorOpen] = useState(false);
+  const [encodingMapOpen, setEncodingMapOpen] = useState(false);
   const [encoderValidatorInput, setEncoderValidatorInput] = useState({
     mnemonic: '',
     encoding: '',
@@ -1930,6 +1933,25 @@ const RISCVExplorer = () => {
                       className="text-indigo-400/80 group-hover:text-indigo-300 transition-colors"
                     />
                     <span className="whitespace-nowrap">Encoder Validator</span>
+                  </button>
+
+                  {/* Beside the validator because they answer neighbouring
+                      questions: one checks a proposed encoding, the other
+                      shows where the space it would occupy already is. */}
+                  <button
+                    type="button"
+                    onClick={() => setEncodingMapOpen(true)}
+                    aria-haspopup="dialog"
+                    aria-expanded={encodingMapOpen}
+                    className="group inline-flex items-center gap-2 px-3 py-2 rounded-xl text-xs font-semibold transition-all duration-300 whitespace-nowrap border hover:opacity-90"
+                    // Tokens, not Tailwind amber: text-amber-300 has no light-theme
+                    // remapping and measured 1.33:1 on the pastel ground.
+                    style={{ color: 'var(--riscv-gold)', borderColor: 'var(--riscv-gold-glow)', background: 'var(--riscv-gold-dim)' }}
+                    data-tooltip="See how the 32-bit opcode space is allocated"
+                    title="See how the 32-bit opcode space is allocated"
+                  >
+                    <Grid3x3 size={14} className="opacity-80" />
+                    <span className="whitespace-nowrap">Encoding Map</span>
                   </button>
 
                   {/* Theme toggle relocated to header */}
@@ -3606,6 +3628,16 @@ const RISCVExplorer = () => {
           </div>
         </footer>
       </div>
+
+      <EncodingMap
+        open={encodingMapOpen}
+        onClose={() => setEncodingMapOpen(false)}
+        catalog={extensions}
+        onSelectExtension={(id) => {
+          const target = Object.values(extensions).flat().find((e) => e && e.id === id);
+          if (target) handleSelectExt(target);
+        }}
+      />
 
       {encoderValidatorOpen && (
         <div className="fixed inset-0 z-50">

--- a/tests/encoding-map.test.mjs
+++ b/tests/encoding-map.test.mjs
@@ -1,0 +1,130 @@
+/**
+ * The opcode map arithmetic.
+ *
+ * Worth pinning because the width rule is easy to get wrong in a way that still
+ * looks plausible. The first version classified an instruction as compressed
+ * when its mask fitted in 16 bits, which sounds reasonable until you notice an
+ * I-type mask of 0x707f is numerically below 0xffff. That filed ordinary 32-bit
+ * instructions into quadrant 3, which does not exist, and the totals still
+ * looked believable.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { buildEncodingMap, distinctInstructions, isThirtyTwoBit, OPCODE_NAMES } from '../src/encodingMap.js';
+
+const here = path.dirname(new URL(import.meta.url).pathname);
+const catalog = JSON.parse(
+  fs.readFileSync(path.join(here, '..', 'src', 'riscv_extensions.json'), 'utf8'),
+);
+const instructions = distinctInstructions(catalog);
+const map = buildEncodingMap(catalog);
+
+test('width is decided by inst[1:0], not by the mask', () => {
+  // The contract, stated in bits: 11 is 32-bit, everything else is compressed.
+  assert.equal(isThirtyTwoBit(0b11n), true);
+  assert.equal(isThirtyTwoBit(0b00n), false);
+  assert.equal(isThirtyTwoBit(0b01n), false);
+  assert.equal(isThirtyTwoBit(0b10n), false);
+
+  // The regression, in real data. ADDI has a mask of 0x707f, comfortably under
+  // 0xffff, so a mask-width test calls it compressed. It is not.
+  const addi = instructions.find((i) => i.mnemonic === 'ADDI');
+  assert.ok(addi, 'ADDI missing from the catalogue');
+  assert.ok(addi.mask < 0x10000n, 'precondition: ADDI mask fits in 16 bits');
+  assert.equal(isThirtyTwoBit(addi.match), true, 'ADDI is a 32-bit instruction');
+
+  // And the genuine article: C.JAL, match 0x2001, quadrant 1.
+  const cjal = instructions.find((i) => i.mnemonic === 'C.JAL');
+  assert.ok(cjal, 'C.JAL missing from the catalogue');
+  assert.equal(isThirtyTwoBit(cjal.match), false, 'C.JAL is compressed');
+});
+
+test('the grid is the opcode map as the manual draws it', () => {
+  assert.equal(map.cells.length, 32, '8 rows of inst[4:2] by 4 columns of inst[6:5]');
+  assert.equal(new Set(map.cells.map((c) => c.opcode)).size, 32, 'no slot appears twice');
+  for (const cell of map.cells) {
+    assert.equal(cell.opcode & 0x3, 0x3, `${cell.name} must imply inst[1:0]=11`);
+    assert.ok(cell.row >= 0 && cell.row < 8, 'row is inst[4:2]');
+    assert.ok(cell.col >= 0 && cell.col < 4, 'col is inst[6:5]');
+    assert.equal(cell.opcode, (cell.col << 5) | (cell.row << 2) | 0x3, 'position matches opcode');
+  }
+});
+
+test('every instruction lands somewhere, exactly once', () => {
+  const { totals } = map;
+  assert.equal(
+    totals.thirtyTwoBit + totals.compressed, totals.distinct,
+    'each instruction is either 32-bit or compressed, never both or neither',
+  );
+  assert.equal(
+    map.cells.reduce((n, c) => n + c.count, 0), totals.thirtyTwoBit,
+    'the grid holds every 32-bit instruction and nothing else',
+  );
+  assert.equal(
+    map.quadrants.reduce((n, q) => n + q.count, 0), totals.compressed,
+    'the quadrants hold every compressed instruction',
+  );
+});
+
+test('quadrant 3 does not exist', () => {
+  // inst[1:0]=11 is the 32-bit encoding, so it cannot also be a quadrant. A
+  // populated quadrant 3 was the visible symptom of the mask-width bug.
+  assert.deepEqual(map.quadrants.map((q) => q.quadrant), [0, 1, 2]);
+});
+
+test('a mnemonic is counted once, however many extensions offer it', () => {
+  // ADD is in RV32I and in every umbrella containing it. Counting catalogue
+  // entries rather than distinct mnemonics would inflate occupancy.
+  const add = instructions.filter((i) => i.mnemonic === 'ADD');
+  assert.equal(add.length, 1, 'ADD should collapse to a single instruction');
+  assert.ok(add[0].extensions.length > 1, 'but should still record every extension offering it');
+  assert.equal(
+    new Set(instructions.map((i) => i.mnemonic)).size, instructions.length,
+    'no mnemonic appears twice',
+  );
+});
+
+test('known opcodes sit in their known slots', () => {
+  const byName = new Map(map.cells.map((c) => [c.name, c]));
+  // Fixed by the ISA, so these are safe to assert literally.
+  assert.equal(byName.get('LOAD').opcode, 0x03);
+  assert.equal(byName.get('OP-IMM').opcode, 0x13);
+  assert.equal(byName.get('OP').opcode, 0x33);
+  assert.equal(byName.get('SYSTEM').opcode, 0x73);
+  assert.equal(OPCODE_NAMES[0x57], 'OP-V');
+
+  const op = byName.get('OP');
+  assert.ok(op.instructions.some((i) => i.mnemonic === 'ADD'), 'ADD belongs to OP');
+  assert.ok(op.extensions.includes('RV32I'), 'and OP should credit the base ISA');
+});
+
+test('occupancy is reported honestly', () => {
+  const { totals } = map;
+  const occupied = map.cells.filter((c) => c.count > 0).length;
+  assert.equal(totals.occupiedSlots, occupied, 'the headline figure matches the cells');
+  assert.equal(totals.totalSlots, 32);
+  assert.ok(occupied > 0 && occupied < 32, 'some slots used, some still free');
+  assert.equal(
+    totals.busiest.count, Math.max(...map.cells.map((c) => c.count)),
+    'busiest really is the maximum',
+  );
+
+  // Ratchet, in the spirit of the catalogue coverage tests: a sync that quietly
+  // stopped delivering instructions would otherwise still produce a valid map.
+  assert.ok(totals.distinct > 1000, `expected over 1000 distinct instructions, found ${totals.distinct}`);
+  assert.ok(occupied >= 20, `expected at least 20 opcode slots in use, found ${occupied}`);
+});
+
+test('empty cells are real slots, not missing data', () => {
+  // The free slots are the interesting half of the map, so they must be present
+  // and nameable rather than simply absent from the grid.
+  const empty = map.cells.filter((c) => c.count === 0);
+  assert.ok(empty.length > 0, 'the encoding space is not full');
+  for (const cell of empty) {
+    assert.ok(cell.name, `slot 0x${cell.opcode.toString(16)} has no name`);
+    assert.deepEqual(cell.instructions, []);
+    assert.deepEqual(cell.extensions, []);
+  }
+});


### PR DESCRIPTION
Closes #2.

The catalogue tells you what an extension contains, but not how much of the base encoding space is spoken for. This adds an **Encoding Map** to the header, beside the Encoder Validator.

It lays out the 32 opcode slots the way the ISA manual does, rows `inst[4:2]` and columns `inst[6:5]`, every cell implying `inst[1:0]=11`, shaded by how many instructions each holds. Compressed instructions sit outside that grid and are summarised by quadrant. Selecting a cell lists its instructions and links through to the extensions that define them.

What it reports, from the current catalogue:

| | |
|---|---|
| opcode slots in use | 23 of 32 |
| distinct instructions | 1218 |
| 32-bit / compressed | 1149 / 69 |
| busiest slot | OP-V, 349 |
| compressed quadrants | Q0 14, Q1 34, Q2 21 |

The free slots are the interesting half, so empty cells are drawn rather than omitted and say what they are reserved for: vendor custom encodings, or instructions longer than 32 bits.

## Design notes

**Computed at runtime from `src/riscv_extensions.json`.** No generated asset, so there is nothing to regenerate and nothing that can drift from the catalogue. Sync the catalogue and the map follows. That was the specific objection that made the earlier dependency-graph proposal unmergeable.

**No d3.** The layout is a 4x8 table and the only visual encoding is a colour ramp, so the smallest usable submodule would have added 87 KB to compute what a logarithm already does. The bundle grew 9 KB instead, 754 to 764 KB.

**The arithmetic is in `src/encodingMap.js`, separate from the component**, so it is testable without a DOM, the same reason `tileMemo.js` is separate: node's test runner cannot import `.jsx`.

## Two things worth a careful look

**Width comes from `inst[1:0]`, not from the mask.** Deriving it from the mask looks reasonable and is wrong: an I-type mask of `0x707f` is numerically below `0xffff`, so a "mask fits in 16 bits" test files ordinary 32-bit instructions as compressed. My first version did exactly that and produced a populated quadrant 3, which does not exist, with totals that still looked believable. `tests/encoding-map.test.mjs` pins the rule and the specific case.

**The heat ramp is in CSS, not JS.** `--riscv-gold` inverts between themes, bright on dark and dark on light, so a single JS-computed mix produced dark ink on a dark wash in light mode, at 1.5:1. Per-theme spans of 55% and 24% fix it. Composited against every translucent layer beneath rather than against the card alone, the worst cell now measures 4.79:1 and the busiest 5.57:1.

This also raises `--riscv-text-3` from `#6f7f95`, which measured 4.17:1 against the card surface and so missed the 4.5:1 floor for body text. That token is used across the app, not only here, so the change is broader than this feature.

## Verification

- 135 tests pass, up from 127. Eight new, covering the width rule, grid shape, conservation (every instruction lands somewhere exactly once), the absence of quadrant 3, mnemonic dedup, known opcode positions, and honest occupancy reporting.
- `npm run build` clean, lint clean.
- Checked in a real browser in both themes: dialog opens and closes, Escape returns focus to the trigger, focus is trapped and wraps, 32 cells and 3 quadrant chips render, the detail panel resolves opcodes and extension links, and every text element inside the dialog clears its WCAG threshold.