### PR TITLE
fix: correct Sv32's level count, Zvknhb's chapter link, and stale doc claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,12 @@ gaps to fill.
 ## Tests
 
 ```bash
-npm test        # 135 tests
+npm test        # 209 tests
 ```
 
-CI runs the tests, builds, then validates every generated `-march` string against
-clang. The suite covers dependency closure, graph integrity, profile
+CI runs the tests, builds, then validates the generated `-march` strings against
+clang. Rows needing a newer clang than the job provides are skipped and reported
+rather than failed, so the check is a floor rather than full coverage. The suite covers dependency closure, graph integrity, profile
 correctness, `riscv-config` conventions, export formats, documentation links, and
 a jsdom smoke test that fails if the page renders blank.
 

--- a/scripts/map-doc-links.mjs
+++ b/scripts/map-doc-links.mjs
@@ -56,6 +56,12 @@ const EXPLICIT = {
   F: 'unpriv/f-st-ext', M: 'unpriv/m-st-ext', Q: 'unpriv/q-st-ext', V: 'unpriv/v-st-ext',
   H: 'priv/hypervisor', S: 'priv/supervisor', U: 'priv/machine',
   RV32I: 'unpriv/rv32', RV64I: 'unpriv/rv64', RV32E: 'unpriv/rv32e', RV64E: 'unpriv/rv32e',
+
+  // Zvknhb is "Vector SHA-2 (full)" and lives in the vector-crypto chapter with
+  // the rest of the Zvk family. Its id appears nowhere in the text the word
+  // matcher scans, so without this it falls through to the colophon — which is
+  // where it had been sending readers.
+  Zvknhb: 'unpriv/vector-crypto',
 };
 
 /** Extensions whose home is a different ratified specification. */
@@ -64,6 +70,14 @@ const OTHER_SPECS = {
   Sdext: `${REF}/debug/index.html`,      Sdtrig: `${REF}/debug/index.html`,
   Sdtrigepm: `${REF}/debug/index.html`,  Sdtrigpend: `${REF}/debug/index.html`,
   Ssqosid: `${REF}/cbqri/index.html`,    RERI: `${REF}/ras-eri/index.html`,
+
+  // RV128 is not served by the unversioned snapshot at all — /isa/unpriv/rv128
+  // is a 404, as are rv128i, rv-128 and quad — while the dated v20240411 path
+  // resolves. It is an unfrozen draft ("We have not frozen the RV128 spec at
+  // this time"), so its presence in the manual moves between releases. Pinned
+  // here so the mapper stops proposing the colophon; tests/doc-links.test.mjs
+  // carries the matching exemption. Remove both if a later snapshot serves it.
+  RV128I: `${REF}/isa/v20240411/unpriv/rv128.html`,
 };
 
 const get = async (url) => {

--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -40,8 +40,9 @@
  *   Base / gc extensions (Zicsr, Zifencei, C, M, A, F, D, etc.):
  *     Universally stable across all modern RISC-V toolchains.
  *
- *   Live binary testing (compiling an empty file with each generated -march string)
- *   has NOT yet been implemented in CI. That is the remaining gap.
+ *   CI does compile-check the generated -march strings against clang. Rows that
+ *   need a newer clang than the job provides are skipped and reported, so the
+ *   check is a floor rather than full coverage — that is the remaining gap.
  */
 
 // ============================================================================

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -25343,7 +25343,7 @@
       ],
       "desc": "Vector SHA-2 (full)",
       "use": "Vector SHA-256/512",
-      "url": "https://docs.riscv.org/reference/isa/unpriv/colophon.html",
+      "url": "https://docs.riscv.org/reference/isa/unpriv/vector-crypto.html",
       "instructions": {
         "VSHA2CH.VV": {
           "encoding": "1011101----------010-----1110111",
@@ -27114,11 +27114,11 @@
       "use": "2-level page tables (RV32 Linux)",
       "url": "https://docs.riscv.org/reference/isa/priv/supervisor.html",
       "instructions": {},
-      "long_name": "32-bit virtual address translation (3 level)",
+      "long_name": "32-bit virtual address translation (2 level)",
       "type": "privileged",
       "state": "ratified",
       "ratification_date": "2019-05",
-      "behavior": "32-bit virtual address translation (3 level)"
+      "behavior": "32-bit virtual address translation (2 level)"
     },
     {
       "id": "Sv39",


### PR DESCRIPTION
Four findings from an audit, each confirmed before changing anything.

## Sv32 contradicted itself

`use` said "2-level page tables (RV32 Linux)" while `long_name` and `behavior` both said "32-bit virtual address translation (3 level)". Sv32 is the two-level mode — Sv39 is the three-level one — so `use` was right and the other two now match it.

## Zvknhb pointed at the colophon

It was the only entry still doing so. Zvknhb is "Vector SHA-2 (full)" and belongs in the vector-crypto chapter with the rest of the Zvk family, where `Zvkb`, `Zvkg`, `Zvkn`, `Zvknc` and `Zvkned` already point.

## The link mapper would have undone that

`links:check` proposed sending both `Zvknhb` and `RV128I` to the colophon. Neither id appears in the text its word matcher scans, so both fall through to the fallback — which is how Zvknhb got there, and which would have reverted the fix on the next run.

Both are pinned in the tables that already exist for this: `Zvknhb` to `unpriv/vector-crypto` in `EXPLICIT`, `RV128I` to its dated chapter in `OTHER_SPECS`, since the unversioned snapshot serves RV128 under no name. `tests/doc-links.test.mjs` already carries the matching exemption, and the two now cross-reference.

`npm run links:check` now reports no drift.

## Stale documentation

- README claimed 135 tests; there are 209.
- README said CI "validates every generated `-march` string against clang". The workflow skips rows needing a newer clang than the job provides and reports them — a floor, not full coverage.
- `src/marchUtils.js` said live binary testing "has NOT yet been implemented in CI", which stopped being true when that check landed.

## Checks

`npm test` 209 passing, `npm run lint` clean, `npm run build` clean, `npm run sync:check` clean, `npm run links:check` no drift.

Three further findings from the same audit need decisions rather than edits and are not in this PR.