### PR TITLE
chore: clear the last two lint warnings

### DIFF
--- a/src/WorkspacePanel.jsx
+++ b/src/WorkspacePanel.jsx
@@ -57,7 +57,6 @@ export default function WorkspacePanel({
   workspaceIds,
   lockedExtensions,
   allExts,
-  onAddId,
   onSetVlen,
   onRemoveId,
   onClear,

--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -411,7 +411,7 @@ export function parseMarchString(marchStr, allExts) {
  * @param {Array}    allExts
  * @returns {{ march: string|null, excluded: {id,reason}[], warnings: string[] }}
  */
-export function buildMarchString(selectedIds, allExts) {
+export function buildMarchString(selectedIds, _allExts) {
   const out = { march: null, excluded: [], warnings: [] };
 
   if (!selectedIds || selectedIds.length === 0) {

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -4151,7 +4151,6 @@ const RISCVExplorer = () => {
         workspaceIds={workspaceIds}
         lockedExtensions={lockedExtensions}
         allExts={allExtsList}
-        onAddId={(id) => addWorkspaceIdsSmart(id)}
         onSetVlen={handleSetVlen}
         onRemoveId={(id) =>
           setWorkspaceIds((prev) => {


### PR DESCRIPTION
`npm run lint` now reports nothing at all — 0 errors, 0 warnings.

## `buildMarchString`

Took an `allExts` parameter it never read. Prefixed `_allExts` to match the linter's convention for a deliberately unused argument. The parameter stays, because callers pass it positionally.

## `WorkspacePanel`'s `onAddId`

Removed outright rather than prefixed.

Prefixing the destructured key would have left the component reading a prop named `_onAddId` that nothing passes, while the parent went on supplying:

```js
onAddId={(id) => addWorkspaceIdsSmart(id)}
```

into nothing. That converts an unused prop into a *silently disconnected* one, which is worse — it reads like a feature that exists. Both sides are removed instead.

Nothing is orphaned by it: `addWorkspaceIdsSmart` still serves four other call sites, and the panel already adds in bulk via `onLoadIds`. If the workspace catalog should gain a per-row add action later, it can be wired deliberately.

## Verified

Driven in a real browser rather than assumed: builder mode on, extension added from a tile, panel opened, `-march` string rendered — all working, no console errors.

`npm test` 209 passing, `npm run build` clean.