### PR TITLE
fix(export): make the export popover readable on light

### DIFF
--- a/src/WorkspacePanel.jsx
+++ b/src/WorkspacePanel.jsx
@@ -306,9 +306,9 @@ export default function WorkspacePanel({
                     zIndex: 50,
                     display: 'flex', flexDirection: 'column', gap: 0,
                     borderRadius: 10,
-                    background: 'linear-gradient(145deg, #1a1f2e 0%, #141824 100%)',
-                    border: '1px solid rgba(245,197,66,0.25)',
-                    boxShadow: '0 12px 32px rgba(0,0,0,0.55), 0 0 0 1px var(--riscv-tint-2) inset',
+                    background: 'var(--riscv-popover-bg)',
+                    border: '1px solid var(--riscv-popover-edge)',
+                    boxShadow: 'var(--riscv-popover-shadow), 0 0 0 1px var(--riscv-tint-2) inset',
                     minWidth: 280, overflow: 'hidden',
                   }}>
 
@@ -317,7 +317,7 @@ export default function WorkspacePanel({
                       display: 'flex', justifyContent: 'space-between', alignItems: 'center',
                       padding: '10px 14px',
                       borderBottom: '1px solid var(--riscv-tint-3)',
-                      background: 'rgba(245,197,66,0.04)',
+                      background: 'var(--riscv-popover-head)',
                     }}>
                       <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
                         <Package size={12} style={{ color: 'var(--riscv-gold)', opacity: 0.85 }} />
@@ -356,7 +356,7 @@ export default function WorkspacePanel({
                           </span>
                           <span style={{
                             fontSize: 11, marginTop: 2, display: 'block',
-                            color: totalInstructions > 100 ? '#f59e0b' : '#64748b',
+                            color: totalInstructions > 100 ? 'var(--riscv-warn)' : 'var(--riscv-text-3)',
                             fontVariantNumeric: 'tabular-nums',
                           }}>
                             {totalInstructions.toLocaleString()} instructions{totalInstructions > 100 ? ' · large export' : ''}
@@ -368,7 +368,7 @@ export default function WorkspacePanel({
                           width: 38, height: 21, borderRadius: 11, flexShrink: 0,
                           background: includeInstructions
                             ? 'linear-gradient(135deg, #f5c542 0%, #fde68a 100%)'
-                            : 'rgba(255,255,255,0.08)',
+                            : 'var(--riscv-tint-4)',
                           boxShadow: includeInstructions ? '0 0 8px rgba(245,197,66,0.4)' : 'none',
                           position: 'relative', transition: 'all 0.25s',
                           border: `1px solid ${includeInstructions ? 'rgba(245,197,66,0.7)' : 'var(--riscv-tint-4)'}`,
@@ -423,7 +423,7 @@ export default function WorkspacePanel({
                         title="UDB architecture configuration for riscv-arch-test. Extension versions and derived params are filled in; implementation params are left as TODO."
                         style={{
                           width: '100%', marginTop: 7, padding: '8px 14px', borderRadius: 7,
-                          background: 'rgba(255,255,255,0.03)',
+                          background: 'var(--riscv-tint-2)',
                           color: 'var(--riscv-text)',
                           border: '1px solid var(--riscv-tint-3)',
                           fontSize: 11.5, fontWeight: 600,
@@ -431,10 +431,10 @@ export default function WorkspacePanel({
                           display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
                         }}
                         onMouseEnter={e => {
-                          e.currentTarget.style.background = 'rgba(255,255,255,0.07)';
+                          e.currentTarget.style.background = 'var(--riscv-tint-4)';
                         }}
                         onMouseLeave={e => {
-                          e.currentTarget.style.background = 'rgba(255,255,255,0.03)';
+                          e.currentTarget.style.background = 'var(--riscv-tint-2)';
                         }}
                       >
                         <Package size={11} />

--- a/src/index.css
+++ b/src/index.css
@@ -36,6 +36,15 @@
   --riscv-report-edge: rgba(255, 77, 107, 0.55);
   --riscv-warn: #f59e0b;
 
+  /* Export popover surface. The card was a hardcoded dark gradient while its
+     contents used the theme tokens, so on light everything inside it resolved
+     dark-on-dark and the header and secondary button became unreadable. The
+     surface is a token now so the two move together. */
+  --riscv-popover-bg: linear-gradient(145deg, #1a1f2e 0%, #141824 100%);
+  --riscv-popover-edge: rgba(245, 197, 66, 0.25);
+  --riscv-popover-shadow: 0 12px 32px rgba(0, 0, 0, 0.55);
+  --riscv-popover-head: rgba(245, 197, 66, 0.04);
+
   --riscv-text: #e2e8f0;
   --riscv-text-2: #aab8ca;
   /* Nudged up from #6f7f95, which measured 4.17:1 against the card surface and
@@ -565,6 +574,14 @@ pre,
   --riscv-report-tint-hover: rgba(194, 51, 77, 0.18);
   --riscv-report-edge: rgba(194, 51, 77, 0.5);
   --riscv-warn: #b06f05;
+
+  /* On light the popover becomes a raised white plate: the amber edge carries
+     the identity the dark gradient used to, and the shadow is tinted with the
+     same ink as the other light-theme cards rather than pure black. */
+  --riscv-popover-bg: linear-gradient(145deg, #ffffff 0%, #fbf9f3 100%);
+  --riscv-popover-edge: rgba(143, 100, 8, 0.32);
+  --riscv-popover-shadow: 0 12px 32px rgba(45, 40, 80, 0.16);
+  --riscv-popover-head: rgba(143, 100, 8, 0.06);
 
   --riscv-text: #2b2a3d;
   --riscv-text-2: #5c5a72;


### PR DESCRIPTION
The export popover painted a hardcoded dark gradient while its contents used the theme tokens. On light those tokens resolve dark, so the header and the `Download UDB config` button rendered dark-on-dark and could not be read. Reported from a screenshot of the light theme.

The gold elements escaped it only because `--riscv-gold` has a dark-amber light variant; everything on `--riscv-text` did not.

## Change

The popover surface is a token now, with a variant per theme, so the card and its contents move together:

| token | dark | light |
|---|---|---|
| `--riscv-popover-bg` | the existing gradient | raised white plate |
| `--riscv-popover-edge` | `rgba(245,197,66,.25)` | `rgba(143,100,8,.32)` |
| `--riscv-popover-shadow` | black | tinted with the same ink as the other light cards |
| `--riscv-popover-head` | gold wash | dark-amber wash |

Two hardcoded values inside the card went the same way: the instruction count was `#f59e0b` (a dark-theme amber that measures poorly on white) and the toggle's off-state track was a white wash that vanished on a light card. Both now use tokens that already have light variants.

## Verification

Checked in the running app in both themes. Dark is byte-identical — every new token's dark value is the literal it replaced.

```
npm test   235 tests, 234 pass, 0 fail, 1 skipped (UDB-drift, needs a checkout)
npm run build   compiled successfully
```