### PR TITLE
fix: label the E bases ratified, and stop the status badge naming a source it cannot vouch for

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -3122,9 +3122,18 @@ const RISCVExplorer = () => {
                               ? state.charAt(0).toUpperCase() + state.slice(1)
                               : 'Status unconfirmed';
                           const tip = ratified
-                            ? 'Ratified per riscv-unified-db'
+                            ? // Deliberately does not name a source. Most states
+                              // are synced from riscv-unified-db, but not all:
+                              // UDB has no E extension and no RV128, so RV32E,
+                              // RV64E and RV128I carry states set here against
+                              // the specification itself. Crediting UDB for
+                              // those would be a false claim about provenance —
+                              // the same mistake as RV128I inheriting I's
+                              // ratification. The linked chapter is the source
+                              // a reader can actually check.
+                              'Ratified — see the linked specification chapter'
                             : state
-                              ? `riscv-unified-db reports this extension as ${state}`
+                              ? `Reported as ${state}; see the linked specification chapter`
                               : 'Neither riscv-unified-db nor riscv-opcodes describes this extension, so its status could not be confirmed';
                           return (
                             <span

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -1756,7 +1756,8 @@
           "mask": "0xfe00707f"
         }
       },
-      "url": "https://docs.riscv.org/reference/isa/unpriv/rv32e.html"
+      "url": "https://docs.riscv.org/reference/isa/unpriv/rv32e.html",
+      "state": "ratified"
     },
     {
       "id": "RV64E",
@@ -2446,7 +2447,8 @@
           "mask": "0x707f"
         }
       },
-      "url": "https://docs.riscv.org/reference/isa/unpriv/rv32e.html"
+      "url": "https://docs.riscv.org/reference/isa/unpriv/rv32e.html",
+      "state": "ratified"
     },
     {
       "id": "RV128I",

--- a/tests/catalog-coverage.test.mjs
+++ b/tests/catalog-coverage.test.mjs
@@ -255,6 +255,29 @@ test('the ratified base ISAs are labelled ratified', () => {
   }
 });
 
+test('the E bases are labelled ratified, locally', () => {
+  // These carry a state that no sync produced, and that is deliberate.
+  // riscv-unified-db has no E extension under any name and riscv-opcodes has no
+  // rv_e tag, so both syncs are silent and the entries fell through to the
+  // panel's "Status unconfirmed" badge — which was honest about the gap but
+  // understated what the specification says. The chapter is titled "RV32E and
+  // RV64E Base Integer Instruction Sets, Version 2.0" and sits in the ratified
+  // library, covering both bases in one place.
+  //
+  // No ratification_date: the chapter gives a version, not a date, and an
+  // invented one would be the RV128I mistake in a new costume.
+  const byId = new Map(entries.map((e) => [e.id, e]));
+  for (const id of ['RV32E', 'RV64E']) {
+    const entry = byId.get(id);
+    assert.ok(entry, `${id} is missing from the catalogue`);
+    assert.equal(entry.state, 'ratified', `${id} should be labelled ratified`);
+    assert.equal(entry.ratification_date, undefined, `${id} has no date we can source`);
+  }
+
+  // One chapter covers both, so sharing its URL is correct rather than sloppy.
+  assert.equal(byId.get('RV64E').url, byId.get('RV32E').url);
+});
+
 test('RV128I is not labelled ratified, because it is not', () => {
   // This test used to assert the opposite. RV128I inherited I's ratification
   // because it is aliased onto I, but that 2019-06 ratification covers RV32I


### PR DESCRIPTION
`RV32E` and `RV64E` displayed **"Status unconfirmed"**.

That was honest rather than broken — neither sync has anything to say about them. riscv-unified-db has **no E extension under any name**, and riscv-opcodes has **no `rv_e` tag** among its 119. With both silent, the field stayed empty and the badge admitted the gap instead of guessing.

But it understated what the specification says. The chapter is titled:

> **"RV32E and RV64E Base Integer Instruction Sets, Version 2.0"** — RISC-V **Ratified** Specifications Library

Version 2.0, in the ratified library, covering both bases in one place.

## What changes

Both are labelled `ratified`. **No `ratification_date`** — the chapter gives a version, not a date, and inventing one would be the RV128I mistake in a new costume.

`RV64E`'s `url` already pointed at `rv32e.html`, which turns out to be correct rather than sloppy: one chapter covers both.

## The badge was making a false claim

Its tooltip read **"Ratified per riscv-unified-db"** for every ratified entry. That is false for precisely the entries UDB does not model — `RV32E`, `RV64E` and `RV128I` all carry states set locally against the specification.

Crediting a database that never mentions them is the same species of error as RV128I inheriting `I`'s ratification. The tooltip now points at the linked chapter — a source the reader can actually check — rather than naming a provenance it cannot vouch for. The unconfirmed case is unchanged, since naming both syncs there is accurate: they genuinely are silent.

## Note on the pattern

Three entries now carry locally-set states, all base ISAs that the catalogue models and no upstream does: `RV32E`, `RV64E` (ratified) and `RV128I` (draft). A test records why each is local, so a future reader doesn't strip them as unsourced.

That is the same gap #8 and #107 circle from the tag side, and the reason a UDB-only migration would still need a local rule for base ISAs — UDB has one `I.yaml` against this catalogue's five base entries.

## Testing

`npm test` — **209 passing**. Verified in the browser that `RV32E` now reads `Ratified` with no dangling date, and that a genuinely UDB-sourced entry (`Zba`) still reads `Ratified 2021-06`.