### PR TITLE
chore: v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "riscv-extensions-landscape",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "riscv-extensions-landscape",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "lucide-react": "^0.294.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riscv-extensions-landscape",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "homepage": "https://riscv.github.io/riscv-extensions-landscape/",


### PR DESCRIPTION
Bumps `package.json` and the lockfile to `1.1.0` ahead of tagging the release.

Seventeen commits since `v1.0.0` — 30 files, +6,258/−1,258, and the test suite roughly doubled (100 → 212).

**Features**
- Encoding-space map (#184, #186, #187)
- Extension data synced from riscv-unified-db (#190)
- Side-by-side comparison of extensions, instructions and profiles (#191)

**Data corrections**, most settled against the ratified manuals: RV128I's borrowed ratification and instruction set (#193), the E bases' status (#195), `Sm` added so MRET and WFI are reachable (#199), Sv32's level count and Zvknhb's chapter link (#196), `0x5b` → custom-2 (#188), and `Zk` pointed at its own chapter (#200).

**Tooling**: weekly riscv-opcodes drift reporting (#185), branch-aware `graph:check` (#198), and a clean lint baseline (#197).