### PR TITLE
feat: elevate comparison ecosystem with mission-control dock and enhanced diff matrix

### DIFF
--- a/src/CompareTray.jsx
+++ b/src/CompareTray.jsx
@@ -11,7 +11,7 @@
  * control for a mode the user has not asked to be in.
  */
 import React from 'react';
-import { Columns, X, Trash2 } from 'lucide-react';
+import { GitCompare, X, Trash2, ArrowRight } from 'lucide-react';
 import { COMPARE_MAX, parseInstructionKey } from './compareModel.js';
 
 const chipLabel = (kind, key) => {
@@ -40,6 +40,7 @@ export default function CompareTray({
   onOpen,
 }) {
   const counts = { ext: extIds.size, instr: instrKeys.size, profile: profileNames.size };
+  
   // Hidden with the mode off, but the pin sets are untouched — flipping the
   // mode back on brings the same comparison straight back.
   if (!visible) return null;
@@ -49,99 +50,122 @@ export default function CompareTray({
     kind === 'instr' ? [...instrKeys] : kind === 'profile' ? [...profileNames] : [...extIds];
   const canCompare = active.length >= 2;
 
-  const tab = (value, label) => (
-    <button
-      key={value}
-      type="button"
-      onClick={() => onKindChange(value)}
-      className="riscv-tray-tab px-2 py-1 rounded text-[11px] font-mono"
-      aria-pressed={kind === value}
-      style={{
-        border: `1px solid ${kind === value ? 'var(--riscv-gold)' : 'var(--riscv-border-2)'}`,
-        background: kind === value ? 'var(--riscv-tint-3)' : 'transparent',
-        color: kind === value ? 'var(--riscv-text)' : 'var(--riscv-text-3)',
-      }}
-    >
-      {label} ({counts[value]})
-    </button>
-  );
+  const tab = (value, label) => {
+    const isSelected = kind === value;
+    const count = counts[value];
+    return (
+      <button
+        key={value}
+        type="button"
+        onClick={() => onKindChange(value)}
+        className="riscv-dock-tab"
+        aria-pressed={isSelected}
+      >
+        <span>{label}</span>
+        {count > 0 && (
+          <span
+            className="riscv-dock-badge"
+            style={{
+              background: isSelected ? 'var(--riscv-violet)' : 'var(--riscv-tint-3)',
+              color: isSelected ? '#ffffff' : 'var(--riscv-text-3)',
+            }}
+          >
+            {count}
+          </span>
+        )}
+      </button>
+    );
+  };
 
   return (
     <div
       role="region"
       aria-label="Comparison tray"
-      style={{
-        position: 'fixed',
-        left: 0,
-        right: 0,
-        bottom: 0,
-        zIndex: 30,
-        background: 'var(--riscv-panel)',
-        borderTop: '1px solid var(--riscv-tint-3)',
-        boxShadow: '0 -12px 40px rgba(0,0,0,0.45)',
-        padding: '8px 12px',
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        flexWrap: 'wrap',
-      }}
+      className="riscv-compare-dock"
     >
-      <div className="flex items-center gap-1.5">
-        <Columns size={13} style={{ color: 'var(--riscv-gold)' }} />
+      {/* Category Segmented Control */}
+      <div className="riscv-dock-tab-group flex-shrink-0">
         {tab('ext', 'Extensions')}
         {tab('instr', 'Instructions')}
         {tab('profile', 'Profiles')}
       </div>
 
-      <div className="flex items-center gap-1 flex-wrap" style={{ flex: 1, minWidth: 120 }}>
-        {active.length === 0 && (
-          <span className="text-[11px]" style={{ color: 'var(--riscv-text-3)' }}>
-            Nothing pinned in this tab yet.
+      {/* Vertical Divider */}
+      <div className="h-5 w-px flex-shrink-0" style={{ background: 'var(--riscv-border-2)' }} />
+
+      {/* Pinned Chips Container (Comfortably handles 1 to 6 items) */}
+      <div className="flex items-center gap-1.5 overflow-x-auto py-1 px-0.5" style={{ flex: 1, minWidth: 160, scrollbarWidth: 'none' }}>
+        {active.length === 0 ? (
+          <span className="text-[11px] italic px-1" style={{ color: 'var(--riscv-text-3)' }}>
+            No {kind === 'ext' ? 'extensions' : kind === 'instr' ? 'instructions' : 'profiles'} pinned yet.
           </span>
-        )}
-        {active.map((key) => (
-          <span
-            key={key}
-            className="riscv-tray-chip inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] font-mono"
-          >
-            {chipLabel(kind, key)}
-            <button
-              type="button"
-              onClick={() => onRemove(kind, key)}
-              title={chipTitle(kind, key)}
-              aria-label={chipTitle(kind, key)}
-              className="riscv-tray-chip-x flex"
+        ) : (
+          active.map((key) => (
+            <span
+              key={key}
+              className="riscv-dock-chip flex-shrink-0"
             >
-              <X size={10} />
-            </button>
-          </span>
-        ))}
+              <span className="font-semibold tracking-wide">{chipLabel(kind, key)}</span>
+              <button
+                type="button"
+                onClick={() => onRemove(kind, key)}
+                title={chipTitle(kind, key)}
+                aria-label={chipTitle(kind, key)}
+                className="riscv-dock-chip-x"
+              >
+                <X size={11} />
+              </button>
+            </span>
+          ))
+        )}
       </div>
 
-      <div className="flex items-center gap-2">
+      {/* Action Controls */}
+      <div className="flex items-center gap-2 flex-shrink-0">
         {active.length > 0 && (
           <button
             type="button"
-            className="riscv-btn px-2 py-1 text-[11px] inline-flex items-center gap-1"
+            className="inline-flex items-center gap-1 px-2.5 py-1.5 text-[11px] font-semibold rounded-lg transition-all duration-200 cursor-pointer border active:scale-95 shadow-sm"
+            style={{
+              background: 'var(--riscv-report-tint)',
+              color: 'var(--riscv-danger)',
+              borderColor: 'var(--riscv-report-edge)',
+            }}
             onClick={() => onClear(kind)}
-            title="Clear this tab"
+            title="Clear all pinned items in this category"
           >
-            <Trash2 size={11} /> Clear
+            <Trash2 size={12} style={{ color: 'var(--riscv-danger)' }} />
+            <span className="hidden sm:inline">Clear</span>
           </button>
         )}
+
         <button
           type="button"
-          className="riscv-btn px-3 py-1 text-[11px] font-semibold disabled:opacity-40"
+          className="inline-flex items-center gap-1.5 px-3.5 py-1.5 text-[12px] font-bold rounded-xl transition-all duration-200 shadow-md"
+          style={{
+            background: canCompare
+              ? 'linear-gradient(to right, #f59e0b, #f5c542)'
+              : 'var(--riscv-surface)',
+            color: canCompare ? '#0f172a' : 'var(--riscv-text-3)',
+            border: canCompare ? 'none' : '1px solid var(--riscv-border)',
+            boxShadow: canCompare ? '0 4px 14px rgba(245, 197, 66, 0.3)' : 'none',
+            cursor: canCompare ? 'pointer' : 'not-allowed',
+            opacity: canCompare ? 1 : 0.45,
+          }}
           onClick={onOpen}
           disabled={!canCompare}
-          title={canCompare ? 'Open the comparison' : 'Pin at least two items to compare'}
+          title={canCompare ? 'Launch side-by-side comparison' : 'Pin at least 2 items to compare'}
         >
-          Compare ({active.length})
+          <GitCompare size={13} className="shrink-0" />
+          <span>Compare ({active.length})</span>
+          {canCompare && <ArrowRight size={12} className="opacity-80" />}
         </button>
-        <span className="text-[10px] font-mono" style={{ color: 'var(--riscv-text-3)' }}>
-          max {COMPARE_MAX}
+
+        <span className="text-[10px] font-mono tracking-tight hidden lg:inline" style={{ color: 'var(--riscv-text-3)' }}>
+          {active.length}/{COMPARE_MAX}
         </span>
       </div>
     </div>
   );
 }
+

--- a/src/CompareTray.jsx
+++ b/src/CompareTray.jsx
@@ -155,6 +155,13 @@ export default function CompareTray({
           onClick={onOpen}
           disabled={!canCompare}
           title={canCompare ? 'Launch side-by-side comparison' : 'Pin at least 2 items to compare'}
+          // A disabled button leaves the tab order, so `title` alone never
+          // reaches a screen reader — the requirement has to be in the name.
+          aria-label={
+            canCompare
+              ? `Compare ${active.length} pinned items side by side`
+              : `Compare — pin at least 2 items first, ${active.length} pinned`
+          }
         >
           <GitCompare size={13} className="shrink-0" />
           <span>Compare ({active.length})</span>

--- a/src/CompareView.jsx
+++ b/src/CompareView.jsx
@@ -11,7 +11,7 @@
  * differences have to be the thing that stands out.
  */
 import React from 'react';
-import { X, Copy, Link2, Columns } from 'lucide-react';
+import { X, Copy, Link2, GitCompare } from 'lucide-react';
 import { toMarkdown } from './compareModel.js';
 import { focusableWithin, nextFocus } from './focusTrap.js';
 import EncodingDiagram from './EncodingDiagram.jsx';
@@ -97,6 +97,7 @@ export default function CompareView({
   open,
   model,
   onClose,
+  onRemoveItem,
   onCopyMarkdown,
   onCopyLink,
   expandDeps,
@@ -149,26 +150,29 @@ export default function CompareView({
 
   if (!open || !model || model.columns.length === 0) return null;
 
+  // Agreement is context, difference is the signal.
   const rows = differencesOnly ? model.rows.filter((r) => !r.allSame) : model.rows;
   const differing = model.rows.filter((r) => !r.allSame).length;
   const heading =
     model.kind === 'instr'
-      ? 'Compare instructions'
+      ? 'Instruction Comparison'
       : model.kind === 'profile'
-        ? 'Compare profiles'
-        : 'Compare extensions';
-  const gridColumns = `minmax(140px, 180px) repeat(${model.columns.length}, minmax(260px, 1fr))`;
+        ? 'Profile Comparison'
+        : 'Extension Comparison';
+  const colMinWidth = model.kind === 'instr' ? '330px' : '260px';
+  const gridColumns = `minmax(140px, 180px) repeat(${model.columns.length}, minmax(${colMinWidth}, 1fr))`;
 
   return (
     <div className="fixed inset-0 z-50">
+      {/* Backdrop */}
       <div
         className="absolute inset-0"
-        style={{ background: 'rgba(7,7,14,0.85)', backdropFilter: 'blur(4px)' }}
+        style={{ background: 'rgba(7,7,14,0.85)', backdropFilter: 'blur(8px)', WebkitBackdropFilter: 'blur(8px)' }}
         onClick={onClose}
         role="presentation"
       />
 
-      <div className="absolute inset-0 p-3 md:p-8 flex items-start justify-center">
+      <div className="absolute inset-0 p-3 md:p-6 lg:p-8 flex items-start justify-center">
         <div
           ref={dialogRef}
           role="dialog"
@@ -176,98 +180,147 @@ export default function CompareView({
           aria-labelledby="compare-view-title"
           tabIndex={-1}
           className="animate-scale-in riscv-card w-full h-full flex flex-col overflow-hidden"
-          style={{ boxShadow: '0 0 60px rgba(0,0,0,0.8), 0 0 0 1px rgba(245,197,66,0.12)' }}
+          style={{
+            boxShadow: '0 0 70px rgba(0,0,0,0.85), 0 0 0 1px rgba(245,197,66,0.18)',
+            borderRadius: 20,
+          }}
         >
+          {/* Header Bar */}
           <div
-            className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 px-4 py-3"
-            style={{ borderBottom: '1px solid var(--riscv-border-2)' }}
+            className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3 px-5 py-3.5"
+            style={{
+              borderBottom: '1px solid var(--riscv-border-2)',
+              background: 'var(--riscv-surface)',
+            }}
           >
-            <h2
-              id="compare-view-title"
-              className="text-[13px] font-bold uppercase tracking-wider inline-flex items-center gap-2 min-w-0"
-              style={{ color: 'var(--riscv-gold)' }}
-            >
-              <Columns size={14} /> {heading}
-              <span
-                className="font-mono normal-case tracking-normal text-[11px] hidden sm:inline"
-                style={{ color: 'var(--riscv-text-3)' }}
+            <div className="flex items-center gap-3 flex-wrap min-w-0">
+              <h2
+                id="compare-view-title"
+                className="text-[14px] font-bold uppercase tracking-wider inline-flex items-center gap-2"
+                style={{ color: 'var(--riscv-violet)' }}
               >
-                {differing} of {model.rows.length}{' '}
-                {model.kind === 'profile' ? 'rows' : 'attributes'} differ
-                {model.kind === 'profile' &&
-                  (model.expandedDependencies
-                    ? ' \u00b7 including implied extensions'
-                    : ' \u00b7 as listed in the specification')}
-              </span>
-            </h2>
+                <GitCompare size={16} /> {heading}
+              </h2>
 
-            <div className="flex flex-wrap items-center gap-2 ml-auto">
-              <label
-                className="inline-flex items-center gap-1.5 text-[11px]"
+              <span
+                className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-[11px] font-mono"
+                style={{
+                  background: differing > 0 ? 'rgba(139, 124, 248, 0.12)' : 'var(--riscv-surface-2)',
+                  color: differing > 0 ? 'var(--riscv-violet)' : 'var(--riscv-text-3)',
+                  border: `1px solid ${differing > 0 ? 'rgba(139, 124, 248, 0.3)' : 'var(--riscv-border-2)'}`,
+                }}
+              >
+                <strong>{differing}</strong> of {model.rows.length} {model.kind === 'profile' ? 'rows' : 'attributes'} differ
+              </span>
+
+              {model.kind === 'profile' && (
+                <span className="text-[11px] font-mono hidden md:inline" style={{ color: 'var(--riscv-text-3)' }}>
+                  {model.expandedDependencies ? '(with implied extensions)' : '(as listed in the specification)'}
+                </span>
+              )}
+            </div>
+
+            {/* Toolbar Controls */}
+            <div className="flex flex-wrap items-center gap-3 ml-auto">
+              {/* Differences Only Precision Switch */}
+              <button
+                type="button"
+                role="switch"
+                aria-checked={differencesOnly}
+                onClick={() => setDifferencesOnly((v) => !v)}
+                className="inline-flex items-center gap-2 text-[12px] font-medium cursor-pointer select-none"
                 style={{ color: 'var(--riscv-text-2)' }}
               >
-                <input
-                  type="checkbox"
-                  checked={differencesOnly}
-                  onChange={(e) => setDifferencesOnly(e.target.checked)}
-                />
-                Show only differences
-              </label>
+                <span className="riscv-switch" data-checked={differencesOnly}>
+                  <span className="riscv-switch-thumb" />
+                </span>
+                <span>Differences only</span>
+              </button>
+
+              {/* Profile Implied Extensions Switch */}
               {model.kind === 'profile' && (
-                <label
-                  className="inline-flex items-center gap-1.5 text-[11px]"
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={Boolean(expandDeps)}
+                  onClick={() => onToggleExpandDeps(!expandDeps)}
+                  className="inline-flex items-center gap-2 text-[12px] font-medium cursor-pointer select-none"
                   style={{ color: 'var(--riscv-text-2)' }}
-                  title="profiles.js lists what the specification enumerates. Expanding runs each list through the dependency graph to show what a conforming implementation actually provides."
+                  title="Expand lists through the dependency graph to show what a conforming implementation provides"
                 >
-                  <input
-                    type="checkbox"
-                    checked={Boolean(expandDeps)}
-                    onChange={(e) => onToggleExpandDeps(e.target.checked)}
-                  />
-                  Include implied extensions
-                </label>
+                  <span className="riscv-switch" data-checked={Boolean(expandDeps)}>
+                    <span className="riscv-switch-thumb" />
+                  </span>
+                  <span>Include implied</span>
+                </button>
               )}
+
+              <div className="h-4 w-px mx-0.5" style={{ background: 'var(--riscv-border-2)' }} />
+
+              {/* Actions */}
               <button
                 type="button"
-                className="riscv-btn px-2 py-1 text-[11px] inline-flex items-center gap-1"
+                className="riscv-btn px-2.5 py-1.5 text-[11px] inline-flex items-center gap-1.5 font-medium"
                 onClick={() => onCopyMarkdown(toMarkdown(model, { differencesOnly }))}
+                title="Copy comparison as Markdown table"
               >
-                <Copy size={11} /> Markdown
+                <Copy size={12} className="opacity-75" />
+                <span>Markdown</span>
               </button>
+
               <button
                 type="button"
-                className="riscv-btn px-2 py-1 text-[11px] inline-flex items-center gap-1"
+                className="riscv-btn px-2.5 py-1.5 text-[11px] inline-flex items-center gap-1.5 font-medium"
                 onClick={onCopyLink}
+                title="Copy shareable permalink for this comparison"
               >
-                <Link2 size={11} /> Link
+                <Link2 size={12} className="opacity-75" />
+                <span>Share Link</span>
               </button>
+
               <button
                 type="button"
-                className="riscv-btn p-1"
+                className="riscv-btn p-1.5"
                 onClick={onClose}
                 aria-label="Close comparison"
               >
-                <X size={14} />
+                <X size={15} />
               </button>
             </div>
           </div>
 
+          {/* Grid View */}
           <div className="flex-1 overflow-auto">
             <div className="compare-grid" style={{ gridTemplateColumns: gridColumns }}>
               <div className="compare-head compare-attr" />
               {model.columns.map((col) => (
                 <div key={col.key} className="compare-head">
-                  <div
-                    className="font-mono text-[12px] font-bold"
-                    style={{ color: 'var(--riscv-text)' }}
-                  >
-                    {col.label}
-                  </div>
-                  {col.sublabel && col.sublabel !== col.label && (
-                    <div className="text-[10px]" style={{ color: 'var(--riscv-text-3)' }}>
-                      {col.sublabel}
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 pr-1">
+                      <div
+                        className="font-mono text-[13px] font-bold truncate"
+                        style={{ color: 'var(--riscv-text)' }}
+                      >
+                        {col.label}
+                      </div>
+                      {col.sublabel && col.sublabel !== col.label && (
+                        <div className="text-[11px] font-mono mt-0.5 truncate" style={{ color: 'var(--riscv-text-3)' }}>
+                          {col.sublabel}
+                        </div>
+                      )}
                     </div>
-                  )}
+                    {onRemoveItem && (
+                      <button
+                        type="button"
+                        onClick={() => onRemoveItem(model.kind, col.key)}
+                        title={`Remove ${col.label} from comparison`}
+                        aria-label={`Remove ${col.label} from comparison`}
+                        className="riscv-dock-chip-x p-1 shrink-0"
+                      >
+                        <X size={12} />
+                      </button>
+                    )}
+                  </div>
                 </div>
               ))}
 
@@ -291,8 +344,13 @@ export default function CompareView({
             </div>
 
             {rows.length === 0 && (
-              <div className="p-6 text-center text-[12px]" style={{ color: 'var(--riscv-text-3)' }}>
-                These items agree on every attribute.
+              <div className="p-12 text-center space-y-2">
+                <div className="text-sm font-semibold" style={{ color: 'var(--riscv-text-2)' }}>
+                  All attributes are identical
+                </div>
+                <div className="text-[12px]" style={{ color: 'var(--riscv-text-3)' }}>
+                  These items agree on every compared attribute. Toggle off "Differences only" to view the full specification.
+                </div>
               </div>
             )}
           </div>

--- a/src/ExtensionTile.jsx
+++ b/src/ExtensionTile.jsx
@@ -22,7 +22,7 @@
  *      "did membership change for THIS id" re-renders only what changed.
  */
 import React from 'react';
-import { Plus, Columns } from 'lucide-react';
+import { Plus, GitCompare } from 'lucide-react';
 import { tilePropsAreEqual } from './tileMemo.js';
 
 function ExtensionTile({
@@ -139,16 +139,17 @@ function ExtensionTile({
               width: 18,
               height: 18,
               borderRadius: 5,
-              border: `1px solid ${inCompare ? 'var(--riscv-check-edge)' : 'var(--riscv-border-2)'}`,
-              background: inCompare ? 'var(--riscv-check-fill)' : 'var(--riscv-surface-2)',
-              color: inCompare ? 'var(--riscv-check)' : 'var(--riscv-text-3)',
+              border: `1px solid ${inCompare ? 'var(--riscv-violet)' : 'var(--riscv-border-2)'}`,
+              background: inCompare ? 'var(--riscv-violet)' : 'var(--riscv-surface-2)',
+              color: inCompare ? '#ffffff' : 'var(--riscv-text-3)',
+              boxShadow: inCompare ? '0 0 10px rgba(139, 124, 248, 0.4)' : 'none',
               cursor: 'pointer',
-              transition: 'all 0.15s',
+              transition: 'all 0.15s ease',
               padding: 0,
             }}
-            title={inCompare ? `Remove ${data.id} from comparison` : `Compare ${data.id}`}
+            title={inCompare ? `Remove ${data.id} from comparison` : `Pin ${data.id} to comparison`}
           >
-            <Columns size={9} />
+            <GitCompare size={9} strokeWidth={inCompare ? 2.5 : 2} />
           </button>
         )}
 

--- a/src/index.css
+++ b/src/index.css
@@ -311,11 +311,13 @@ pre,
   background: rgba(139, 124, 248, 0.2);
 }
 
-/* A bit position the compared instructions disagree on. An inset ring rather
-   than a background, so the field colouring underneath stays readable. */
+/* A bit position the compared instructions disagree on. Refined border and glow so bit digits inside stay completely legible. */
 .riscv-bit-diff {
-  box-shadow: inset 0 0 0 2px var(--riscv-gold);
+  box-shadow: inset 0 0 0 1.5px var(--riscv-gold), 0 0 5px rgba(245, 197, 66, 0.4);
   position: relative;
+  font-weight: 700;
+  color: var(--riscv-text) !important;
+  z-index: 1;
 }
 
 /* Extension tile hover lift */
@@ -783,10 +785,18 @@ pre,
 /* Panels and toolbars that painted a dark plate inline keep their own colour;
    these are the containers that read as holes on light. */
 :root[data-theme='light'] .riscv-card,
+:root[data-theme='light'] .bg-slate-950,
+:root[data-theme='light'] .bg-slate-950\/90,
+:root[data-theme='light'] .bg-slate-950\/80,
+:root[data-theme='light'] .bg-slate-950\/75,
+:root[data-theme='light'] .bg-slate-950\/50,
+:root[data-theme='light'] .bg-slate-950\/40,
+:root[data-theme='light'] .bg-slate-950\/30,
 :root[data-theme='light'] .bg-slate-900\/50,
 :root[data-theme='light'] .bg-slate-900\/60,
-:root[data-theme='light'] .bg-slate-950\/40,
-:root[data-theme='light'] .bg-slate-950\/50,
+:root[data-theme='light'] .bg-slate-900\/75,
+:root[data-theme='light'] .bg-slate-900\/80,
+:root[data-theme='light'] .bg-slate-900\/90,
 :root[data-theme='light'] .riscv-card-2 {
   background: var(--riscv-surface);
   border-color: var(--riscv-border);
@@ -817,14 +827,47 @@ pre,
   color: #047857 !important;
 }
 
+/* Violet palette remappings for light theme */
+:root[data-theme='light'] .bg-violet-950,
+:root[data-theme='light'] .bg-violet-950\/90,
+:root[data-theme='light'] .bg-violet-950\/80,
+:root[data-theme='light'] .bg-violet-950\/50,
+:root[data-theme='light'] .bg-violet-950\/30,
+:root[data-theme='light'] .bg-violet-500\/20,
+:root[data-theme='light'] .bg-violet-500\/10 {
+  background: #efeafc !important;
+}
+:root[data-theme='light'] .border-violet-900\/60,
+:root[data-theme='light'] .border-violet-700\/50,
+:root[data-theme='light'] .border-violet-400\/60,
+:root[data-theme='light'] .border-violet-400\/30 {
+  border-color: #d3c5f3 !important;
+}
+:root[data-theme='light'] .text-violet-300,
+:root[data-theme='light'] .text-violet-200,
+:root[data-theme='light'] .text-violet-100 {
+  color: #4b2f9c !important;
+}
+
 /* Sidebar Details Panel explicit Tailwind overrides for light theme */
 :root[data-theme='light'] .bg-slate-900 {
   background: var(--riscv-surface-2) !important;
 }
 :root[data-theme='light'] .bg-slate-800,
+:root[data-theme='light'] .bg-slate-800\/90,
+:root[data-theme='light'] .bg-slate-800\/80,
 :root[data-theme='light'] .bg-slate-800\/70,
 :root[data-theme='light'] .bg-slate-800\/50 {
   background: var(--riscv-surface) !important;
+}
+:root[data-theme='light'] .bg-slate-700,
+:root[data-theme='light'] .bg-slate-700\/90,
+:root[data-theme='light'] .bg-slate-700\/80,
+:root[data-theme='light'] .bg-slate-700\/70,
+:root[data-theme='light'] .bg-slate-700\/60,
+:root[data-theme='light'] .bg-slate-700\/50,
+:root[data-theme='light'] .bg-slate-700\/40 {
+  background: var(--riscv-surface-2) !important;
 }
 :root[data-theme='light'] .bg-slate-600 {
   background: var(--riscv-muted) !important;
@@ -1224,51 +1267,46 @@ pre,
 .compare-head {
   position: sticky;
   top: 0;
-  z-index: 2;
-  padding: 8px 10px;
+  z-index: 10;
+  padding: 10px 14px;
   background: var(--riscv-panel);
   border-bottom: 1px solid var(--riscv-border-2);
 }
 .compare-attr {
   position: sticky;
   left: 0;
-  z-index: 1;
+  z-index: 9;
   background: var(--riscv-panel);
   font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.05em;
   color: var(--riscv-text-3);
+  box-shadow: 2px 0 10px rgba(0, 0, 0, 0.08);
 }
 .compare-head.compare-attr {
-  z-index: 3;
+  z-index: 11;
+  background: var(--riscv-panel);
 }
 .compare-cell {
-  padding: 8px 10px;
+  padding: 10px 14px;
   border-bottom: 1px solid var(--riscv-border-2);
   overflow-wrap: anywhere;
 }
-/* Agreement is context, difference is the signal.
-   tint-3 alone is a 6% white wash — technically a highlight, but invisible
-   when you are scanning fifty rows for the four that matter. A differing row
-   now carries a gold wash AND a gold edge on its sticky label cell, so the
-   rows worth reading are findable from the scrollbar. */
 .compare-same {
-  /* Dimmed with a colour token rather than opacity. Opacity composites the
-     whole cell, so at 0.38 the agreeing rows measured 2.20:1 in light and
-     3.11:1 in dark, and the presence marks — already muted — were dimmed a
-     second time down to 1.69:1. Agreeing rows are still content: a reader
-     compares RVA22 against RVA23 precisely to see what they share. The gold
-     wash and gold edge on the differing rows carry the emphasis instead. */
   color: var(--riscv-text-2);
 }
 .compare-diff {
-  background: var(--riscv-diff-bg);
+  background: rgba(139, 124, 248, 0.09);
   color: var(--riscv-text);
 }
+:root[data-theme='light'] .compare-diff {
+  background: rgba(109, 91, 208, 0.07);
+}
 .compare-attr.compare-diff {
-  box-shadow: inset 3px 0 0 var(--riscv-diff-edge);
-  color: var(--riscv-text);
-  font-weight: 600;
+  background: var(--riscv-panel) !important;
+  box-shadow: inset 3px 0 0 var(--riscv-violet), 2px 0 10px rgba(0, 0, 0, 0.08);
+  color: var(--riscv-violet);
+  font-weight: 700;
 }
 
 /* Header toolbar. A full-width plate holding filters on the left and actions
@@ -1418,21 +1456,21 @@ pre,
     border-color 0.15s ease;
 }
 .riscv-pin-btn:hover {
-  border-color: var(--riscv-check-edge);
+  border-color: rgba(139, 124, 248, 0.4);
   background: var(--riscv-tint-3);
-  color: var(--riscv-check);
+  color: var(--riscv-violet);
 }
 .riscv-pin-btn[aria-pressed='true'] {
-  border-color: var(--riscv-check-edge);
-  background: var(--riscv-check-fill);
-  color: var(--riscv-check);
+  border-color: rgba(139, 124, 248, 0.6);
+  background: rgba(139, 124, 248, 0.18);
+  color: var(--riscv-violet);
 }
 .riscv-pin-btn[aria-pressed='true']:hover {
-  border-color: var(--riscv-check);
-  background: var(--riscv-tint-4);
+  border-color: var(--riscv-violet);
+  background: rgba(139, 124, 248, 0.28);
 }
 .riscv-pin-btn:focus-visible {
-  outline: 2px solid var(--riscv-check-edge);
+  outline: 2px solid var(--riscv-violet);
   outline-offset: 1px;
 }
 
@@ -1511,3 +1549,196 @@ pre,
   white-space: nowrap;
   border-width: 0;
 }
+
+/* ─── Mission-Control Comparison Ecosystem ────────────────────────────────── */
+
+@keyframes dockSlideUp {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 20px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
+}
+
+.riscv-compare-dock {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 45;
+  width: auto;
+  max-width: min(96vw, 1060px);
+  background: var(--riscv-panel);
+  border: 1px solid var(--riscv-tint-4);
+  box-shadow: 0 20px 48px -10px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-radius: 18px;
+  padding: 8px 14px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  animation: dockSlideUp 0.25s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+:root[data-theme='light'] .riscv-compare-dock {
+  background: rgba(255, 255, 255, 0.94);
+  border-color: rgba(0, 0, 0, 0.12);
+  box-shadow: 0 20px 48px -10px rgba(0, 0, 0, 0.18), 0 0 0 1px rgba(0, 0, 0, 0.05);
+}
+
+.riscv-dock-tab-group {
+  display: flex;
+  align-items: center;
+  background: var(--riscv-surface-2);
+  padding: 3px;
+  border-radius: 12px;
+  border: 1px solid var(--riscv-border-2);
+  gap: 2px;
+}
+
+.riscv-dock-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 9px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--riscv-text-3);
+  transition: all 0.18s ease;
+  border: 1px solid transparent;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.riscv-dock-tab:hover {
+  color: var(--riscv-text);
+  background: var(--riscv-tint-2);
+}
+
+.riscv-dock-tab[aria-pressed='true'] {
+  background: var(--riscv-panel);
+  color: var(--riscv-text);
+  border-color: var(--riscv-border-2);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+}
+
+.riscv-dock-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-family: monospace;
+  font-weight: 700;
+}
+
+.riscv-dock-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px 4px 10px;
+  border-radius: 8px;
+  font-size: 11px;
+  font-family: monospace;
+  background: var(--riscv-surface-2);
+  border: 1px solid var(--riscv-border-2);
+  color: var(--riscv-text);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  transition: all 0.15s ease;
+}
+
+.riscv-dock-chip:hover {
+  border-color: var(--riscv-tint-4);
+  background: var(--riscv-tint-3);
+}
+
+.riscv-dock-chip-x {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  color: var(--riscv-text-3);
+  transition: all 0.15s ease;
+}
+
+.riscv-dock-chip-x:hover {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+  transform: scale(1.15);
+}
+
+/* Precision Switch for Diff Controls */
+.riscv-switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 32px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--riscv-surface-2);
+  border: 1px solid var(--riscv-border-2);
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+  flex-shrink: 0;
+}
+
+.riscv-switch[data-checked='true'] {
+  background: var(--riscv-violet);
+  border-color: var(--riscv-violet);
+}
+
+.riscv-switch-thumb {
+  display: block;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--riscv-text-3);
+  transform: translateX(2px);
+  transition: transform 0.2s ease, background-color 0.2s ease;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+}
+
+.riscv-switch[data-checked='true'] .riscv-switch-thumb {
+  background: #0f172a;
+  transform: translateX(16px);
+}
+
+:root[data-theme='light'] .riscv-switch[data-checked='true'] .riscv-switch-thumb {
+  background: #ffffff;
+}
+
+/* Column Header Remove Button in Diff View */
+.compare-col-header {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.compare-col-remove {
+  opacity: 0.4;
+  padding: 3px;
+  border-radius: 5px;
+  color: var(--riscv-text-3);
+  transition: all 0.15s ease;
+}
+
+.compare-col-header:hover .compare-col-remove,
+.compare-col-remove:hover {
+  opacity: 1;
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+}
+

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -41,7 +41,7 @@ import {
   Maximize2,
   Sun,
   Moon,
-  Columns,
+  GitCompare,
 } from 'lucide-react';
 import extensions from './riscv_extensions.json';
 import EncodingMap from './EncodingMap.jsx';
@@ -1916,14 +1916,14 @@ const RISCVExplorer = () => {
                                   toggleCompareProfile(profile);
                                 }}
                                 aria-pressed={compareProfileNames.has(profile)}
-                                className="riscv-pin-btn ml-0.5 px-1 py-0.5 rounded border text-[11px]"
+                                className="riscv-pin-btn ml-0.5 px-1 py-0.5 rounded border text-[11px] inline-flex items-center justify-center transition-all"
                                 title={
                                   compareProfileNames.has(profile)
                                     ? `Remove ${profile} from comparison`
-                                    : `Compare ${profile}`
+                                    : `Pin ${profile} to comparison`
                                 }
                               >
-                                <Columns size={9} />
+                                <GitCompare size={9} strokeWidth={compareProfileNames.has(profile) ? 2.5 : 2} />
                               </button>
                             )}
                           </span>
@@ -2032,40 +2032,51 @@ const RISCVExplorer = () => {
                     type="button"
                     aria-pressed={compareMode}
                     onClick={() => setCompareMode((v) => !v)}
-                    className={[
-                      'compare-mode-toggle relative inline-flex items-center gap-2 px-3 py-2 text-xs font-bold rounded-xl transition-all duration-300 whitespace-nowrap',
+                    className="compare-mode-toggle relative inline-flex items-center gap-2 px-3 py-2 text-xs font-bold rounded-xl transition-all duration-200 whitespace-nowrap cursor-pointer"
+                    style={
                       compareMode
-                        ? 'bg-gradient-to-b from-violet-400 to-violet-500 text-slate-900 hover:from-violet-300 hover:to-violet-400'
-                        : 'bg-slate-800/80 text-violet-300/90 border border-violet-400/30 hover:bg-slate-700/80 hover:text-violet-200',
-                    ].join(' ')}
-                    style={{
-                      boxShadow: compareMode
-                        ? '0 4px 18px rgba(167,139,250,0.35)'
-                        : '0 2px 10px rgba(0,0,0,0.2)',
-                    }}
+                        ? {
+                            background: 'var(--riscv-violet)',
+                            color: '#ffffff',
+                            boxShadow: '0 4px 18px rgba(139,124,248,0.35)',
+                            border: '1px solid var(--riscv-violet)',
+                          }
+                        : {
+                            background: 'var(--riscv-surface)',
+                            color: 'var(--riscv-violet)',
+                            border: '1px solid rgba(139,124,248,0.35)',
+                          }
+                    }
                     data-tooltip={
                       compareMode
-                        ? 'Compare mode is ON — pin extensions, instructions or profiles to compare them. Click here to turn off; pinned items are kept.'
-                        : 'Turn on Compare mode to pin extensions, instructions or profiles side by side'
+                        ? 'Compare mode is ON — click to turn off (pinned items are preserved)'
+                        : 'Turn on Compare mode to pin extensions, instructions, or profiles'
                     }
                   >
-                    <Columns size={14} className="opacity-80 flex-shrink-0" />
+                    <GitCompare size={14} className="flex-shrink-0" />
                     <span className="whitespace-nowrap hidden sm:inline">Compare</span>
                     <span
-                      className={[
-                        'inline-flex items-center justify-center px-1.5 h-[16px] rounded-full text-[10px] font-black tracking-wide',
+                      className="inline-flex items-center justify-center px-1.5 h-[16px] rounded-full text-[10px] font-black tracking-wide"
+                      style={
                         compareMode
-                          ? 'bg-slate-900/75 text-violet-300'
-                          : 'bg-slate-900/60 text-slate-400',
-                      ].join(' ')}
+                          ? {
+                              background: 'rgba(0,0,0,0.25)',
+                              color: '#ffffff',
+                            }
+                          : comparePinnedTotal > 0
+                            ? {
+                                background: 'var(--riscv-violet-dim)',
+                                color: 'var(--riscv-violet)',
+                                border: '1px solid rgba(139,124,248,0.3)',
+                              }
+                            : {
+                                background: 'var(--riscv-tint-3)',
+                                color: 'var(--riscv-text-3)',
+                              }
+                      }
                     >
-                      {compareMode ? 'ON' : 'OFF'}
+                      {comparePinnedTotal > 0 ? comparePinnedTotal : compareMode ? 'ON' : 'OFF'}
                     </span>
-                    {comparePinnedTotal > 0 && (
-                      <span className="inline-flex items-center justify-center min-w-[18px] px-1 h-[18px] rounded-full text-[10px] font-black bg-slate-900/75 text-violet-300">
-                        {comparePinnedTotal}
-                      </span>
-                    )}
                   </button>
 
                   {/* ISA Configuration Builder — fused action group */}
@@ -3415,14 +3426,14 @@ const RISCVExplorer = () => {
                                             toggleCompareInstruction(selectedExt.id, mnemonic);
                                           }}
                                           aria-pressed={pinned}
-                                          className="riscv-pin-btn px-1 py-0.5 rounded-r border-l-0 text-[11px]"
+                                          className="riscv-pin-btn px-1 py-0.5 rounded-r border-l-0 text-[11px] inline-flex items-center justify-center transition-all"
                                           title={
                                             pinned
                                               ? `Remove ${mnemonic} from comparison`
                                               : `Compare ${mnemonic}`
                                           }
                                         >
-                                          <Columns size={9} />
+                                          <GitCompare size={9} strokeWidth={pinned ? 2.5 : 2} />
                                         </button>
                                       );
                                     })()}
@@ -3492,6 +3503,41 @@ const RISCVExplorer = () => {
                               )}
                             </h4>
                             <div className="flex items-center gap-2">
+                              {(() => {
+                                const isPinned = compareInstrKeys.has(
+                                  instructionKey(selectedExt.id, selectedInstruction.mnemonic),
+                                );
+                                return (
+                                  <button
+                                    type="button"
+                                    aria-pressed={isPinned}
+                                    className="inline-flex items-center gap-1 px-2 py-1 riscv-btn tooltip-align-right"
+                                    style={
+                                      isPinned
+                                        ? {
+                                            background: 'var(--riscv-violet-dim)',
+                                            color: 'var(--riscv-violet)',
+                                            borderColor: 'rgba(139, 124, 248, 0.4)',
+                                          }
+                                        : undefined
+                                    }
+                                    onClick={() => {
+                                      toggleCompareInstruction(selectedExt.id, selectedInstruction.mnemonic);
+                                      if (!compareMode) setCompareMode(true);
+                                    }}
+                                    data-tooltip={isPinned ? 'Remove from comparison' : 'Pin to comparison'}
+                                  >
+                                    <GitCompare
+                                      size={12}
+                                      style={{
+                                        color: isPinned ? 'var(--riscv-violet)' : 'inherit',
+                                        opacity: isPinned ? 1 : 0.7,
+                                      }}
+                                    />
+                                    {isPinned ? 'Pinned' : 'Compare'}
+                                  </button>
+                                );
+                              })()}
                               <button
                                 type="button"
                                 className="inline-flex items-center gap-1 px-2 py-1 riscv-btn tooltip-align-right"
@@ -3855,6 +3901,7 @@ const RISCVExplorer = () => {
         open={compareOpen}
         model={compareModel}
         onClose={closeCompareView}
+        onRemoveItem={removeCompareItem}
         onCopyMarkdown={copyCompareMarkdown}
         onCopyLink={copyCompareLink}
         expandDeps={compareExpandDeps}
@@ -4309,6 +4356,41 @@ const RISCVExplorer = () => {
                 </div>
 
                 <div className="flex items-center gap-2 shrink-0">
+                  {(() => {
+                    const isPinned = compareInstrKeys.has(
+                      instructionKey(selectedExt.id, selectedInstruction.mnemonic),
+                    );
+                    return (
+                      <button
+                        type="button"
+                        aria-pressed={isPinned}
+                        className="inline-flex items-center gap-1.5 px-3 py-1.5 riscv-btn tooltip-bottom-right"
+                        style={
+                          isPinned
+                            ? {
+                                background: 'var(--riscv-violet-dim)',
+                                color: 'var(--riscv-violet)',
+                                borderColor: 'rgba(139, 124, 248, 0.4)',
+                              }
+                            : undefined
+                        }
+                        onClick={() => {
+                          toggleCompareInstruction(selectedExt.id, selectedInstruction.mnemonic);
+                          if (!compareMode) setCompareMode(true);
+                        }}
+                        data-tooltip={isPinned ? 'Remove from comparison' : 'Pin to comparison'}
+                      >
+                        <GitCompare
+                          size={13}
+                          style={{
+                            color: isPinned ? 'var(--riscv-violet)' : 'inherit',
+                            opacity: isPinned ? 1 : 0.7,
+                          }}
+                        />
+                        <span>{isPinned ? 'Pinned' : 'Compare'}</span>
+                      </button>
+                    );
+                  })()}
                   <button
                     type="button"
                     className="inline-flex items-center gap-1.5 px-3 py-1.5 riscv-btn tooltip-bottom-right"


### PR DESCRIPTION
## What this changes

Modernizes the RISC-V Comparison Suite into an **industry-grade analysis** environment without altering any underlying comparison data models, URL hashes, or diffing logic.

### 1. Mission-Control Floating Dock (`CompareTray.jsx`)

Replaces the static full-width bottom bar with an elevated glassmorphic dock featuring:

- Segmented category tabs: `Extensions`, `Instructions`, `Profiles`
- Dynamic chip management supporting up to 6 pinned items
- Interactive red dustbin clear action matching the ISA Builder pattern

**Before**

<img width="1917" height="776" alt="Screenshot 2026-08-27 010102" src="https://github.com/user-attachments/assets/3bd38c0c-26d3-440e-97a1-83991445e065" />

**After**

<img width="1917" height="828" alt="Screenshot 2026-08-27 010112" src="https://github.com/user-attachments/assets/f419c7ac-4ef1-4dd4-918a-8fe54fbe40fa" />

---

### 2. Fixed Sticky Column Opacity Bug (`CompareView.jsx` & `index.css`)

Enforces 100% solid opacity on sticky headers and attribute columns across Dark and Light themes, resolving the horizontal scroll defect where underlying cells bled through sticky labels.

**Before**

<img width="1917" height="972" alt="Screenshot 2026-08-26 235834" src="https://github.com/user-attachments/assets/c5eb4de0-9143-40ba-9f8b-f8d8aad7f6e3" />

**After**

<img width="1907" height="978" alt="Screenshot 2026-08-27 004423" src="https://github.com/user-attachments/assets/6525ed6b-cbaa-403a-82d8-28a418aede39" />

---

### 3. Enhanced Bitfield Diff Readability

Expands instruction comparison column widths to `330px` and refines `.riscv-bit-diff` with:

- A crisp `1.5px` inset gold border
- Subtle halo glow
- Improved readability for 32-bit digits (`0`, `1`, `x`)

---

### 4. In-Diff Column Pruning

Adds column dismissal buttons (`✕`) directly to column headers, allowing engineers to remove items from an active comparison without closing the modal.

---

### 5. Universal `GitCompare` Iconography & Theme Harmonization

Unifies all compare trigger affordances across:

- Tiles
- Profile tabs
- Snapshot chips
- Details cards
- Modals
- Dock

All compare actions now use the industry-standard `GitCompare` icon and a cohesive Purple/Violet theme (`var(--riscv-violet)`).

<img width="1813" height="308" alt="Screenshot 2026-08-27 004717" src="https://github.com/user-attachments/assets/1d21b3a8-4ed2-47d2-be4f-302d93f1e96a" />

---

## Why

The existing comparison experience suffered from UX friction and visual defects:

- The full-width tray consumed significant vertical real estate and broke into awkward wrapped layouts when pinning multiple items.
- In the side-by-side diff matrix, horizontally scrolling caused table values to overlap legibility of frozen attribute headers due to semi-translucent background washes.
- Instruction 32-bit encoding rows were compressed into narrow widths where thick inset rings obscured bit numbers.
- Pruning items from a comparison required completely dismissing the modal, locating items on the grid, and unpinning manually.
- Generic icons and inconsistent color schemes (green vs purple) lacked visual hierarchy.

## How it was verified

- [x] `npm test` passes
- [x] `npm run build` succeeds (bundle compiled cleanly with 0 errors)
- Tested comparison flows across **Extensions**, **Instructions**, and **Profiles** with 2 to 6 pinned items.
- Validated sticky column horizontal scrolling with no background bleed-through in both Dark (`#14141e`) and Light (`#f7f5fb`) themes.
- Verified in-diff column removal (`onRemoveItem`) dynamically updates pinned Sets and UI state.
- Checked responsive layouts on desktop (1536px, 1280px) and compact tablet/mobile viewports.

## Sign-off

- [x] Every commit is signed off (`git commit -s`) per Developer Certificate of Origin (DCO).

**Note:** This PR is stacked on top of #222 (`feat/expanded-instruction-details`) and is ready to merge immediately after #222.