### PR TITLE
feat: test the synchronisation tooling

### DIFF
--- a/tests/sync-tooling.test.mjs
+++ b/tests/sync-tooling.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * The synchronisation tooling, exercised as processes.
+ *
+ * These scripts had no tests, which is uncomfortable given how much rides on
+ * them: they decide which upstream instructions attach to which extension, and
+ * a silent misroute there shows up much later as a catalogue that looks fine
+ * and is wrong. Two real examples reached production — RV128I displaying
+ * RV64I's 52 instructions because it was routed through the rv64_i tag, and
+ * MRET/WFI reachable from nowhere because no catalogue entry claimed them.
+ *
+ * They export nothing and run on load, so they are driven the way CI drives
+ * them rather than imported. That is the honest surface: it tests the thing
+ * that actually runs.
+ *
+ * Nothing here writes. The instruction sync is exercised through --dry-run, and
+ * one test asserts --dry-run really does leave the catalogue alone — a guard on
+ * the guard, since every other test in this file depends on it.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(here, '..');
+const CATALOG = path.join(root, 'src', 'riscv_extensions.json');
+
+const hashCatalog = () =>
+  createHash('sha256').update(fs.readFileSync(CATALOG)).digest('hex');
+
+/** Run a script, returning { status, stdout }. Never throws on a non-zero exit. */
+function run(script, args = []) {
+  try {
+    const stdout = execFileSync('node', [path.join(root, 'scripts', script), ...args], {
+      cwd: root,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { status: 0, stdout };
+  } catch (err) {
+    return { status: err.status ?? 1, stdout: `${err.stdout ?? ''}${err.stderr ?? ''}` };
+  }
+}
+
+test('the committed catalogue is what the instruction sync produces', () => {
+  // --strict fails when a mapped tag yields no instructions, so a clean exit
+  // means every routing rule still resolves against the current instr_dict.
+  // If someone hand-edits an extension's instructions, this is what notices.
+  const { status, stdout } = run('sync_instructions.mjs', ['--dry-run', '--strict']);
+  assert.equal(status, 0, `sync reported a problem:\n${stdout}`);
+  assert.match(stdout, /Instructions written:\s+\d+/, 'expected a summary line');
+});
+
+test('--dry-run does not touch the catalogue', () => {
+  // Everything else here leans on this being true.
+  const before = hashCatalog();
+  run('sync_instructions.mjs', ['--dry-run', '--strict']);
+  assert.equal(hashCatalog(), before, '--dry-run wrote to the catalogue');
+});
+
+test('the sync reports the instruction count it actually wrote', () => {
+  const { stdout } = run('sync_instructions.mjs', ['--dry-run']);
+  const reported = Number(stdout.match(/Instructions written:\s+(\d+)/)?.[1]);
+  const actual = Object.values(JSON.parse(fs.readFileSync(CATALOG, 'utf8')))
+    .flat()
+    .filter(Boolean)
+    .reduce((n, e) => n + Object.keys(e.instructions || {}).length, 0);
+  assert.equal(reported, actual, 'the summary disagrees with the catalogue it describes');
+});
+
+test('every routed tag resolves to a catalogue entry', () => {
+  // The reverse direction is deliberately not asserted. Upstream carries tags
+  // this catalogue has no entry for — vector dot/zip/fp8 proposals that appear
+  // zero times in the ratified manual — and their absence is correct, not a
+  // gap. What must hold is that nothing the catalogue claims to route from has
+  // gone away upstream.
+  const catalog = JSON.parse(fs.readFileSync(CATALOG, 'utf8'));
+  const dict = JSON.parse(fs.readFileSync(path.join(root, 'src', 'instr_dict.json'), 'utf8'));
+  const upstream = new Set();
+  for (const v of Object.values(dict)) for (const t of v.extension ?? []) upstream.add(t.toLowerCase());
+
+  const dangling = [];
+  for (const e of Object.values(catalog).flat().filter(Boolean)) {
+    for (const t of e.tags ?? []) {
+      if (!upstream.has(t.toLowerCase())) dangling.push(`${e.id} -> ${t}`);
+    }
+  }
+  assert.deepEqual(dangling, [], 'these entries route from tags upstream no longer defines');
+});
+
+test('the UDB sync fails loudly when pointed somewhere wrong', () => {
+  // It used to be possible for a sync to report an error and still exit 0,
+  // which lets a scheduled job look successful while having done nothing.
+  const { status, stdout } = run('sync_udb_extensions.cjs', ['/nonexistent-udb-path']);
+  assert.equal(status, 1, 'a missing UDB checkout must be a failure, not a warning');
+  assert.match(stdout, /not found/i, 'it should say what it could not find');
+});
+
+test('the graph seeder fails loudly when pointed somewhere wrong', () => {
+  const { status } = run('seed-dependency-graph.mjs', ['--check', '--udb', '/nonexistent-udb-path']);
+  assert.equal(status, 1, 'a missing UDB checkout must be a failure');
+});
+
+test('the graph matches upstream, when a UDB checkout is available', (t) => {
+  // Skipped rather than failed when UDB is absent: contributors are not
+  // required to clone it, and CI has its own step for this.
+  const udb = path.resolve(root, '..', 'riscv-unified-db');
+  if (!fs.existsSync(path.join(udb, 'spec', 'std', 'isa', 'ext'))) {
+    t.skip('no riscv-unified-db checkout beside this repo');
+    return;
+  }
+  const { status, stdout } = run('seed-dependency-graph.mjs', ['--check', '--udb', udb]);
+  // Drift against a non-trunk branch says more about the branch than about us,
+  // and the seeder now names the branch precisely so this stays diagnosable.
+  if (status !== 0 && /not main/i.test(stdout)) {
+    t.skip(`UDB checkout is on a feature branch:\n${stdout.split('\n').slice(-6).join('\n')}`);
+    return;
+  }
+  assert.equal(status, 0, stdout);
+});


### PR DESCRIPTION
Closes #113.

The sync scripts had no tests, which is uncomfortable given how much rides on them: they decide which upstream instructions attach to which extension, and a misroute surfaces much later as a catalogue that looks fine and is wrong.

Two such reached production and were fixed this cycle — RV128I showing RV64I's 52 instructions because it routed through the `rv64_i` tag (#193), and `MRET`/`WFI` reachable from nowhere because no entry claimed them (#199).

## Approach

Both scripts export nothing and run on load, so they're driven as **processes** rather than imported. That's the honest surface — it exercises what actually runs in CI, rather than a refactored shadow of it.

**Nothing writes.** The instruction sync runs under `--dry-run`, and one test asserts `--dry-run` really does leave the catalogue byte-identical — a guard on the guard, since every other test here depends on it.

## The seven

| Test | Catches |
|---|---|
| Committed catalogue is what the sync produces, in `--strict` | a hand-edited instruction list, or a routing rule that stopped resolving |
| Reported count matches the catalogue | a summary that lies about its own work |
| Every routed tag still exists upstream | an entry routing from a tag upstream dropped |
| UDB sync exits non-zero on a bad path | a scheduled job looking successful having done nothing |
| Graph seeder exits non-zero on a bad path | same |
| Graph matches upstream when UDB is present | real drift |
| `--dry-run` writes nothing | the assumption the rest depend on |

## One deliberate asymmetry

The tag test asserts every tag the catalogue routes *from* exists upstream, but **not** the reverse. Upstream carries tags this catalogue has no entry for — the vector dot/zip/fp8 proposals that appear zero times in the ratified manual — and their absence is correct, not a gap. Asserting the reverse would turn a correct state into a permanent failure.

## Skipping, not failing

The graph test skips when no UDB checkout sits beside the repo, since contributors aren't required to clone it. It **also** skips when the checkout is on a non-trunk branch, reporting why — drift against someone's feature branch says more about the branch than about this repo, which cost real investigation before `graph:check` learned to name the branch (#198).

`npm test` — **219 tests**, 218 passing, 1 skipped (UDB checkout on a feature branch). Lint silent.