### PR TITLE
feat: skip link, focus trapping, and the missing ARIA state

### DIFF
--- a/src/CompareView.jsx
+++ b/src/CompareView.jsx
@@ -13,6 +13,7 @@
 import React from 'react';
 import { X, Copy, Link2, Columns } from 'lucide-react';
 import { toMarkdown } from './compareModel.js';
+import { focusableWithin, nextFocus } from './focusTrap.js';
 import EncodingDiagram from './EncodingDiagram.jsx';
 
 function Cell({ row, value, bitDiff }) {
@@ -121,7 +122,22 @@ export default function CompareView({
     restoreFocusRef.current = document.activeElement;
     dialogRef.current?.focus();
     const onKey = (e) => {
-      if (e.key === 'Escape') onCloseRef.current();
+      if (e.key === 'Escape') {
+        onCloseRef.current();
+        return;
+      }
+      // Hold Tab inside the dialog. Without this it walks out into the page
+      // behind the backdrop, which is still focusable and now invisible.
+      if (e.key !== 'Tab') return;
+      const target = nextFocus(
+        focusableWithin(dialogRef.current),
+        document.activeElement,
+        e.shiftKey,
+      );
+      if (target) {
+        e.preventDefault();
+        target.focus();
+      }
     };
     window.addEventListener('keydown', onKey);
     return () => {

--- a/src/focusTrap.js
+++ b/src/focusTrap.js
@@ -1,0 +1,64 @@
+/**
+ * focusTrap.js — which element Tab should reach next inside a modal.
+ *
+ * A dialog that takes focus but does not hold it is barely better than one that
+ * does neither: Tab walks out of the modal and into the page behind it, which
+ * is still there, still focusable, and now invisible behind a backdrop. The
+ * keyboard user is editing a page they cannot see.
+ *
+ * Pure logic in a .js file rather than .jsx for the same reason tileMemo.js is:
+ * node's test runner cannot import .jsx, and the wrap-around arithmetic is
+ * exactly the part worth testing.
+ */
+
+/** Elements that can hold focus, in DOM order. Disabled and hidden ones cannot. */
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+/**
+ * @param {Element} container
+ * @returns {Element[]} focusable descendants, skipping anything not rendered
+ */
+export function focusableWithin(container) {
+  if (!container || typeof container.querySelectorAll !== 'function') return [];
+  return [...container.querySelectorAll(FOCUSABLE)].filter((el) => {
+    // offsetParent is null for display:none. A zero-size box is also
+    // unreachable in practice — the compare tray's hidden tabs, for instance.
+    if (el.hasAttribute('aria-hidden')) return false;
+    const r = typeof el.getBoundingClientRect === 'function' ? el.getBoundingClientRect() : null;
+    return !r || r.width > 0 || r.height > 0;
+  });
+}
+
+/**
+ * The element Tab should land on, or null to let the browser handle it.
+ *
+ * Returns a target only at the ends of the list, where the browser would
+ * otherwise leave the dialog. Everywhere else it returns null so normal tab
+ * order applies — intercepting every Tab would mean reimplementing the
+ * browser's own traversal, which is not worth owning.
+ *
+ * @param {Element[]} items    focusable elements, in order
+ * @param {Element}   active   currently focused element
+ * @param {boolean}   backwards true for Shift+Tab
+ */
+export function nextFocus(items, active, backwards) {
+  if (!items || items.length === 0) return null;
+  const first = items[0];
+  const last = items[items.length - 1];
+  const index = items.indexOf(active);
+
+  // Focus is on the dialog container itself, or somewhere outside the trap:
+  // pull it to whichever end the user is heading for.
+  if (index === -1) return backwards ? last : first;
+
+  if (backwards && active === first) return last;
+  if (!backwards && active === last) return first;
+  return null;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1404,3 +1404,39 @@ pre,
     transform: none;
   }
 }
+
+/* Skip link. Off-screen until focused, then pinned to the top-left — the
+   standard pattern, and the only affordance here aimed squarely at someone who
+   never touches a mouse. Without it the header's filters and four action
+   controls sit between the tab order and the 227 tiles, on every load. */
+.riscv-skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  z-index: 100;
+  padding: 10px 16px;
+  border-radius: 0 0 8px 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--riscv-bg);
+  background: var(--riscv-gold);
+  text-decoration: none;
+}
+.riscv-skip-link:focus {
+  left: 0;
+  outline: 2px solid var(--riscv-text);
+  outline-offset: 2px;
+}
+
+/* Visually hidden, still announced. For meaning carried only by colour. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1715,6 +1715,14 @@ const RISCVExplorer = () => {
       className="min-h-screen relative overflow-x-hidden"
       style={{ background: 'var(--riscv-bg)', color: 'var(--riscv-text)' }}
     >
+      {/* Skip link. First thing in the tab order, visible only once focused.
+          Without it a keyboard user pays for the whole header — filters, four
+          action controls, the search field — on every page load before reaching
+          the 227 tiles they came for. */}
+      <a href="#extension-grid" className="riscv-skip-link">
+        Skip to the extension grid
+      </a>
+
       {/* Gradient top border */}
       <div className="riscv-top-border" />
       <div className="px-3 md:px-6 py-4 md:py-6 max-w-[1700px] mx-auto">
@@ -1843,6 +1851,7 @@ const RISCVExplorer = () => {
                                   return current === profile ? null : profile;
                                 })
                               }
+                              aria-pressed={activeProfile === profile}
                               className={[
                                 'px-3 py-1.5 text-[12px] rounded-lg transition-all duration-200 font-medium',
                                 activeProfile === profile
@@ -1900,6 +1909,7 @@ const RISCVExplorer = () => {
                                 return current === vol ? null : vol;
                               })
                             }
+                            aria-pressed={activeVolume === vol}
                             className={[
                               'px-3 py-1.5 text-[12px] rounded-lg transition-all duration-200 font-medium',
                               activeVolume === vol
@@ -2468,7 +2478,13 @@ const RISCVExplorer = () => {
             </div>
           </div>
           {/* ─── Main Grid ───────────────────────────────────────────────── */}
-          <div className="lg:col-span-8 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 auto-rows-min">
+          <div
+            id="extension-grid"
+            tabIndex={-1}
+            role="region"
+            aria-label="Extension catalogue"
+            className="lg:col-span-8 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 auto-rows-min"
+          >
             {/* Search Bar */}
             <div className="col-span-full mb-2 flex items-center gap-3">
               <div className="relative flex-1">
@@ -2479,7 +2495,8 @@ const RISCVExplorer = () => {
                 />
                 <input
                   ref={searchInputRef}
-                  type="text"
+                  type="search"
+                  aria-label="Search extensions, instructions and encodings"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   placeholder="Search extensions, instructions, encodings…"
@@ -3039,6 +3056,9 @@ const RISCVExplorer = () => {
           {/* ─── Sidebar ─────────────────────────────────────────────────── */}
           <div
             id="detail-panel"
+            role="region"
+            aria-label="Selected extension details"
+            aria-live="polite"
             className={`lg:col-span-4 mt-6 lg:mt-0 ${selectedExt ? 'panel-open' : ''}`}
           >
             <div

--- a/tests/focus-trap.test.mjs
+++ b/tests/focus-trap.test.mjs
@@ -1,0 +1,54 @@
+/**
+ * The modal focus trap.
+ *
+ * A dialog that takes focus but does not hold it is barely better than one that
+ * does neither: Tab walks out into the page behind the backdrop, which is still
+ * focusable and now invisible. These assert the wrap-around arithmetic, which is
+ * where that goes wrong.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { nextFocus, focusableWithin } from '../src/focusTrap.js';
+
+const items = ['a', 'b', 'c'];
+
+test('Tab from the last element wraps to the first', () => {
+  assert.equal(nextFocus(items, 'c', false), 'a');
+});
+
+test('Shift+Tab from the first element wraps to the last', () => {
+  assert.equal(nextFocus(items, 'a', true), 'c');
+});
+
+test('Tab in the middle is left to the browser', () => {
+  // Intercepting every Tab would mean reimplementing the browser's own
+  // traversal. Only the ends need holding.
+  assert.equal(nextFocus(items, 'a', false), null);
+  assert.equal(nextFocus(items, 'b', false), null);
+  assert.equal(nextFocus(items, 'b', true), null);
+});
+
+test('focus outside the trap is pulled to the end the user is heading for', () => {
+  // This is the case on open, when focus sits on the dialog container itself
+  // and so is not in the list.
+  assert.equal(nextFocus(items, 'not-in-list', false), 'a');
+  assert.equal(nextFocus(items, 'not-in-list', true), 'c');
+});
+
+test('a dialog with one focusable element keeps focus on it', () => {
+  assert.equal(nextFocus(['only'], 'only', false), 'only');
+  assert.equal(nextFocus(['only'], 'only', true), 'only');
+});
+
+test('an empty dialog does not throw or claim a target', () => {
+  assert.equal(nextFocus([], 'x', false), null);
+  assert.equal(nextFocus(null, 'x', false), null);
+  assert.equal(nextFocus(undefined, undefined, true), null);
+});
+
+test('focusableWithin tolerates being handed nothing', () => {
+  // It runs against a ref that may be null on the first pass.
+  assert.deepEqual(focusableWithin(null), []);
+  assert.deepEqual(focusableWithin(undefined), []);
+  assert.deepEqual(focusableWithin({}), []);
+});


### PR DESCRIPTION
Addresses #20.

## What was already done

Four of the nine items had landed since the issue was filed in April, so I audited before building:

- Extension tiles are `role="button"` with `tabIndex` and `onKeyDown`
- Three dialogs carry `role="dialog"`, `aria-modal` and `aria-labelledby`, with Escape-to-close and focus restore
- Encoding bit cells have labels (native `title`, since a `::after` tooltip is clipped by the dialogs' `overflow-hidden`)
- Colour is not load-bearing in the comparison view — ✓ and — carry the same information as green and red

## The five that hadn't

**A keyboard user paid for the whole header on every load.** The filters and four action controls sit between the tab order and the 227 tiles they came for, with no way past. There's a skip link now — first in the tab order, visible only once focused — pointing at the grid, which gains an `id` and an accessible name so it's a landmark worth skipping to.

**The comparison dialog took focus but didn't hold it.** Tab walked out into the page behind the backdrop, which is still focusable and now invisible — the reader ends up editing a page they can't see. Tab and Shift+Tab now wrap at the ends.

The wrap-around arithmetic lives in `src/focusTrap.js` with **7 tests**, because that's the part that goes wrong. The middle of the range deliberately returns `null` and lets the browser handle it — intercepting every Tab would mean reimplementing the browser's own traversal, which isn't worth owning.

**The search field had no accessible name.** A placeholder is not a label: it disappears on focus and isn't reliably announced. Now a labelled `type="search"`.

**The profile and volume filters are toggles whose only state cue was colour.** They carry `aria-pressed` now.

**The detail panel replaced its contents silently.** It's a named region with `aria-live="polite"`, so a selection made in the grid reaches someone not watching that corner.

## Verified in a browser, not just asserted

| | |
|---|---|
| Skip link | first tab stop; moves `-9999px` → `0` on focus; target exists |
| Focus trap | Tab from last element and Shift+Tab from first both stay inside (6 focusable) |
| `aria-pressed` | `RVA23` flips `false → true → false` on click |
| Search | `type="search"`, `aria-label` present |
| Detail panel | `role="region"`, `aria-live="polite"`, labelled |

`npm test` — **226 tests**, 225 passing, 1 skipped (UDB checkout on a feature branch). Lint silent.

## Not claiming WCAG conformance

This closes the specific gaps #20 lists. A full audit would still want testing with a real screen reader, a look at focus visibility across every control, and the encoder-validator and workspace dialogs given the same trap treatment — the helper is now there to reuse.