### PR TITLE
Scale the encoding-map bar against a meaningful interval

### DIFF
--- a/src/EncodingMap.jsx
+++ b/src/EncodingMap.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Grid3x3, X } from 'lucide-react';
-import { buildEncodingMap, FREE_SLOT_KINDS } from './encodingMap.js';
+import { barWidth, buildEncodingMap, FREE_SLOT_KINDS } from './encodingMap.js';
 
 /**
  * The RISC-V opcode map, drawn from the catalogue.
@@ -24,12 +24,6 @@ import { buildEncodingMap, FREE_SLOT_KINDS } from './encodingMap.js';
  * beside the bar when the bar is too short to compare.
  */
 
-/** Log scale, because OP-V holds 349 and the median occupied slot holds single digits. */
-function barWidth(count, max) {
-  if (count <= 0) return 0;
-  // Floor at 6% so a slot holding one instruction is still visibly not empty.
-  return 6 + (Math.log(count + 1) / Math.log(max + 1)) * 94;
-}
 
 const CATEGORY_LABEL = {
   vendor: 'vendor custom',
@@ -50,7 +44,7 @@ const CATEGORY_COLOUR = {
   unassigned: 'var(--riscv-text-3)',
 };
 
-function Cell({ cell, max, selected, onSelect }) {
+function Cell({ cell, total, selected, onSelect }) {
   const isFree = cell.count === 0;
   const colour = CATEGORY_COLOUR[cell.category] ?? 'var(--riscv-text-3)';
   const label = CATEGORY_LABEL[cell.category] ?? 'unassigned';
@@ -86,14 +80,13 @@ function Cell({ cell, max, selected, onSelect }) {
       ) : (
         <div className="flex items-center gap-1.5 mt-1">
           <span className="slot-bar-track" aria-hidden="true">
-            <span className="slot-bar-fill" style={{ width: `${barWidth(cell.count, max)}%` }} />
+            <span className="slot-bar-fill" style={{ width: `${barWidth(cell.count, total)}%` }} />
           </span>
-          <span
-            className="font-mono text-[10px] tabular-nums shrink-0"
-            style={{ color: 'var(--riscv-text-2)' }}
-          >
-            {cell.count}
-          </span>
+          {/* Fixed width, or the number steals track from its own bar: a cell
+              showing 349 had a 189px track while one showing 4 had 201px, so
+              equal shares rendered as unequal lengths and the busiest cells got
+              the shortest tracks. */}
+          <span className="slot-count font-mono text-[10px] tabular-nums">{cell.count}</span>
         </div>
       )}
     </button>
@@ -158,7 +151,6 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
   if (!open || !map) return null;
 
   const { cells, quadrants, totals } = map;
-  const max = totals.busiest.count;
   const free = totals.freeByKind;
   const freeTotal = Object.values(free).reduce((a, b) => a + b, 0);
   const rows = [0, 1, 2, 3, 4, 5, 6, 7];
@@ -202,7 +194,8 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
                 style={{ color: 'var(--riscv-text-3)' }}
               >
                 The base opcode map, laid out as the ISA manual prints it. Every cell implies{' '}
-                <span className="font-mono">inst[1:0]=11</span>. Longer bars mean busier.
+                <span className="font-mono">inst[1:0]=11</span>. Each bar is the slot&rsquo;s share
+                of all {totals.thirtyTwoBit} 32-bit instructions.
               </p>
             </div>
             <button
@@ -236,7 +229,8 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
               <span>
                 busiest is{' '}
                 <strong style={{ color: 'var(--riscv-text)' }}>{totals.busiest.name}</strong> with{' '}
-                {totals.busiest.count}
+                {totals.busiest.count}, or{' '}
+                {((totals.busiest.count / totals.thirtyTwoBit) * 100).toFixed(1)}% of them
               </span>
             </div>
 
@@ -286,7 +280,7 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
                         <Cell
                           key={cell.opcode}
                           cell={cell}
-                          max={max}
+                          total={totals.thirtyTwoBit}
                           selected={selected?.opcode === cell.opcode}
                           onSelect={setSelected}
                         />

--- a/src/encodingMap.js
+++ b/src/encodingMap.js
@@ -85,6 +85,34 @@ const FREE_SLOT_CATEGORIES = {
 };
 
 /**
+ * Bar length as a share of every 32-bit instruction.
+ *
+ * The denominator matters more than the curve, and the first two versions got
+ * it wrong in the same way. Both divided by the busiest slot, so a full bar
+ * meant "ties OP-V" — a circular reference that says nothing about the encoding
+ * space and that moves when a different slot gains instructions. A slot's bar
+ * would shrink because OP-V grew.
+ *
+ * Dividing by the total gives a real interval. A full bar means the slot holds
+ * every 32-bit instruction there is, the bars sum to the whole, and the figure
+ * is sayable: OP-V holds 30% of all 32-bit instructions.
+ *
+ * Linear, so length is proportional to count. The earlier log curve gave a slot
+ * holding one instruction 17% of the track and rendered a 349x difference as a
+ * 5.6x difference in length, which flattered the empty slots and hid how
+ * lopsided the space actually is.
+ */
+export function barWidth(count, total) {
+  if (count <= 0 || total <= 0) return 0;
+  const share = (count / total) * 100;
+  // A hairline so an occupied slot never reads as empty: one instruction is
+  // 0.09%, which rounds to nothing on a 171px track. Kept well below the
+  // smallest real share on the map (OP-VE at 1.83%) so the stub cannot be
+  // mistaken for a measurement. The exact count is printed alongside.
+  return Math.max(share, 0.8);
+}
+
+/**
  * Collapse the catalogue to distinct instructions.
  *
  * A mnemonic appears under several extensions (ADD is in RV32I and in every

--- a/src/index.css
+++ b/src/index.css
@@ -747,6 +747,17 @@ pre,
   background: var(--riscv-gold);
 }
 
+/* Reserve room for the widest count so the number cannot steal width from its
+   own bar. Without this a cell showing 349 had a 189px track while one showing
+   4 had 201px, so equal shares rendered as unequal lengths and the busiest
+   cells got the shortest tracks. */
+.slot-count {
+  flex: 0 0 auto;
+  width: 2.25rem;
+  text-align: right;
+  color: var(--riscv-text-2);
+}
+
 /* Builder Toolbar Container */
 :root[data-theme='light'] .builder-toolbar {
   background: #ffffff !important;

--- a/tests/encoding-map.test.mjs
+++ b/tests/encoding-map.test.mjs
@@ -13,6 +13,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import {
+  barWidth,
   buildEncodingMap,
   distinctInstructions,
   isThirtyTwoBit,
@@ -170,6 +171,46 @@ test('OP-P is free because P is unratified, not because it is spare', () => {
   assert.ok(opP, 'OP-P is missing from the map');
   assert.equal(opP.count, 0);
   assert.equal(opP.category, 'unratified');
+});
+
+test('the bar measures share of the whole, not share of the busiest slot', () => {
+  // The defect this pins is a denominator, not a curve. Two earlier versions
+  // divided by the busiest slot, so a full bar meant "ties OP-V": circular, and
+  // unstable, because a slot's bar would shrink when a *different* slot gained
+  // instructions. Dividing by the total gives a fixed interval.
+  const total = map.totals.thirtyTwoBit;
+
+  // Proportional: doubling the count doubles the length.
+  assert.equal(barWidth(200, 1000), 20);
+  assert.equal(barWidth(400, 1000), 40);
+
+  // A slot holding everything fills the track. Nothing on this map does, which
+  // is the point: the endpoint is real rather than whatever the maximum happens
+  // to be today.
+  assert.equal(barWidth(total, total), 100);
+  const busiest = map.totals.busiest;
+  assert.ok(
+    barWidth(busiest.count, total) < 100,
+    `${busiest.name} should not fill the track: it holds ${busiest.count} of ${total}`,
+  );
+
+  // The regression itself. Under the old rule the busiest slot always measured
+  // 100% whatever it held, so these two would be equal.
+  assert.notEqual(barWidth(busiest.count, total), barWidth(total, total));
+
+  // And a slot's bar must not depend on any other slot. Same count, same width.
+  assert.equal(barWidth(40, total), barWidth(40, total));
+
+  // Empty stays empty; the stub is only for occupied slots.
+  assert.equal(barWidth(0, total), 0);
+  assert.equal(barWidth(1, total), 0.8, 'one instruction gets the hairline stub');
+  assert.ok(
+    barWidth(1, total) < barWidth(21, total),
+    'the stub must stay below the smallest real share, or it reads as a measurement',
+  );
+
+  // Guard against a zero denominator rather than emitting NaN into a style.
+  assert.equal(barWidth(5, 0), 0);
 });
 
 test('cells carry their coordinates as bits', () => {


### PR DESCRIPTION
Rafael caught this on review of #186: the bar was setting an interval that does not make sense.

## The interval

`barWidth` divided by `max`, the busiest slot. So a full bar meant **"ties OP-V"**. That is circular. It says nothing about the encoding space, and it is unstable: a slot's bar would shrink because a *different* slot gained instructions. There was no interval at all, only a comparison against whatever happened to be largest.

Dividing by the total gives a real one. A full bar means the slot holds every 32-bit instruction there is, the bars sum to the whole, and the number is sayable: **OP-V holds 30.4% of all 1149**, not "100%".

The legend now states the interval outright: *"Each bar is the slot's share of all 1149 32-bit instructions."*

## Log to linear

A smaller point, but distorting in the same direction. Measured on the deployed build:

| slot | count | log (was) | linear (now) |
|---|---|---|---|
| LUI | 1 | 17.1% | 0.09% |
| AUIPC | 2 | 23.6% | 0.17% |
| OP-VE | 21 | 55.6% | 1.83% |
| LOAD-FP | 181 | 89.5% | 15.75% |
| OP-V | 349 | 100% | 30.37% |

A **349× difference in count rendered as a 5.6× difference in length**, and a slot holding one instruction got a sixth of the track. The old curve said the encoding space was evenly loaded. It is not: vector and floating-point hold roughly two thirds of the 32-bit instructions between them, and the map now shows that.

Occupied slots below ~0.8% get a hairline stub so they cannot read as empty. It sits well under the smallest real share on the map (OP-VE at 1.83%) so it cannot be mistaken for a measurement, and the exact count is printed beside every bar regardless.

## A layout bug found while measuring

The track shared a flex row with the count, and the count was `shrink-0`, so **a wider number stole width from its own bar**:

| cells showing | track |
|---|---|
| 1–9 | 201px |
| 17–85 | 195px |
| 137–349 | 189px |

The busiest slots got the shortest tracks, and equal shares rendered as unequal pixel lengths across the grid. The count now has a fixed column; all 23 tracks measure 171px.

## Verification

- **139 tests**, up from 138. `barWidth` moves to `encodingMap.js` so it is testable without a DOM, the same reason the rest of the arithmetic lives there. The new test pins the denominator, that a slot's width never depends on another slot, that the stub stays below real values, and that a zero total returns 0 rather than writing `NaN` into a style attribute.
- In-browser: 23 bars, one distinct track width (171px), OP-V renders at `30.3742%`, no `NaN` in the markup.
- Build 768 KiB, lint 0 errors.