### PR TITLE
fix: stop showing the sync-internal tags key as an extension attribute

### DIFF
--- a/src/compareModel.js
+++ b/src/compareModel.js
@@ -88,7 +88,14 @@ const EXTENSION_FIELDS = [
     get: (e) => orNull(e.ratification_date),
   },
   { key: 'type', label: 'Type', render: 'text', get: (e) => orNull(e.type) },
-  { key: 'tags', label: 'Tags', render: 'chips', get: (e) => listOrNull(e.tags) },
+  // No Tags row. `tags` is a sync-internal routing key — it names which
+  // riscv-opcodes tag an entry's instructions are pulled from, not a property
+  // of the extension — and reading it as an attribute is misleading. RV64E and
+  // RV128I both carry `rv64_i` because upstream has no rv64_e or rv128 tag to
+  // route from, so a comparison showed two different base ISAs with identical
+  // tags belonging to neither. marchUtils.js:591 already special-cases those
+  // same base tags at runtime for the same reason. The field stays because the
+  // sync needs it; it just has no business on screen.
   { key: 'use', label: 'Use', render: 'text', get: (e) => orNull(e.use) },
   {
     key: 'instruction_count',

--- a/tests/compare-model.test.mjs
+++ b/tests/compare-model.test.mjs
@@ -57,10 +57,25 @@ test('absent normalizes to null and stays distinct from empty', () => {
   assert.notEqual(normalizeCell(''), null);
 });
 
-test('arrays compare as sets, because tag order is not meaningful', () => {
+test('arrays compare as sets, because list order is not meaningful', () => {
   assert.equal(normalizeCell(['bit', 'addr']), normalizeCell(['addr', 'bit']));
   assert.equal(cellsAllSame([['bit', 'addr'], ['addr', 'bit']]), true);
   assert.equal(cellsAllSame([['bit'], ['addr']]), false);
+});
+
+test('the sync-internal tags field is never shown as an attribute', () => {
+  // `tags` routes riscv-opcodes instructions onto entries; it is not a property
+  // of the extension. RV64E and RV128I both carry `rv64_i`, so displaying it
+  // showed two different base ISAs with identical tags belonging to neither.
+  const model = buildExtensionComparison([byId('RV64E'), byId('RV128I')]);
+  assert.deepEqual(
+    model.rows.filter((r) => /tag/i.test(r.key) || /tag/i.test(r.label)),
+    [],
+    'the comparison must not surface the tags routing key',
+  );
+
+  // Both entries do still carry the field, for the sync.
+  assert.ok(byId('RV64E').tags.includes('rv64_i'));
 });
 
 test('a single column always agrees with itself', () => {


### PR DESCRIPTION
Comparing `RV64E` against `RV128I` showed both carrying the identical tags `rv64_i, rv_i` — tags that describe neither of them.

## Why

`tags` is not a property of an extension. It is the routing key `scripts/sync_instructions.mjs` uses to decide which riscv-opcodes tag an entry's instructions are pulled from.

Upstream has no `rv64_e` and no `rv128` tag — E reuses I's encodings, and RV128 is not modelled in riscv-opcodes at all. Across all 119 tags in `instr_dict.json`, the entire I family is `rv_i` and `rv64_i`. So both entries route through `rv64_i` to get any instructions at all, and the tag records *where the data came from*, not what the extension is.

`src/marchUtils.js:591` already special-cases these same base-ISA tags at runtime:

```js
// Base ISA tags belong to whichever base ISA the user actually selected
if (['rv_i', 'rv64_i', 'rv32_e', 'rv64_e'].includes(t)) {
```

It has to ask which base the user selected, because the tag cannot say. Same defect, patched in a different layer.

## What changes

The Tags row comes out of the comparison view. The field stays — the sync needs it.

Nothing else displayed it: the search index is built from `id`, `name`, `desc`, `use` and mnemonics, and the detail panel never showed it. The comparison view was the only surface, and putting it there was a mistake in #191.

## Related, not fixed here

While tracing this I confirmed `RV128I` carries **RV64I's 52 instructions verbatim**, each stamped `extension: ["rv64_i"]`, and defines no `LQ`/`SQ`/`LDU`. That is a data problem rather than a display one, and it needs a decision about what RV128I should show when no upstream source defines it.

Worth noting for #8 and #107: riscv-unified-db's instruction YAMLs declare `definedBy.extension.name` — the catalogue's own ID namespace — so sourcing instructions from UDB removes the tag-mapping problem rather than improving the mapping.

## Testing

`npm test` — **206 passing**. A new test asserts the comparison never surfaces a tags row, and that the field is still present on the records for the sync.