### PR TITLE
chore: v1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "riscv-extensions-landscape",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "riscv-extensions-landscape",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "lucide-react": "^0.294.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riscv-extensions-landscape",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "index.js",
   "homepage": "https://riscv.github.io/riscv-extensions-landscape/",


### PR DESCRIPTION
Patch release covering the three merges that landed after the `v1.1.0` tag, plus the `Smctr` fix.

| PR | Change |
|---|---|
| #202 | Workspace toast timers cleared on unmount |
| #204 | Skip link, focus trapping, and missing ARIA state |
| #207 | `SCTRCLR` attributed to `Smctr` as well as `Ssctr` |

#203 (synchronisation tooling tests) also landed in this range but has no user-visible effect.

Patch rather than minor: nothing here adds user-facing capability. #204 makes existing UI reachable by keyboard and screen reader, #202 fixes a leak, #207 corrects catalogue data.

Note that CI deploys on push to `main`, so gh-pages already serves this code — the tag marks a reference point rather than shipping anything new.