### PR TITLE
fix: make the comparison dialog usable on a phone

### DIFF
--- a/src/CompareView.jsx
+++ b/src/CompareView.jsx
@@ -41,17 +41,11 @@ function Cell({ row, value, bitDiff }) {
         ? 'var(--riscv-success)'
         : 'var(--riscv-danger)';
     return value ? (
-      <span
-        aria-label="present"
-        style={{ color: tone, fontWeight: row.allSame ? 400 : 700 }}
-      >
+      <span aria-label="present" style={{ color: tone, fontWeight: row.allSame ? 400 : 700 }}>
         &#10003;
       </span>
     ) : (
-      <span
-        aria-label="absent"
-        style={{ color: tone, fontWeight: row.allSame ? 400 : 700 }}
-      >
+      <span aria-label="absent" style={{ color: tone, fontWeight: row.allSame ? 400 : 700 }}>
         &mdash;
       </span>
     );
@@ -169,17 +163,17 @@ export default function CompareView({
           style={{ boxShadow: '0 0 60px rgba(0,0,0,0.8), 0 0 0 1px rgba(245,197,66,0.12)' }}
         >
           <div
-            className="flex items-center justify-between gap-3 px-4 py-3"
+            className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 px-4 py-3"
             style={{ borderBottom: '1px solid var(--riscv-border-2)' }}
           >
             <h2
               id="compare-view-title"
-              className="text-[13px] font-bold uppercase tracking-wider inline-flex items-center gap-2"
+              className="text-[13px] font-bold uppercase tracking-wider inline-flex items-center gap-2 min-w-0"
               style={{ color: 'var(--riscv-gold)' }}
             >
               <Columns size={14} /> {heading}
               <span
-                className="font-mono normal-case tracking-normal text-[11px]"
+                className="font-mono normal-case tracking-normal text-[11px] hidden sm:inline"
                 style={{ color: 'var(--riscv-text-3)' }}
               >
                 {differing} of {model.rows.length}{' '}
@@ -191,7 +185,7 @@ export default function CompareView({
               </span>
             </h2>
 
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2 ml-auto">
               <label
                 className="inline-flex items-center gap-1.5 text-[11px]"
                 style={{ color: 'var(--riscv-text-2)' }}


### PR DESCRIPTION
At 390px the comparison dialog's header controls were pushed past its right edge and clipped by its own `overflow-hidden`. **Markdown**, **Link** and — the part that matters — **Close** were all off-screen.

Opening a shared `?cmp=` link on a phone trapped the reader: no visible close button, no Escape key on a touch device, and the backdrop reduced to the 3px margin around a dialog that fills the screen.

## Cause

The header was one `flex items-center justify-between` row. On a narrow viewport the title plus the control group exceed the dialog width, and without wrapping the controls simply overflow — straight into the dialog's own `overflow-hidden`.

## Fix

The header wraps. The title takes the first line and the controls flow onto the next; the title may shrink rather than winning the row outright; and the "N of M attributes differ" count is hidden below `sm`, where it was wrapping across three lines and pushing everything else out.

## Verified under device emulation

390×844, `mobile,touch`, DPR 3 — a real viewport override, not a resized window:

| | Before | After |
|---|---|---|
| Header controls reachable | 1 of 4 | **4 of 4** |
| Close button | off-screen | x=309, 24px square, tappable |
| Bit diff still marks bit 25 | ✓ | ✓ |

The rest of the mobile surface checked out and needed no changes: no horizontal page scroll at 390px, zero elements clipped beyond the `overflow-x-hidden` root, the detail panel behaves as its designed bottom sheet (fixed, 75vh, z-50), and all 32 encoding bits fit without scrolling — 330px available, 32 cells at 10.3px, so the row's 288px floor never engages.

`npm test` — 208 passing.