### PR TITLE
Correct 0x5b to custom-2 and separate allocation from dataset

### DIFF
--- a/src/EncodingMap.jsx
+++ b/src/EncodingMap.jsx
@@ -24,12 +24,10 @@ import { barWidth, buildEncodingMap, FREE_SLOT_KINDS } from './encodingMap.js';
  * beside the bar when the bar is too short to compare.
  */
 
-
 const CATEGORY_LABEL = {
-  vendor: 'vendor custom',
+  vendor: 'custom',
   reserved: 'reserved',
   wide: '> 32-bit',
-  unratified: 'unratified',
   unassigned: 'unassigned',
 };
 
@@ -37,10 +35,6 @@ const CATEGORY_COLOUR = {
   vendor: 'var(--riscv-accent-4)',
   reserved: 'var(--riscv-text-3)',
   wide: 'var(--riscv-accent-8)',
-  // Not --riscv-warn: its light value #b06f05 measured 3.95:1 on the cell
-  // surface, under the 4.5:1 floor. accent-7 is the same warning register and
-  // clears it at 4.99:1.
-  unratified: 'var(--riscv-accent-7)',
   unassigned: 'var(--riscv-text-3)',
 };
 
@@ -193,9 +187,11 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
                 className="text-[12px] mt-1"
                 style={{ color: 'var(--riscv-text-3)' }}
               >
-                The base opcode map, laid out as the ISA manual prints it. Every cell implies{' '}
-                <span className="font-mono">inst[1:0]=11</span>. Each bar is the slot&rsquo;s share
-                of all {totals.thirtyTwoBit} 32-bit instructions.
+                The base 32-bit opcode map. Every cell implies{' '}
+                <span className="font-mono">inst[1:0]=11</span>. Slot names and categories come from
+                the specification; the counts and bars come from this site&rsquo;s catalogue, so a
+                bar is a slot&rsquo;s share of the instruction definitions we carry, not a measure
+                of how much encoding space it consumes.
               </p>
             </div>
             <button
@@ -217,30 +213,31 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
                 <strong style={{ color: 'var(--riscv-text)' }}>
                   {totals.occupiedSlots}/{totals.totalSlots}
                 </strong>{' '}
-                opcode slots used
+                major opcodes assigned to standard 32-bit classes
               </span>
               <span>
                 <strong style={{ color: 'var(--riscv-text)' }}>{totals.thirtyTwoBit}</strong> 32-bit
+                definitions
               </span>
               <span>
-                <strong style={{ color: 'var(--riscv-text)' }}>{totals.compressed}</strong>{' '}
-                compressed
+                <strong style={{ color: 'var(--riscv-text)' }}>{totals.compressed}</strong> with{' '}
+                <span className="font-mono">inst[1:0]≠11</span>
               </span>
               <span>
                 busiest is{' '}
-                <strong style={{ color: 'var(--riscv-text)' }}>{totals.busiest.name}</strong> with{' '}
-                {totals.busiest.count}, or{' '}
-                {((totals.busiest.count / totals.thirtyTwoBit) * 100).toFixed(1)}% of them
+                <strong style={{ color: 'var(--riscv-text)' }}>{totals.busiest.name}</strong>, with{' '}
+                {totals.busiest.count} of them (
+                {((totals.busiest.count / totals.thirtyTwoBit) * 100).toFixed(1)}%)
               </span>
             </div>
 
-            {/* The headline figure invites the wrong conclusion on its own: the
-                free slots are almost all spoken for. */}
+            {/* "23 of 32 assigned" invites the wrong conclusion on its own: the
+                remaining nine are allocated too, just not to standard classes. */}
             <p className="text-[11.5px] mb-4" style={{ color: 'var(--riscv-text-3)' }}>
-              The {freeTotal} unused slots are not spare capacity. {free.vendor ?? 0} are vendor
-              custom space, {free.wide ?? 0} are reserved for instructions longer than 32 bits,{' '}
-              {free.unratified ?? 0} is allocated to an unratified extension, and{' '}
-              {free.reserved ?? 0} is reserved outright. None is available for a new standard
+              The other {freeTotal} are not spare capacity. {free.vendor ?? 0} are custom opcodes,
+              set aside for non-standard extensions and avoided by future standard ones,{' '}
+              {free.wide ?? 0} are reserved for instructions longer than 32 bits, and{' '}
+              {free.reserved ?? 0} is reserved outright. None is available for a new standard 32-bit
               extension.
             </p>
 
@@ -295,7 +292,7 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
               className="mt-3 flex flex-wrap gap-x-4 gap-y-1 items-center text-[10.5px]"
               style={{ color: 'var(--riscv-text-3)' }}
             >
-              {['vendor', 'wide', 'unratified', 'reserved'].map((kind) => (
+              {['vendor', 'wide', 'reserved'].map((kind) => (
                 <span key={kind} className="flex items-center gap-1">
                   <span
                     aria-hidden="true"
@@ -316,7 +313,11 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
               className="mt-3 flex flex-wrap gap-2 items-center text-[11px]"
               style={{ color: 'var(--riscv-text-3)' }}
             >
-              <span>Compressed, outside the 32-bit map:</span>
+              {/* Not "compressed". RISC-V uses the low bits to encode
+                  instruction length, so inst[1:0]!=11 means "not 32 bits", which
+                  is a wider statement than "the C extension" once Zc* and other
+                  16-bit encodings are in the dataset. */}
+              <span>Definitions outside the 32-bit map:</span>
               {quadrants.map((q) => (
                 <span
                   key={q.quadrant}
@@ -331,6 +332,27 @@ export default function EncodingMap({ open, onClose, catalog, onSelectExtension 
                 </span>
               ))}
             </div>
+
+            {/* Name the dataset. Without this the counts read as properties of
+                the ISA, which they are not: a different selection of upstream
+                files, or a different upstream revision, gives different numbers.
+                The slot names and categories above are not affected, being
+                architectural. */}
+            <p className="mt-3 text-[10.5px]" style={{ color: 'var(--riscv-text-3)' }}>
+              Counts are instruction definitions in this site&rsquo;s catalogue, built from the
+              ratified files of{' '}
+              <a
+                href="https://github.com/riscv/riscv-opcodes"
+                target="_blank"
+                rel="noreferrer noopener"
+                style={{ color: 'var(--riscv-gold)' }}
+              >
+                riscv-opcodes
+              </a>{' '}
+              plus corrections recorded in the repository. One definition can constrain anything
+              from a handful of encodings to a large region of the slot, so these are not a measure
+              of encoding-space consumption.
+            </p>
 
             {selected && (
               <div

--- a/src/encodingMap.js
+++ b/src/encodingMap.js
@@ -39,7 +39,10 @@ export const OPCODE_NAMES = {
   0x4f: 'NMADD',
   0x53: 'OP-FP',
   0x57: 'OP-V',
-  0x5b: 'OP-P',
+  // custom-2, not OP-P. The manual assigns all four custom opcodes
+  // 0x0b/0x2b/0x5b/0x7b, and P does not use this slot at all: riscv-opcodes
+  // encodes rv_p under OP-IMM, OP-IMM-32 and OP-32 (0x13, 0x1b, 0x3b).
+  0x5b: 'custom-2',
   0x5f: '48b',
   0x63: 'BRANCH',
   0x67: 'JALR',
@@ -52,36 +55,37 @@ export const OPCODE_NAMES = {
 };
 
 /**
- * What an unused slot is actually reserved for.
+ * What a slot with no standard 32-bit class is set aside for.
  *
- * The nine free slots are the most interesting part of the map and they are not
+ * These nine are the most interesting part of the map and they are not
  * interchangeable. Drawn as one undifferentiated grey they read as spare
- * capacity, which three quarters of them are not.
+ * capacity, which none of them is.
  *
- * OP-P is the one that needs sourcing rather than assertion: the slot is
- * allocated to the packed-SIMD extension, and P is unratified, which is why we
- * carry no instructions for it. riscv-opcodes files it under
- * extensions/unratified/rv_p. So the slot is spoken for, not free.
+ * This is architectural allocation, fixed by the specification, and it is a
+ * different question from whether our dataset happens to carry instructions for
+ * a slot. Conflating the two produced a real error: an earlier version labelled
+ * 0x5b "OP-P, unratified" on the strength of the name in the table alone. That
+ * was wrong twice over. The manual assigns 0x5b to custom-2, one of four custom
+ * opcodes, and P does not use the slot at all: riscv-opcodes encodes rv_p under
+ * OP-IMM, OP-IMM-32 and OP-32 (0x13, 0x1b, 0x3b).
  */
 export const FREE_SLOT_KINDS = {
   vendor:
-    'Vendor custom space. Reserved for non-standard extensions and never allocated by RISC-V International.',
+    'Custom space. The specification sets all four custom opcodes aside for non-standard extensions, and undertakes that future standard extensions will avoid them.',
   reserved: 'Reserved by the specification. Not available for use.',
   wide: 'Reserved for instructions longer than 32 bits, which this map does not cover.',
-  unratified:
-    'Allocated to an extension that is not ratified, so the catalogue carries no instructions for it.',
 };
 
 const FREE_SLOT_CATEGORIES = {
   0x0b: 'vendor', // custom-0
   0x2b: 'vendor', // custom-1
+  0x5b: 'vendor', // custom-2
   0x7b: 'vendor', // custom-3
   0x6b: 'reserved',
   0x1f: 'wide', // 48b
   0x3f: 'wide', // 64b
   0x5f: 'wide', // 48b
   0x7f: 'wide', // 80b+
-  0x5b: 'unratified', // OP-P
 };
 
 /**

--- a/tests/encoding-map.test.mjs
+++ b/tests/encoding-map.test.mjs
@@ -163,14 +163,35 @@ test('every free slot says what it is reserved for', () => {
   );
 });
 
-test('OP-P is free because P is unratified, not because it is spare', () => {
-  // Worth naming: the slot is allocated to packed SIMD, and riscv-opcodes files
-  // rv_p under extensions/unratified/. Calling it vendor space or reserved
-  // would misrepresent why the catalogue has nothing for it.
-  const opP = map.cells.find((c) => c.name === 'OP-P');
-  assert.ok(opP, 'OP-P is missing from the map');
-  assert.equal(opP.count, 0);
-  assert.equal(opP.category, 'unratified');
+test('there are four custom opcodes, and 0x5b is one of them', () => {
+  // This encodes a correction. An earlier version named 0x5b "OP-P" and filed
+  // it as an unratified allocation, which was wrong twice over: the manual
+  // assigns 0x5b to custom-2, and P does not use the slot at all, encoding
+  // under OP-IMM, OP-IMM-32 and OP-32 (0x13, 0x1b, 0x3b) in riscv-opcodes. The
+  // mistake came from treating a name in our own table as a source, so the fix
+  // is pinned rather than merely applied.
+  const byOpcode = new Map(map.cells.map((c) => [c.opcode, c]));
+  for (const [i, opcode] of [0x0b, 0x2b, 0x5b, 0x7b].entries()) {
+    const cell = byOpcode.get(opcode);
+    assert.equal(cell.name, `custom-${i}`, `0x${opcode.toString(16)} should be custom-${i}`);
+    assert.equal(cell.category, 'vendor', `custom-${i} is custom space`);
+  }
+  assert.equal(map.totals.freeByKind.vendor, 4, 'all four custom opcodes counted');
+  assert.equal(map.cells.find((c) => c.name === 'OP-P'), undefined, 'nothing should claim to be OP-P');
+});
+
+test('the free-slot taxonomy describes the specification, not our dataset', () => {
+  // Whether we hold instructions for a slot is a fact about this catalogue;
+  // what the slot is set aside for is a fact about the specification. Only the
+  // second belongs in a category, which is why "unratified" is not one.
+  assert.deepEqual(
+    Object.keys(FREE_SLOT_KINDS).sort(), ['reserved', 'vendor', 'wide'],
+    'categories cover specification allocation only',
+  );
+  assert.deepEqual(
+    map.totals.freeByKind, { vendor: 4, wide: 4, reserved: 1 },
+    'four custom, four longer-than-32-bit, one reserved',
+  );
 });
 
 test('the bar measures share of the whole, not share of the busiest slot', () => {


### PR DESCRIPTION
Acting on review feedback for #186 and #187. Both points were right.

## 0x5b is custom-2, not OP-P

The specification assigns **four** custom opcodes, `0x0b`/`0x2b`/`0x5b`/`0x7b`, and sets all four aside for non-standard extensions with an undertaking that future standard extensions will avoid them. The map showed three.

My `OP-P, unratified` label was wrong on both halves, and I defended it in #186 as "sourced, not assumed". What I actually checked was that riscv-opcodes files `rv_p` under `extensions/unratified/`. I never checked which opcode P uses. **It does not use 0x5b at all:**

```
$ grep -oE "6\.\.0=[0-9a-fx]+" extensions/unratified/rv_p | sort -u
6..0=0x13   OP-IMM
6..0=0x1b   OP-IMM-32
6..0=0x3b   OP-32
```

The name came from our own `OPCODE_NAMES` table and I read it back as though it were evidence.

`unratified` is gone as a category. Whether we hold instructions for a slot is a fact about this catalogue; what the slot is set aside for is a fact about the specification. Only the second belongs in a taxonomy of allocation, and mixing them is what produced the error.

## The counts were making an architectural claim they cannot support

`1149`, `69` and OP-V's `349` are not properties of the ISA encoding map. They are counts of definitions in whatever set of riscv-opcodes files we carry, and one definition can constrain a handful of encodings or a large region of a slot. "30.4% of all 32-bit instructions" implied something about encoding space.

| was | now |
|---|---|
| `23/32 opcode slots used` | `23/32 major opcodes assigned to standard 32-bit classes` |
| `1149 32-bit` | `1149 32-bit definitions` |
| `69 compressed` | `69 with inst[1:0]≠11` |
| "slot's share of all 1149 32-bit instructions" | "share of the instruction definitions we carry, not a measure of how much encoding space it consumes" |

A footnote now names and links the dataset, so the numbers cannot be read as architectural.

## "Compressed" was the wrong word

The quadrant strip conflated the C extension with the length encoding. `inst[1:0]!=11` means "not 32 bits", which is a wider statement once Zc\* and other 16-bit encodings are in the set. It reads **"Definitions outside the 32-bit map"** with the bit pattern on each chip.

## Left alone deliberately

`OP-VE` at `0x77` is correct, the ratified vector-crypto opcode. Our catalogue places Zvkg, Zvkn, Zvkned, Zvknha, Zvknhb and Zvks there, which agrees. `0x6b` reserved and `custom-3` at `0x7b` were already right.

## Verification

- **140 tests**, up from 139. New ones pin all four custom opcodes by number *and* name, that nothing claims to be `OP-P`, that the category set covers specification allocation only, and that the free-slot tally is 4 custom / 4 wider-than-32-bit / 1 reserved.
- Contrast re-audited: **0 failures across 122 elements in both themes**.
- In-browser: all four `custom-*` cells render, no `OP-P` anywhere in the dialog.