### PR TITLE
Make the encoding map readable

### DIFF
--- a/src/EncodingMap.jsx
+++ b/src/EncodingMap.jsx
@@ -1,42 +1,103 @@
 import React from 'react';
 import { Grid3x3, X } from 'lucide-react';
-import { buildEncodingMap } from './encodingMap.js';
+import { buildEncodingMap, FREE_SLOT_KINDS } from './encodingMap.js';
 
 /**
  * The RISC-V opcode map, drawn from the catalogue.
  *
  * Derived at runtime from src/riscv_extensions.json, the same source the tiles
  * and the builder read. There is no generated asset behind this and nothing to
- * regenerate: sync the catalogue and the map follows. That is deliberate. A
- * separate data file would drift from the catalogue, which is exactly what made
- * the earlier dependency-graph proposal unmergeable.
+ * regenerate: sync the catalogue and the map follows.
  *
- * Plain SVG-free markup and CSS grid, no charting library. The layout is a 4x8
- * table and the only visual encoding is a colour ramp, so d3 would have added
- * 87 KB or more to a 754 KB bundle to compute what a logarithm already does.
- * Worth revisiting for a force-directed dependency view, where the maths is
- * real. Not here.
+ * Plain markup and CSS grid, no charting library. The layout is a 4x8 table and
+ * the quantities are small integers, so d3 would have added 87 KB or more to
+ * compute what a division already does.
+ *
+ * Density is a bar, not a colour wash. The first version shaded the whole cell
+ * and it failed on both counts. Contrast collapsed exactly where the data
+ * mattered most, because --riscv-gold is bright on the dark theme, so the
+ * busiest cells became pale plates under pale text: OP-V measured 2.56:1
+ * against a 4.5:1 floor, and seven more cells failed with it. And colour is a
+ * poor channel for quantity, so JAL with 1, MADD with 4 and MISC-MEM with 7
+ * were indistinguishable. A bar on a constant surface fixes both: the text
+ * contrast no longer varies with the data at all, and the number is right there
+ * beside the bar when the bar is too short to compare.
  */
 
-/**
- * Occupancy to a gold ramp, log scaled.
- *
- * OP-V holds 349 instructions while the median occupied cell holds single
- * digits. On a linear ramp almost every cell lands on the palest step and the
- * distribution disappears.
- */
-function densityStyle(count, max) {
-  if (count === 0) {
-    return {
-      background: 'var(--riscv-tint-1)',
-      borderColor: 'var(--riscv-border)',
-      color: 'var(--riscv-text-3)',
-    };
-  }
-  // Intensity only. The ramp itself lives in CSS (.heat-cell) so it can differ
-  // per theme: --riscv-gold is bright on dark and *dark* on light, so a single
-  // JS-computed mix made busy cells dark-on-dark in light mode, at 1.5:1.
-  return { '--heat': (Math.log(count + 1) / Math.log(max + 1)).toFixed(3) };
+/** Log scale, because OP-V holds 349 and the median occupied slot holds single digits. */
+function barWidth(count, max) {
+  if (count <= 0) return 0;
+  // Floor at 6% so a slot holding one instruction is still visibly not empty.
+  return 6 + (Math.log(count + 1) / Math.log(max + 1)) * 94;
+}
+
+const CATEGORY_LABEL = {
+  vendor: 'vendor custom',
+  reserved: 'reserved',
+  wide: '> 32-bit',
+  unratified: 'unratified',
+  unassigned: 'unassigned',
+};
+
+const CATEGORY_COLOUR = {
+  vendor: 'var(--riscv-accent-4)',
+  reserved: 'var(--riscv-text-3)',
+  wide: 'var(--riscv-accent-8)',
+  // Not --riscv-warn: its light value #b06f05 measured 3.95:1 on the cell
+  // surface, under the 4.5:1 floor. accent-7 is the same warning register and
+  // clears it at 4.99:1.
+  unratified: 'var(--riscv-accent-7)',
+  unassigned: 'var(--riscv-text-3)',
+};
+
+function Cell({ cell, max, selected, onSelect }) {
+  const isFree = cell.count === 0;
+  const colour = CATEGORY_COLOUR[cell.category] ?? 'var(--riscv-text-3)';
+  const label = CATEGORY_LABEL[cell.category] ?? 'unassigned';
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(selected ? null : cell)}
+      title={`${cell.name} · opcode 0x${cell.opcode.toString(16).padStart(2, '0')} · inst[6:5]=${cell.colBits} inst[4:2]=${cell.rowBits} · ${cell.count} instruction${cell.count === 1 ? '' : 's'}`}
+      className="slot-cell text-left rounded px-2 py-1.5"
+      style={{
+        borderStyle: isFree ? 'dashed' : 'solid',
+        borderColor: isFree ? colour : 'var(--riscv-border-2)',
+        ...(selected ? { outline: '2px solid var(--riscv-gold)', outlineOffset: 1 } : null),
+      }}
+    >
+      <div className="flex items-baseline justify-between gap-1">
+        <span
+          className="font-mono text-[10.5px] leading-tight truncate"
+          style={{ color: 'var(--riscv-text)' }}
+        >
+          {cell.name}
+        </span>
+        <span className="font-mono text-[9px] shrink-0" style={{ color: 'var(--riscv-text-3)' }}>
+          0x{cell.opcode.toString(16).padStart(2, '0')}
+        </span>
+      </div>
+
+      {isFree ? (
+        <div className="font-mono text-[9.5px] mt-1 truncate" style={{ color: colour }}>
+          {/* The slot named "reserved" would otherwise read "reserved / reserved". */}
+          {label === cell.name.toLowerCase() ? '—' : label}
+        </div>
+      ) : (
+        <div className="flex items-center gap-1.5 mt-1">
+          <span className="slot-bar-track" aria-hidden="true">
+            <span className="slot-bar-fill" style={{ width: `${barWidth(cell.count, max)}%` }} />
+          </span>
+          <span
+            className="font-mono text-[10px] tabular-nums shrink-0"
+            style={{ color: 'var(--riscv-text-2)' }}
+          >
+            {cell.count}
+          </span>
+        </div>
+      )}
+    </button>
+  );
 }
 
 export default function EncodingMap({ open, onClose, catalog, onSelectExtension }) {
@@ -98,6 +159,11 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
 
   const { cells, quadrants, totals } = map;
   const max = totals.busiest.count;
+  const free = totals.freeByKind;
+  const freeTotal = Object.values(free).reduce((a, b) => a + b, 0);
+  const rows = [0, 1, 2, 3, 4, 5, 6, 7];
+  const cols = [0, 1, 2, 3];
+  const at = (row, col) => cells.find((c) => c.row === row && c.col === col);
 
   return (
     <div className="fixed inset-0 z-50">
@@ -135,9 +201,8 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
                 className="text-[12px] mt-1"
                 style={{ color: 'var(--riscv-text-3)' }}
               >
-                The base opcode map. Rows are <span className="font-mono">inst[4:2]</span>, columns
-                are <span className="font-mono">inst[6:5]</span>, and every cell implies{' '}
-                <span className="font-mono">inst[1:0]=11</span>. Darker means busier.
+                The base opcode map, laid out as the ISA manual prints it. Every cell implies{' '}
+                <span className="font-mono">inst[1:0]=11</span>. Longer bars mean busier.
               </p>
             </div>
             <button
@@ -152,7 +217,7 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
 
           <div className="p-4">
             <div
-              className="flex flex-wrap gap-x-5 gap-y-1 text-[12px] mb-4"
+              className="flex flex-wrap gap-x-5 gap-y-1 text-[12px] mb-1"
               style={{ color: 'var(--riscv-text-2)' }}
             >
               <span>
@@ -175,46 +240,86 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
               </span>
             </div>
 
-            <div
-              className="grid gap-1.5"
-              style={{ gridTemplateColumns: 'repeat(4, minmax(0,1fr))' }}
-            >
-              {[0, 1, 2, 3].map((col) => (
-                <div key={col} className="grid gap-1.5">
-                  {cells
-                    .filter((c) => c.col === col)
-                    .sort((a, b) => a.row - b.row)
-                    .map((cell) => {
-                      const isSel = selected?.opcode === cell.opcode;
+            {/* The headline figure invites the wrong conclusion on its own: the
+                free slots are almost all spoken for. */}
+            <p className="text-[11.5px] mb-4" style={{ color: 'var(--riscv-text-3)' }}>
+              The {freeTotal} unused slots are not spare capacity. {free.vendor ?? 0} are vendor
+              custom space, {free.wide ?? 0} are reserved for instructions longer than 32 bits,{' '}
+              {free.unratified ?? 0} is allocated to an unratified extension, and{' '}
+              {free.reserved ?? 0} is reserved outright. None is available for a new standard
+              extension.
+            </p>
+
+            <div className="overflow-x-auto -mx-1 px-1">
+              <div className="min-w-[560px]">
+                {/* Column headers: inst[6:5]. */}
+                <div className="encoding-grid mb-1.5">
+                  <div
+                    className="font-mono text-[9.5px] self-end pb-0.5"
+                    style={{ color: 'var(--riscv-text-3)' }}
+                  >
+                    inst[4:2]
+                  </div>
+                  {cols.map((col) => (
+                    <div
+                      key={col}
+                      className="font-mono text-[10px] text-center"
+                      style={{ color: 'var(--riscv-text-2)' }}
+                    >
+                      <span style={{ color: 'var(--riscv-text-3)' }}>inst[6:5]=</span>
+                      {col.toString(2).padStart(2, '0')}
+                    </div>
+                  ))}
+                </div>
+
+                {rows.map((row) => (
+                  <div key={row} className="encoding-grid mb-1.5">
+                    <div
+                      className="font-mono text-[10px] flex items-center justify-end pr-1"
+                      style={{ color: 'var(--riscv-text-2)' }}
+                    >
+                      {row.toString(2).padStart(3, '0')}
+                    </div>
+                    {cols.map((col) => {
+                      const cell = at(row, col);
                       return (
-                        <button
+                        <Cell
                           key={cell.opcode}
-                          type="button"
-                          onClick={() => setSelected(isSel ? null : cell)}
-                          title={`${cell.name} · opcode 0x${cell.opcode.toString(16).padStart(2, '0')} · ${cell.count} instruction${cell.count === 1 ? '' : 's'}`}
-                          className="heat-cell text-left rounded border px-2 py-1.5 transition-colors"
-                          style={{
-                            ...densityStyle(cell.count, max),
-                            ...(isSel
-                              ? { outline: '2px solid var(--riscv-gold)', outlineOffset: 1 }
-                              : null),
-                          }}
-                        >
-                          <div className="font-mono text-[10.5px] leading-tight truncate">
-                            {cell.name}
-                          </div>
-                          <div className="text-[10px] opacity-70 font-mono">
-                            {cell.count > 0 ? cell.count : '—'}
-                          </div>
-                        </button>
+                          cell={cell}
+                          max={max}
+                          selected={selected?.opcode === cell.opcode}
+                          onSelect={setSelected}
+                        />
                       );
                     })}
-                </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div
+              className="mt-3 flex flex-wrap gap-x-4 gap-y-1 items-center text-[10.5px]"
+              style={{ color: 'var(--riscv-text-3)' }}
+            >
+              {['vendor', 'wide', 'unratified', 'reserved'].map((kind) => (
+                <span key={kind} className="flex items-center gap-1">
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      display: 'inline-block',
+                      width: 10,
+                      height: 10,
+                      border: `1px dashed ${CATEGORY_COLOUR[kind]}`,
+                      borderRadius: 2,
+                    }}
+                  />
+                  {CATEGORY_LABEL[kind]}
+                </span>
               ))}
             </div>
 
             <div
-              className="mt-4 flex flex-wrap gap-2 items-center text-[11px]"
+              className="mt-3 flex flex-wrap gap-2 items-center text-[11px]"
               style={{ color: 'var(--riscv-text-3)' }}
             >
               <span>Compressed, outside the 32-bit map:</span>
@@ -238,14 +343,15 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
                 className="mt-4 rounded border p-3"
                 style={{ background: 'var(--riscv-surface-2)', borderColor: 'var(--riscv-border)' }}
               >
-                <div className="flex items-baseline justify-between gap-3 mb-2">
+                <div className="flex items-baseline justify-between gap-3 mb-2 flex-wrap">
                   <h4
                     className="font-mono text-[13px] font-bold"
                     style={{ color: 'var(--riscv-gold)' }}
                   >
                     {selected.name}{' '}
                     <span className="font-normal" style={{ color: 'var(--riscv-text-3)' }}>
-                      opcode 0x{selected.opcode.toString(16).padStart(2, '0')}
+                      opcode 0x{selected.opcode.toString(16).padStart(2, '0')} · inst[6:5]=
+                      {selected.colBits} inst[4:2]={selected.rowBits}
                     </span>
                   </h4>
                   <span className="text-[11px]" style={{ color: 'var(--riscv-text-3)' }}>
@@ -255,9 +361,14 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
 
                 {selected.count === 0 ? (
                   <p className="text-[12px]" style={{ color: 'var(--riscv-text-2)' }}>
-                    Nothing in the catalogue uses this slot. Most unused slots are not spare
-                    capacity: they are reserved for vendor custom encodings, or for instructions
-                    longer than 32 bits.
+                    <span
+                      className="font-mono"
+                      style={{ color: CATEGORY_COLOUR[selected.category] }}
+                    >
+                      {CATEGORY_LABEL[selected.category]}
+                    </span>
+                    {'. '}
+                    {FREE_SLOT_KINDS[selected.category] ?? 'Not allocated by the specification.'}
                   </p>
                 ) : (
                   <>

--- a/src/encodingMap.js
+++ b/src/encodingMap.js
@@ -52,6 +52,39 @@ export const OPCODE_NAMES = {
 };
 
 /**
+ * What an unused slot is actually reserved for.
+ *
+ * The nine free slots are the most interesting part of the map and they are not
+ * interchangeable. Drawn as one undifferentiated grey they read as spare
+ * capacity, which three quarters of them are not.
+ *
+ * OP-P is the one that needs sourcing rather than assertion: the slot is
+ * allocated to the packed-SIMD extension, and P is unratified, which is why we
+ * carry no instructions for it. riscv-opcodes files it under
+ * extensions/unratified/rv_p. So the slot is spoken for, not free.
+ */
+export const FREE_SLOT_KINDS = {
+  vendor:
+    'Vendor custom space. Reserved for non-standard extensions and never allocated by RISC-V International.',
+  reserved: 'Reserved by the specification. Not available for use.',
+  wide: 'Reserved for instructions longer than 32 bits, which this map does not cover.',
+  unratified:
+    'Allocated to an extension that is not ratified, so the catalogue carries no instructions for it.',
+};
+
+const FREE_SLOT_CATEGORIES = {
+  0x0b: 'vendor', // custom-0
+  0x2b: 'vendor', // custom-1
+  0x7b: 'vendor', // custom-3
+  0x6b: 'reserved',
+  0x1f: 'wide', // 48b
+  0x3f: 'wide', // 64b
+  0x5f: 'wide', // 48b
+  0x7f: 'wide', // 80b+
+  0x5b: 'unratified', // OP-P
+};
+
+/**
  * Collapse the catalogue to distinct instructions.
  *
  * A mnemonic appears under several extensions (ADD is in RV32I and in every
@@ -141,10 +174,17 @@ export function buildEncodingMap(catalog) {
         opcode,
         row,
         col,
+        // The coordinates as bits, so the grid can be read like the manual's
+        // table rather than requiring the reader to redo the arithmetic.
+        rowBits: row.toString(2).padStart(3, '0'),
+        colBits: col.toString(2).padStart(2, '0'),
         name: OPCODE_NAMES[opcode] || 'unassigned',
         count: held.length,
         instructions: held,
         extensions: [...new Set(held.flatMap((i) => i.extensions))].sort(),
+        // Only meaningful when the slot is empty. An occupied slot needs no
+        // explanation: its instructions are the explanation.
+        category: held.length === 0 ? (FREE_SLOT_CATEGORIES[opcode] ?? 'unassigned') : null,
       });
     }
   }
@@ -167,6 +207,11 @@ export function buildEncodingMap(catalog) {
       occupiedSlots,
       totalSlots: cells.length,
       busiest: cells.reduce((a, b) => (b.count > a.count ? b : a), cells[0]),
+      // How the free space breaks down, so "9 slots left" cannot be read as
+      // "9 slots available". Most of it is not.
+      freeByKind: cells
+        .filter((c) => c.count === 0)
+        .reduce((acc, c) => ({ ...acc, [c.category]: (acc[c.category] ?? 0) + 1 }), {}),
     },
   };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -17,7 +17,6 @@
   --riscv-muted: #414157;
 
   --riscv-gold: #f5c542;
-  --riscv-heat-span: 55%;
   --riscv-gold-dim: rgba(245, 197, 66, 0.12);
   --riscv-gold-glow: rgba(245, 197, 66, 0.20);
 
@@ -489,8 +488,6 @@ pre,
      0.152. Only the text colour moved, so the dim and glow tints below keep
      the original warmth for borders and halos. */
   --riscv-gold: #8f6408;
-  /* Gentler on light: the mix darkens toward the ink rather than away from it. */
-  --riscv-heat-span: 24%;
   --riscv-gold-dim: rgba(168, 118, 10, 0.10);
   --riscv-gold-glow: rgba(168, 118, 10, 0.18);
 
@@ -708,14 +705,46 @@ pre,
   color: #fef3c7 !important;
 }
 
-/* Encoding-map heat cells.
-   The span differs per theme because --riscv-gold inverts: it is bright on the
-   dark ground and dark on the light one. A single mix percentage therefore
-   produces a dark cell with dark ink in light mode, which measured 1.5:1. */
-.heat-cell {
-  background: color-mix(in srgb, var(--riscv-gold) calc(12% + var(--heat, 0) * var(--riscv-heat-span)), transparent);
-  border-color: var(--riscv-gold-glow);
-  color: var(--riscv-text);
+/* Encoding map.
+   Row label plus the four inst[6:5] columns. One template shared by the header
+   row and every data row keeps the cells aligned under their headers. */
+.encoding-grid {
+  display: grid;
+  grid-template-columns: 2.75rem repeat(4, minmax(0, 1fr));
+  gap: 0.375rem;
+}
+
+/* Every slot gets the same surface, whatever it holds.
+   An earlier version shaded the cell by occupancy. Because --riscv-gold is
+   bright on the dark theme, the busiest cells became pale plates under pale
+   text and contrast collapsed exactly where the data mattered: OP-V measured
+   2.56:1, and seven more cells failed with it. Density moved to the bar below,
+   so text contrast is now constant and independent of the data. */
+.slot-cell {
+  background: var(--riscv-tint-1);
+  border-width: 1px;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.slot-cell:hover {
+  background: var(--riscv-tint-3);
+}
+
+.slot-bar-track {
+  display: block;
+  flex: 1 1 auto;
+  height: 5px;
+  min-width: 0;
+  border-radius: 999px;
+  background: var(--riscv-tint-4);
+  overflow: hidden;
+}
+
+.slot-bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--riscv-gold);
 }
 
 /* Builder Toolbar Container */

--- a/tests/encoding-map.test.mjs
+++ b/tests/encoding-map.test.mjs
@@ -12,7 +12,13 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
-import { buildEncodingMap, distinctInstructions, isThirtyTwoBit, OPCODE_NAMES } from '../src/encodingMap.js';
+import {
+  buildEncodingMap,
+  distinctInstructions,
+  isThirtyTwoBit,
+  FREE_SLOT_KINDS,
+  OPCODE_NAMES,
+} from '../src/encodingMap.js';
 
 const here = path.dirname(new URL(import.meta.url).pathname);
 const catalog = JSON.parse(
@@ -126,5 +132,54 @@ test('empty cells are real slots, not missing data', () => {
     assert.ok(cell.name, `slot 0x${cell.opcode.toString(16)} has no name`);
     assert.deepEqual(cell.instructions, []);
     assert.deepEqual(cell.extensions, []);
+  }
+});
+
+test('every free slot says what it is reserved for', () => {
+  // Drawn as one undifferentiated grey, the free slots read as spare capacity.
+  // Almost none of them is: they are vendor space, longer-than-32-bit
+  // encodings, an unratified allocation, and one outright reservation. An
+  // uncategorised slot would silently fall back to "unassigned" in the UI, so
+  // this fails rather than letting that pass.
+  const uncategorised = map.cells
+    .filter((c) => c.count === 0 && c.category === 'unassigned')
+    .map((c) => `${c.name} @ 0x${c.opcode.toString(16)}`);
+  assert.deepEqual(uncategorised, [], `free slots with no category:\n  ${uncategorised.join('\n  ')}`);
+
+  for (const cell of map.cells) {
+    if (cell.count > 0) {
+      assert.equal(cell.category, null, `${cell.name} is occupied and needs no category`);
+    } else {
+      assert.ok(FREE_SLOT_KINDS[cell.category], `${cell.name} has no description for ${cell.category}`);
+    }
+  }
+
+  // The tally the summary sentence is built from must match the cells.
+  const counted = Object.values(map.totals.freeByKind).reduce((a, b) => a + b, 0);
+  assert.equal(
+    counted, map.cells.filter((c) => c.count === 0).length,
+    'freeByKind must account for every free slot',
+  );
+});
+
+test('OP-P is free because P is unratified, not because it is spare', () => {
+  // Worth naming: the slot is allocated to packed SIMD, and riscv-opcodes files
+  // rv_p under extensions/unratified/. Calling it vendor space or reserved
+  // would misrepresent why the catalogue has nothing for it.
+  const opP = map.cells.find((c) => c.name === 'OP-P');
+  assert.ok(opP, 'OP-P is missing from the map');
+  assert.equal(opP.count, 0);
+  assert.equal(opP.category, 'unratified');
+});
+
+test('cells carry their coordinates as bits', () => {
+  // The grid is only readable as the manual prints it if a cell states its own
+  // position. Without these the reader has to redo the arithmetic.
+  for (const cell of map.cells) {
+    assert.equal(cell.rowBits, cell.row.toString(2).padStart(3, '0'));
+    assert.equal(cell.colBits, cell.col.toString(2).padStart(2, '0'));
+    // And the bits must reconstruct the opcode, which is the whole point.
+    const rebuilt = (parseInt(cell.colBits, 2) << 5) | (parseInt(cell.rowBits, 2) << 2) | 0b11;
+    assert.equal(rebuilt, cell.opcode, `${cell.name} coordinates do not rebuild its opcode`);
   }
 });


### PR DESCRIPTION
Follow-up to #184, prompted by Rafael asking whether the heatmap was the best representation. It was not, and reviewing it turned up a contrast failure I had reported as passing.

## The bug

`--riscv-gold` is bright on the dark theme, so shading a cell by occupancy made the busiest cells pale plates under pale text. **The contrast got worse as the cell got more important:**

| cell | count | contrast |
|---|---|---|
| OP-V | 349 | **2.56:1** |
| LOAD-FP | 181 | 2.96:1 |
| OP-FP | 143 | 3.12:1 |
| STORE-FP | 137 | 3.15:1 |
| SYSTEM | 85 | 3.51:1 |
| OP | 65 | 3.73:1 |
| AMO | 55 | 3.88:1 |
| OP-IMM | 40 | 4.18:1 |

Eight cells under the 4.5:1 floor in the default theme.

**I had checked this and reported it clean.** The audit was broken: Chrome returns `color-mix` results as `color(srgb 0.96 0.77 0.26 / 0.67)` with components in 0–1, and the checker parsed them as 0–255, so every heat cell measured as near-black and passed trivially. Light mode was genuinely fine, which made the wrong result look plausible.

## The fix

Density is a **bar on a constant surface**, so text contrast no longer varies with the data: **0 failures across 120 elements in both themes.**

It also fixes a problem the colour wash had regardless of contrast: colour is a poor channel for quantity. `JAL 1`, `MADD 4` and `MISC-MEM 7` were indistinguishable. They are now three obviously different bars, with the exact number beside each.

The legend was wrong too. It said "Darker means busier", true only in light mode. It now says "Longer bars mean busier", true in both.

## Axis coordinates

Rows labelled `000`–`111` for `inst[4:2]`, columns `inst[6:5]=00`–`11`, and the hex opcode in every cell. Previously the description stated the rule and left you to count rows and do the arithmetic. Now a slot's encoding reads straight off the grid, the way the manual prints the table.

## Categorised free space

The nine free slots were nine identical greys, which reads as spare capacity. They are not interchangeable, and **none of them is available**:

| | |
|---|---|
| 3 | vendor custom (`custom-0`, `custom-1`, `custom-3`) |
| 4 | wider than 32-bit (`48b`, `64b`, `48b`, `80b+`) |
| 1 | unratified (`OP-P`, allocated to packed SIMD) |
| 1 | reserved outright |

The summary now states that plainly rather than leaving "23/32 used" to imply nine slots going spare. `OP-P` is sourced, not assumed: riscv-opcodes files `rv_p` under `extensions/unratified/`.

One category colour had to change: `--riscv-warn` is `#b06f05` on light and measured 3.95:1 on the cell surface. `--riscv-accent-7` is the same warning register and clears it at 4.99:1.

## Verification

- **138 tests**, up from 135. New ones pin that every free slot has a category and a description, that occupied slots carry none, that `freeByKind` accounts for every free slot, that `OP-P` is `unratified` rather than vendor or reserved, and that each cell's row and column bits reconstruct its opcode.
- Contrast re-audited with a corrected `color(srgb …)` parser: **0 failures, both themes**.
- Interaction checked in-browser: selecting `OP-V` shows `opcode 0x57`, `inst[6:5]=10 inst[4:2]=101` and 10 extension links; selecting `OP-P` explains why it is empty; Escape closes and returns focus to the trigger.
- Build 768 KiB (up 4 KiB), lint 0 errors.