### PR TITLE
fix: declare clang in the graph provenance, and point Zk at its chapter

### DIFF
--- a/scripts/map-doc-links.mjs
+++ b/scripts/map-doc-links.mjs
@@ -62,6 +62,14 @@ const EXPLICIT = {
   // matcher scans, so without this it falls through to the colophon — which is
   // where it had been sending readers.
   Zvknhb: 'unpriv/vector-crypto',
+
+  // Zk is the scalar-crypto umbrella — "shorthand for the following set of
+  // other extensions", per the chapter that defines it. Its whole family
+  // (Zkn, Zknd, Zkne, Zknh, Zkr, Zks, Zksed, Zksh, Zkt) already resolves to
+  // that chapter, but the two-letter id is below the matcher's length floor,
+  // so it fell through to the generic repo link despite being ratified and
+  // carrying 51 instructions.
+  Zk: 'unpriv/scalar-crypto',
 };
 
 /** Extensions whose home is a different ratified specification. */

--- a/scripts/seed-dependency-graph.mjs
+++ b/scripts/seed-dependency-graph.mjs
@@ -401,6 +401,15 @@ const graph = {
   sources: {
     udb: { repo: 'riscv/riscv-unified-db', commit, branch, path: 'spec/std/isa/ext' },
     'isa-manual': { repo: 'riscv/riscv-isa-manual', note: 'section cited per edge' },
+    // Edges carry src: 'clang' where neither UDB nor the manual states the
+    // relation outright and the toolchain's own implication is the backing —
+    // see LOCAL for Zvfh -> Zvfhmin. Declared here so a reader meeting that
+    // src on an edge can tell what it rests on, and that it is the weakest of
+    // the three.
+    clang: {
+      repo: 'llvm/llvm-project',
+      note: 'RISCVISAInfo implication, cited per edge; weaker backing than udb or isa-manual',
+    },
   },
   // Sorted so a regeneration produces a reviewable diff rather than a reshuffle.
   nodes: Object.fromEntries(

--- a/src/isa-dependency-graph.json
+++ b/src/isa-dependency-graph.json
@@ -11,6 +11,10 @@
     "isa-manual": {
       "repo": "riscv/riscv-isa-manual",
       "note": "section cited per edge"
+    },
+    "clang": {
+      "repo": "llvm/llvm-project",
+      "note": "RISCVISAInfo implication, cited per edge; weaker backing than udb or isa-manual"
     }
   },
   "nodes": {
@@ -288,7 +292,6 @@
     },
     "Sm": {
       "requires": [],
-      "catalogued": false,
       "verified": "udb"
     },
     "Sm1p11": {

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -23565,7 +23565,7 @@
       ],
       "desc": "Scalar Crypto Base",
       "use": "Top-level scalar crypto bundle",
-      "url": "https://github.com/riscv/riscv-isa-manual",
+      "url": "https://docs.riscv.org/reference/isa/unpriv/scalar-crypto.html",
       "instructions": {
         "PACKW": {
           "encoding": "0000100----------100-----0111011",

--- a/tests/isa-graph.test.mjs
+++ b/tests/isa-graph.test.mjs
@@ -51,6 +51,22 @@ const cite = (ext, ref = 'test fixture') => ({ ext, src: 'udb', ref });
 // The shipped graph
 // ---------------------------------------------------------------------------
 
+test('every edge source is declared in the graph provenance block', () => {
+  // An edge carrying src: "clang" while `sources` lists only udb and isa-manual
+  // leaves a reader unable to tell what that edge rests on — and the three do
+  // not carry equal weight. Whatever an edge cites, the block must explain.
+  const used = new Set();
+  for (const node of Object.values(DEPENDENCY_GRAPH.nodes ?? {})) {
+    for (const e of node.requires ?? []) if (e.src) used.add(e.src);
+    for (const e of node.conflicts ?? []) if (e.src) used.add(e.src);
+    for (const c of node.choices ?? []) for (const o of c.options ?? []) if (o?.src) used.add(o.src);
+  }
+  const declared = new Set(Object.keys(DEPENDENCY_GRAPH.sources ?? {}));
+  const undeclared = [...used].filter((s) => !declared.has(s)).sort();
+  assert.deepEqual(undeclared, [], 'edges cite sources the provenance block does not describe');
+  assert.ok(used.size > 0, 'expected at least one sourced edge');
+});
+
 test('shipped graph is structurally valid', () => {
   const { errors, stats } = validateGraph(DEPENDENCY_GRAPH);
   assert.deepEqual(errors, [], `graph has structural errors:\n  ${errors.join('\n  ')}`);


### PR DESCRIPTION
Two items from an audit re-evaluation.

## The graph cited a source it never declared

`sources` listed `udb` and `isa-manual`, while an edge carried `src: "clang"` — the `Zvfh -> Zvfhmin` implication, where neither UDB nor the manual states the relation outright and the toolchain's own behaviour is the backing.

A reader meeting that `src` had nothing to resolve it against, and the three do not carry equal weight. `clang` is declared now, noting explicitly that it is the weakest of the three:

```json
"clang": {
  "repo": "llvm/llvm-project",
  "note": "RISCVISAInfo implication, cited per edge; weaker backing than udb or isa-manual"
}
```

A test asserts every `src` appearing on any edge — `requires`, `conflicts`, or a choice option — is described in the block, so the two can't drift apart again.

## Zk pointed at the repo root

It was the **only** ratified, instruction-bearing entry still on the generic `riscv-isa-manual` link, despite carrying **51 instructions**. Its entire family already resolves to the scalar-crypto chapter — `Zkn`, `Zknd`, `Zkne`, `Zknh`, `Zkr`, `Zks`, `Zksed`, `Zksh`, `Zkt`.

The chapter defines it outright:

> "**Zk - Standard scalar cryptography extension.** This extension is shorthand for the following set of other extensions: Zkn (NIST Algorithm suite)…"

The reason it was missed is mechanical: the mapper skips ids shorter than three characters as too short to word-match safely, so `Zk` could never resolve and fell through to the fallback. Pinned in `EXPLICIT` the same way `Zvknhb` was. `links:check` reports no drift.

## One incidental correction

Regenerating the graph dropped `catalogued: false` from the `Sm` node. That flag marks nodes the graph knows about and the catalogue doesn't; #199 added `Sm`, so it was stale. It was the last one — **no node is flagged uncatalogued now**.

## Checks

`npm test` **212 passing** (1 new) · lint silent · `graph:check` no drift vs UDB main · `links:check` no drift.