### PR TITLE
fix: attribute SCTRCLR to Smctr as well as Ssctr

### DIFF
--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -193,6 +193,23 @@ for (const entry of extEntries) {
   }
 }
 
+// Pass 1c: Shared ownership of SCTRCLR (priv ISA, Control Transfer Records)
+// riscv-unified-db declares `definedBy: {anyOf: [Smctr, Ssctr]}` — both extensions
+// define the instruction. A riscv-opcodes tag names exactly one owner, so rv_ssctr
+// routes SCTRCLR to Ssctr alone and Smctr, which has no tag of its own, renders
+// empty. Copied from the Ssctr entry rather than restated so the two cannot drift.
+const SCTRCLR_SHARED_OWNERS = new Set(['Smctr']);
+const sctrclrSource = extMap.get('Ssctr')?.instructions?.SCTRCLR;
+assert(!!sctrclrSource, 'Ssctr must supply SCTRCLR before it can be shared with Smctr');
+
+if (sctrclrSource) {
+  for (const entry of extEntries) {
+    if (!SCTRCLR_SHARED_OWNERS.has(entry.id)) continue;
+    assert(!('SCTRCLR' in entry.instructions), `Upstream instr_dict now provides SCTRCLR for ${entry.id}. Remove this injection.`);
+    entry.instructions.SCTRCLR = JSON.parse(JSON.stringify(sctrclrSource));
+  }
+}
+
 // Pass 2: Umbrella Topological Resolution
 const umbrellaEntries = extEntries.filter(e => e.members?.length > 0);
 const MAX_UMBRELLA_PASSES = 10;
@@ -279,6 +296,8 @@ assertExtension('Zalrsc', { mustInclude: ['LR.W', 'SC.W', 'LR.D', 'SC.D'] });
 assertExtension('Zmmul', { mustInclude: ['MUL'], mustExclude: ['DIV', 'DIVU', 'REM', 'REMU', 'DIVW', 'DIVUW', 'REMW', 'REMUW'] });
 assertExtension('Zicbom', { mustExclude: ['CBO.ZERO'] });
 assertExtension('Zicboz', { mustInclude: ['CBO.ZERO'], mustExclude: ['CBO.CLEAN'] });
+assertExtension('Smctr', { mustInclude: ['SCTRCLR'] });
+assertExtension('Ssctr', { mustInclude: ['SCTRCLR'] });
 
 const rv32iExt = extMap.get('RV32I');
 assert(!!rv32iExt, 'RV32I extension entry must exist in catalog');
@@ -375,7 +394,10 @@ if (dryRun) {
   fs.renameSync(tmpPath, catalogPath);
 }
 
-const totalPopulated = tagsPopulated + splitRulePopulated + umbrellaPopulated;
+// Counted from the catalog itself, not by summing the pass counters: injection
+// passes populate entries no pass counter owns, so the sum understates coverage.
+const totalPopulated = extEntries.filter(e => Object.keys(e.instructions ?? {}).length > 0).length;
+const injected = totalPopulated - (tagsPopulated + splitRulePopulated + umbrellaPopulated);
 const emptyExts = totalExts - totalPopulated;
 const coverage = ((totalPopulated / totalExts) * 100).toFixed(1);
 
@@ -386,6 +408,7 @@ console.log(`  Total extensions:        ${totalExts}`);
 console.log(`  Populated via tags:      ${tagsPopulated}`);
 console.log(`  Populated via split:     ${splitRulePopulated}`);
 console.log(`  Populated via umbrella:  ${umbrellaPopulated}`);
+console.log(`  Populated via injection: ${injected}`);
 console.log(`  Still empty:             ${emptyExts}`);
 console.log(`  Coverage:                ${totalPopulated} / ${totalExts} (${coverage}%)`);
 console.log(`  Instructions written:    ${instructionsWritten}\n`);

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -29452,7 +29452,17 @@
       "desc": "Control Transfer Records (M)",
       "use": "Hardware CFI logs (M)",
       "url": "https://docs.riscv.org/reference/isa/priv/smctr.html",
-      "instructions": {},
+      "instructions": {
+        "SCTRCLR": {
+          "encoding": "00010000010000000000000001110011",
+          "variable_fields": [],
+          "extension": [
+            "rv_ssctr"
+          ],
+          "match": "0x10400073",
+          "mask": "0xffffffff"
+        }
+      },
       "long_name": "Control Transfer Records",
       "type": "privileged",
       "state": "ratified",

--- a/tests/catalog-coverage.test.mjs
+++ b/tests/catalog-coverage.test.mjs
@@ -340,3 +340,28 @@ test('extension ids are unique', () => {
   }
   assert.deepEqual(dupes, [], `duplicate extension ids: ${dupes.join(', ')}`);
 });
+
+test('an instruction with two owners is attributed to both', () => {
+  // riscv-unified-db declares SCTRCLR as `definedBy: {anyOf: [Smctr, Ssctr]}`.
+  // riscv-opcodes tags name a single owner, so rv_ssctr routed it to Ssctr and
+  // left Smctr — which defines the same instruction — rendering as empty (#206).
+  // Guards the committed catalogue directly, so it fails even without a sync run.
+  const owners = ['Smctr', 'Ssctr'].map((id) => {
+    const entry = entries.find((e) => e.id === id);
+    assert.ok(entry, `${id} must exist in the catalogue`);
+    return entry;
+  });
+
+  for (const entry of owners) {
+    assert.ok(
+      entry.instructions?.SCTRCLR,
+      `${entry.id} defines SCTRCLR and must carry it`,
+    );
+  }
+
+  assert.deepEqual(
+    owners[0].instructions.SCTRCLR,
+    owners[1].instructions.SCTRCLR,
+    'both owners must describe SCTRCLR identically',
+  );
+});


### PR DESCRIPTION
Closes #206.

`Smctr` (Control Transfer Records, M-mode) rendered as defining no instructions. It defines one — `SCTRCLR` — and riscv-unified-db says so explicitly:

```yaml
definedBy:
  extension:
    anyOf:
      - name: Smctr
      - name: Ssctr
```

A riscv-opcodes tag names exactly one owner. `rv_ssctr` routed `SCTRCLR` to `Ssctr`, and `Smctr` has no tag of its own, so the instruction was reachable from only one of its two owners.

## Approach

A hand-edit to `riscv_extensions.json` would not have survived: `sync_instructions.mjs` resets `entry.instructions = {}` and rebuilds from tags, so the next sync reverts it. The fix goes through the routing layer instead, as **Pass 1c**, following the existing Pass 1b (RV32 shift mask) pattern:

- Copies the entry from `Ssctr` rather than restating the encoding, so the two cannot drift apart if upstream revises it.
- Keeps Pass 1b's self-retiring assert — if upstream `instr_dict` ever provides `SCTRCLR` for `Smctr` directly, the sync fails and tells you to delete the injection.
- Adds `assertExtension` validations for both owners, so `sync:check` fails on regression.

## Also fixed

The sync summary computed coverage as `tagsPopulated + splitRulePopulated + umbrellaPopulated`. Injection passes populate entries no counter owns, so it reported `87 / 228` while the catalogue held 88. Coverage is now counted from the data, with an explicit `Populated via injection` line.

```
  Populated via tags:      71
  Populated via split:     12
  Populated via umbrella:  4
  Populated via injection: 1
  Still empty:             140
  Coverage:                88 / 228 (38.6%)
```

## Verification

- `npm run sync:check` (strict) — all validation checks passed
- Re-running sync is idempotent; the injected entry is byte-identical to `Ssctr`'s
- `npm test` — 226 pass, 0 fail, 1 skipped (pre-existing: UDB checkout on a feature branch)
- `npm run lint` — clean
- New test guards the committed catalogue directly, so it fails even without a sync run