### PR TITLE
Report riscv-opcodes drift weekly instead of syncing it

### DIFF
--- a/.github/workflows/check-opcodes-drift.yml
+++ b/.github/workflows/check-opcodes-drift.yml
@@ -1,0 +1,136 @@
+name: Check riscv-opcodes Drift
+
+# Instruction encodings come from riscv-opcodes, but unlike the UDB sync this
+# job cannot fix what it finds. src/instr_dict.json is hand-maintained and holds
+# entries upstream does not (the vlseg family, the MOP expansions), so
+# regenerating it would delete them. This reports and files an issue instead.
+on:
+  # An hour after the UDB sync, so a person reading Monday's notifications sees
+  # extension metadata and instruction drift together, without both jobs cloning
+  # large repositories at the same moment.
+  schedule:
+    - cron: '0 7 * * 1'
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: check-opcodes-drift
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout landscape repo
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Clone riscv-opcodes
+        id: opcodes
+        run: |
+          git clone --depth 1 https://github.com/riscv/riscv-opcodes.git ../riscv-opcodes
+          echo "sha=$(git -C ../riscv-opcodes rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+
+      - name: Check for drift
+        id: drift
+        run: |
+          # The script exits 1 when upstream has encodings we lack. That is a
+          # report, not a job failure, so capture the status rather than letting
+          # it end the run.
+          set +e
+          node scripts/check-opcodes-drift.mjs ../riscv-opcodes > drift.txt
+          status=$?
+          set -e
+          cat drift.txt
+          if [ "${status}" -eq 0 ]; then
+            echo "in_sync=true" >> "$GITHUB_OUTPUT"
+          elif [ "${status}" -eq 1 ]; then
+            echo "in_sync=false" >> "$GITHUB_OUTPUT"
+          else
+            # Exit 2 means the checkout was missing or unreadable. That is a real
+            # failure and must not be reported as drift.
+            echo "check-opcodes-drift failed with status ${status}"
+            exit "${status}"
+          fi
+
+      - name: Find any existing report
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Match on a marker in the body, so an unrelated issue with a similar
+          # title cannot be mistaken for this report.
+          number=$(gh issue list --state open --label automated --limit 100 --json number,body \
+            --jq 'map(select(.body | contains("<!-- opcodes-drift-report -->"))) | .[0].number // empty')
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update the report
+        if: steps.drift.outputs.in_sync == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPSTREAM_SHA: ${{ steps.opcodes.outputs.sha }}
+          EXISTING: ${{ steps.existing.outputs.number }}
+        run: |
+          {
+            echo "<!-- opcodes-drift-report -->"
+            echo "riscv-opcodes has ratified encodings that \`src/instr_dict.json\` does not carry."
+            echo
+            echo '```'
+            cat drift.txt
+            echo '```'
+            echo
+            echo "Upstream commit \`${UPSTREAM_SHA}\`. Reproduce locally:"
+            echo
+            echo '```'
+            echo "git clone --depth 1 https://github.com/riscv/riscv-opcodes.git ../riscv-opcodes"
+            echo "npm run opcodes:check"
+            echo '```'
+            echo
+            echo "**Not applied automatically.** \`src/instr_dict.json\` is hand-maintained"
+            echo "and holds entries upstream does not, so regenerating it from riscv-opcodes"
+            echo "would delete them. Add the new encodings by hand, run \`npm run sync\` to"
+            echo "route them onto the catalogue, then \`npm test\`."
+            echo
+            echo "Closed automatically once the two are back in sync."
+          } > body.md
+
+          if [ -n "${EXISTING}" ]; then
+            gh issue edit "${EXISTING}" --body-file body.md
+            gh issue comment "${EXISTING}" \
+              --body "Still drifting as of upstream \`${UPSTREAM_SHA}\`. Report updated."
+          else
+            gh issue create \
+              --title "riscv-opcodes has ratified encodings we do not carry" \
+              --body-file body.md \
+              --label automated,data-sync
+          fi
+
+      - name: Close the report once back in sync
+        if: steps.drift.outputs.in_sync == 'true' && steps.existing.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXISTING: ${{ steps.existing.outputs.number }}
+        run: |
+          gh issue close "${EXISTING}" \
+            --comment "Back in sync with riscv-opcodes. Closing automatically."
+
+      - name: Summary
+        if: always()
+        run: |
+          if [ -f drift.txt ]; then
+            {
+              echo '```'
+              cat drift.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/README.md
+++ b/README.md
@@ -78,7 +78,27 @@ Or check for drift without writing anything:
 npm run sync:check
 npm run graph:check -- <path-to-riscv-unified-db>
 npm run links:check
+npm run opcodes:check -- <path-to-riscv-opcodes>
 ```
+
+### What updates itself, and what does not
+
+| | how it refreshes |
+|---|---|
+| extension metadata, CSRs, ratification state | the `sync-udb-extensions` workflow, Mondays at 06:00 UTC, opens a PR |
+| the published site | any push to `main` rebuilds and publishes to `gh-pages` |
+| instruction encodings | **by hand.** The `check-opcodes-drift` workflow, Mondays at 07:00 UTC, files an issue when upstream is ahead |
+
+`src/instr_dict.json` is hand-maintained on purpose and is not regenerated from
+riscv-opcodes. It carries entries upstream does not: the 56 `vlseg` segment
+loads, which riscv-opcodes does not express at all, and the MOP and C.MOP
+encodings expanded from upstream's three `_n` templates. A regenerate would
+delete them, so the drift check reports and leaves the decision to a person.
+
+It compares mnemonics rather than encodings, ignores upstream's 172
+`$pseudo_op` aliases (`mv` is `addi rd, rs, 0`, an encoding we already carry),
+and counts `extensions/unratified/` separately rather than treating drafts as
+gaps to fill.
 
 ## Code layout
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "deploy": "gh-pages -d dist --branch gh-pages --dotfiles",
     "graph:check": "node scripts/seed-dependency-graph.mjs --check --udb",
     "links:check": "node scripts/map-doc-links.mjs --check",
+    "opcodes:check": "node scripts/check-opcodes-drift.mjs",
     "predeploy": "npm run build",
     "sync": "node scripts/sync_instructions.mjs",
     "sync:check": "npm run sync -- --strict",

--- a/scripts/check-opcodes-drift.mjs
+++ b/scripts/check-opcodes-drift.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+/**
+ * Reports when riscv-opcodes has ratified encodings we do not carry.
+ *
+ * Reads only. It never writes src/instr_dict.json, and that restraint is the
+ * whole design rather than caution for its own sake.
+ *
+ * src/instr_dict.json is hand-maintained, deliberately. It currently holds 300
+ * mnemonics upstream does not: the 56 vlseg segment loads, which riscv-opcodes
+ * does not express at all, and the 48 MOP and C.MOP encodings expanded from
+ * upstream's three `_n` templates. Regenerating from upstream would delete
+ * every one. So this reports drift and leaves the decision to a person, rather
+ * than opening a PR that silently loses data.
+ *
+ * The comparison is on mnemonics, not encodings. A newly ratified extension
+ * arrives as new mnemonics, which is the signal worth acting on. Comparing
+ * match and mask would additionally flag every place we knowingly differ, every
+ * week, which is how a check earns its way into being ignored.
+ *
+ * Two categories are excluded, each for a reason:
+ *
+ *   $pseudo_op    Assembler aliases. `mv` is `addi rd, rs, 0`; `nop` is
+ *                 `addi x0, x0, 0`. Upstream defines 172. They are spellings of
+ *                 encodings we already carry, so counting them as missing
+ *                 reported 93 phantom gaps when this was first measured.
+ *
+ *   unratified/   Drafts, 32 files including rv_zvabd and rv_p. Reporting these
+ *                 as missing would invite publishing unratified encodings as
+ *                 though they were settled, the exact failure the withdrawn
+ *                 bitmanip cleanup addressed. Counted and named, never flagged.
+ *
+ * Usage:
+ *   node scripts/check-opcodes-drift.mjs [path-to-riscv-opcodes] [--json]
+ *
+ * Exits 0 when in sync, 1 when upstream has ratified encodings we lack. That
+ * exit code is for the weekly workflow, not for CI on pull requests: upstream
+ * moving is news, not a regression in the branch under review.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+const asJson = args.includes('--json');
+const opcodesDir = args.find((a) => !a.startsWith('--')) ?? '../riscv-opcodes';
+
+const here = path.dirname(new URL(import.meta.url).pathname);
+const repoRoot = path.join(here, '..');
+
+/**
+ * Encodings we deliberately do not carry under upstream's name.
+ *
+ * Upstream writes MOP as three parameterised templates. We store the expansions
+ * instead, because a template cannot be searched for, validated against, or
+ * placed on the encoding map. Verify with:
+ *   node -e "const d=require('./src/instr_dict.json'); \
+ *            console.log(Object.keys(d).filter(k=>/^mop_r_/.test(k)).length)"
+ * which prints 32, the expansion of mop_r_n.
+ */
+const EXPANDED_TEMPLATES = new Map([
+  ['mop_r_n', 'expanded to MOP.R.0 through MOP.R.31'],
+  ['mop_rr_n', 'expanded to MOP.RR.0 through MOP.RR.7'],
+  ['c_mop_n', 'expanded to C.MOP.1 through C.MOP.15, odd values only'],
+]);
+
+/** Upstream mnemonic to our instr_dict key: lowercase, dots become underscores. */
+const normalise = (mnemonic) => mnemonic.toLowerCase().replace(/\./g, '_');
+
+/**
+ * Pull the real encodings out of one riscv-opcodes extension file.
+ *
+ * One instruction per line, mnemonic first, then field and bit-range
+ * assignments:
+ *   andn  rd rs1 rs2 31..25=32 14..12=7 6..2=0x0C 1..0=3
+ * with `#` comments, `$import other::inst` re-exports, and `$pseudo_op`.
+ */
+function parseExtensionFile(contents) {
+  const real = [];
+  const pseudo = [];
+  for (const rawLine of contents.split('\n')) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    if (line.startsWith('$pseudo_op')) {
+      // $pseudo_op rv_i::addi mv rd rs1 31..20=0
+      const name = line.split(/\s+/)[2];
+      if (name) pseudo.push(normalise(name));
+      continue;
+    }
+    // $import re-exports an instruction defined elsewhere, so its definition is
+    // already counted in its own file. Skipping avoids double counting.
+    if (line.startsWith('$')) continue;
+    const name = line.split(/\s+/)[0];
+    if (name) real.push(normalise(name));
+  }
+  return { real, pseudo };
+}
+
+/** Parse every file directly inside `dir`, ignoring subdirectories. */
+function collect(dir) {
+  const encodings = new Map(); // mnemonic -> Set of files defining it
+  const pseudoOps = new Set();
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    const parsed = parseExtensionFile(fs.readFileSync(path.join(dir, entry.name), 'utf8'));
+    for (const m of parsed.real) {
+      if (!encodings.has(m)) encodings.set(m, new Set());
+      encodings.get(m).add(entry.name);
+    }
+    for (const m of parsed.pseudo) pseudoOps.add(m);
+  }
+  return { encodings, pseudoOps };
+}
+
+const extensionsDir = path.join(opcodesDir, 'extensions');
+if (!fs.existsSync(extensionsDir)) {
+  console.error(`Could not find ${extensionsDir}`);
+  console.error('Clone it first:');
+  console.error('  git clone --depth 1 https://github.com/riscv/riscv-opcodes.git ../riscv-opcodes');
+  process.exit(2);
+}
+
+// Top level is ratified; the unratified/ subdirectory is counted separately and
+// never treated as a gap.
+const ratified = collect(extensionsDir);
+const unratifiedDir = path.join(extensionsDir, 'unratified');
+const unratified = fs.existsSync(unratifiedDir)
+  ? collect(unratifiedDir)
+  : { encodings: new Map(), pseudoOps: new Set() };
+
+const ours = new Set(
+  Object.keys(JSON.parse(fs.readFileSync(path.join(repoRoot, 'src', 'instr_dict.json'), 'utf8')))
+    .map(normalise),
+);
+
+const missing = [];
+const templates = [];
+for (const [mnemonic, files] of ratified.encodings) {
+  if (ours.has(mnemonic)) continue;
+  const reason = EXPANDED_TEMPLATES.get(mnemonic);
+  if (reason) templates.push({ mnemonic, reason });
+  else missing.push({ mnemonic, files: [...files].sort() });
+}
+missing.sort((a, b) => a.mnemonic.localeCompare(b.mnemonic));
+
+// Reported as information, never as an error: mostly vlseg and MOP expansions.
+const oursOnly = [...ours].filter(
+  (m) => !ratified.encodings.has(m) && !unratified.encodings.has(m) && !ratified.pseudoOps.has(m),
+);
+
+const byFile = new Map();
+for (const { mnemonic, files } of missing) {
+  for (const f of files) {
+    if (!byFile.has(f)) byFile.set(f, []);
+    byFile.get(f).push(mnemonic);
+  }
+}
+
+if (asJson) {
+  console.log(JSON.stringify({
+    inSync: missing.length === 0,
+    upstreamRatifiedEncodings: ratified.encodings.size,
+    upstreamPseudoOps: ratified.pseudoOps.size,
+    upstreamUnratifiedEncodings: unratified.encodings.size,
+    ourEncodings: ours.size,
+    ourEncodingsNotUpstream: oursOnly.length,
+    expandedTemplates: templates,
+    missing,
+    missingByFile: Object.fromEntries(byFile),
+  }, null, 2));
+} else {
+  console.log(`upstream ratified encodings : ${ratified.encodings.size}`);
+  console.log(`upstream pseudo-ops         : ${ratified.pseudoOps.size} (aliases, excluded by design)`);
+  console.log(`upstream unratified         : ${unratified.encodings.size} (drafts, not published)`);
+  console.log(`ours                        : ${ours.size}`);
+  console.log(`ours but not upstream       : ${oursOnly.length} (vlseg and MOP expansions)`);
+  console.log('');
+  for (const { mnemonic, reason } of templates) {
+    console.log(`template  ${mnemonic} — ${reason}`);
+  }
+  if (templates.length) console.log('');
+
+  if (missing.length === 0) {
+    console.log('In sync. Upstream has no ratified encoding we do not carry.');
+  } else {
+    console.log(`${missing.length} ratified encoding(s) upstream that we do not carry:`);
+    for (const [file, mnemonics] of [...byFile].sort()) {
+      console.log(`  ${file.padEnd(22)} ${mnemonics.join(' ')}`);
+    }
+    console.log('');
+    console.log('Not added automatically: src/instr_dict.json is hand-maintained and');
+    console.log('carries entries upstream does not, which a regenerate would delete.');
+  }
+}
+
+process.exit(missing.length === 0 ? 0 : 1);


### PR DESCRIPTION
Extension metadata has synced itself from UDB since #137, but instruction encodings never did. `src/instr_dict.json` is vendored and nothing checked whether upstream had moved, so a newly ratified extension could sit unnoticed indefinitely.

## Why this reports instead of syncing

The obvious fix, regenerating the file from riscv-opcodes on a cron, is wrong here. `src/instr_dict.json` is hand-maintained and carries **277 mnemonics upstream does not**: the 56 `vlseg` segment loads, which riscv-opcodes does not express at all, and the MOP and C.MOP encodings expanded from upstream's three `_n` templates. A regenerate would delete every one.

So a Monday job clones riscv-opcodes, diffs mnemonics, and opens an issue when upstream has ratified encodings we lack. It updates that same issue on later runs and closes it once back in sync.

## Measured before designing it

The naive comparison is useless, so it was worth checking first:

| | |
|---|---|
| upstream ratified encodings | 883 |
| upstream pseudo-ops | 172 (excluded, aliases) |
| upstream unratified | 638 (excluded, drafts) |
| ours | 1244 |
| **ratified encodings we lack** | **3** |

**Counting pseudo-ops would have reported 93 phantom gaps on the first run.** `mv` is `addi rd, rs, 0`; `nop` is `addi x0, x0, 0`. We already carry those encodings under their real names, so every one would be noise, and a check that cries wolf weekly gets muted.

**Counting `extensions/unratified/` would be worse than noise.** It would invite publishing draft encodings as though they were settled, which is what the withdrawn-bitmanip cleanup (#175) and the ratification labelling (#182) were both about. They are counted and named, never flagged.

The three that remain are `mop_r_n`, `mop_rr_n` and `c_mop_n`, allowlisted with the expansion each one stands for.

## Verification

All three exit paths, against real data:

| path | exit | |
|---|---|---|
| in sync | 0 | against upstream `c1d9bdf` |
| drift | 1 | two findings against a doctored checkout |
| checkout missing | 2 | distinguished, so an unreadable clone is not reported as drift |

The simulated run also confirmed a `$pseudo_op` and an `unratified/` file land in their own buckets rather than being flagged: pseudo-op count went 172 to 173, unratified 638 to 639, findings stayed at the 2 real encodings.

`npm test` 135 pass, lint 0 errors.

## One thing worth knowing

This also creates the `automated` and `data-sync` labels. Both were already referenced by `sync-udb-extensions.yml`, but **neither existed**, so that workflow's `create-pull-request` step was carrying an untested assumption. Its first scheduled run is Monday 2026-08-24, so this is fixed ahead of it rather than after.