### PR TITLE
fix: remap the light-theme classes the expand modal left paired

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -570,6 +570,12 @@ pre,
   --riscv-success: #14866a;
   --riscv-danger: #c2334d;
   --riscv-report-fg: #99203a;
+  /* The Discontinued badge pairs --riscv-danger with this tint. At 0.12 the
+     tint composites to #f8e7ea on a white card, which puts #c2334d at 4.54:1 —
+     AA with 0.04 to spare. It clears only because .riscv-card is #ffffff here;
+     the same badge on --riscv-bg (#f7f5fb) measures 4.22:1 and fails. Raising
+     the alpha or moving the badge off the card breaks it, so re-measure if
+     either changes. */
   --riscv-report-tint: rgba(194, 51, 77, 0.12);
   --riscv-report-tint-hover: rgba(194, 51, 77, 0.18);
   --riscv-report-edge: rgba(194, 51, 77, 0.5);
@@ -791,6 +797,18 @@ pre,
   color: #0f5a68 !important; /* Matches ext-tile cyan- text for consistency */
 }
 
+/* The underline has to move with the text it sits under. Left alone, the
+   decoration keeps Tailwind's bright cyan (#bdf2fa once the /30 alpha is
+   composited on white) beneath #0f5a68 text, which reads as a stray highlight
+   rather than an underline. */
+:root[data-theme='light'] .decoration-cyan-300,
+:root[data-theme='light'] .decoration-cyan-400\/30 {
+  text-decoration-color: #0f5a68 !important;
+}
+:root[data-theme='light'] .hover\:decoration-cyan-300:hover {
+  text-decoration-color: #0f5a68 !important;
+}
+
 :root[data-theme='light'] .text-emerald-300 {
   color: #065f46 !important; /* Matches ext-tile emerald- text for consistency */
 }
@@ -811,7 +829,8 @@ pre,
 :root[data-theme='light'] .bg-slate-600 {
   background: var(--riscv-muted) !important;
 }
-:root[data-theme='light'] .border-slate-700 {
+:root[data-theme='light'] .border-slate-700,
+:root[data-theme='light'] .border-slate-700\/50 {
   border-color: var(--riscv-border-2) !important;
 }
 :root[data-theme='light'] .border-slate-600 {
@@ -842,7 +861,8 @@ pre,
 :root[data-theme='light'] .text-yellow-200 {
   color: #8a4a08 !important;
 }
-:root[data-theme='light'] .border-yellow-400 {
+:root[data-theme='light'] .border-yellow-400,
+:root[data-theme='light'] .border-yellow-700\/30 {
   border-color: #f2d4b6 !important;
 }
 :root[data-theme='light'] .bg-yellow-500\/10,

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -511,6 +511,12 @@ const RISCVExplorer = () => {
   const onCloseExpandedModalRef = React.useRef(() => setInstructionExpandOpen(false));
   onCloseExpandedModalRef.current = () => setInstructionExpandOpen(false);
 
+  // Expanded instruction modal: focus trap and Escape, in one listener.
+  //
+  // Both live here rather than in separate effects — an earlier pass had a
+  // second capture-phase listener closing on Escape as well, which was
+  // harmless only because setState is idempotent. CompareView.jsx keeps the
+  // same shape: one window listener owning both keys for the dialog.
   React.useEffect(() => {
     if (!instructionExpandOpen) return undefined;
     restoreModalFocusRef.current = document.activeElement;
@@ -779,19 +785,6 @@ const RISCVExplorer = () => {
     [],
   );
   const searchInputRef = React.useRef(null);
-
-  // Instruction Expand modal keyboard behaviour — Escape closes it.
-  React.useEffect(() => {
-    if (!instructionExpandOpen) return undefined;
-    const onKeyDown = (e) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        setInstructionExpandOpen(false);
-      }
-    };
-    document.addEventListener('keydown', onKeyDown, true);
-    return () => document.removeEventListener('keydown', onKeyDown, true);
-  }, [instructionExpandOpen]);
 
   // Encoder Validator dialog keyboard behaviour.
   //


### PR DESCRIPTION
Follow-up to #222. That review was about foreground/background pairs where only one half carried a light-theme remap; the fix resolved the three reported cases, and four more of the same shape survived it.

| Class | Rendered in light | Why it was missed |
|---|---|---|
| `border-slate-700/50` | `#99a0aa` on a now-white plate | `border-slate-700` is remapped; the `/50` variant is a separate class |
| `border-yellow-700/30` | `#e1c5a0` on the cream plate | same |
| `decoration-cyan-300` | bright cyan under `#0f5a68` text | text remapped, decoration not |
| `decoration-cyan-400/30` | `#bdf2fa` under `#0f5a68` text | same |

None broke readability — they read as heavier or lighter than intended rather than invisible — which is why they were follow-up rather than blocking.

## Escape handling

The expanded modal had two effects keyed on `instructionExpandOpen`, both closing on Escape: the new focus-trap effect and an older capture-phase listener. Harmless, since `setInstructionExpandOpen(false)` is idempotent, but redundant. Folded into the trap effect, matching `CompareView.jsx`, which keeps one window listener owning both Escape and Tab for its dialog.

Checked first that nothing in the modal calls `stopPropagation` on `keydown`, so the surviving bubble-phase listener still receives the key.

## Discontinued badge

Not changed — documented. `--riscv-danger` over the `0.12` tint measures **4.54:1** on a white card against a 4.5 floor, and it clears only because `.riscv-card` is `#ffffff` in light theme; the same badge on `--riscv-bg` (`#f7f5fb`) is **4.22:1** and fails. The comment records that so a future tint adjustment does not silently break it.

## Verification

- `npm run build` compiles; the new selectors and `text-decoration-color: #0f5a68` are present in the bundle
- `npm test` — 234 pass, 0 fail, 1 skipped (pre-existing)
- `npm run lint` — clean
- Colour values computed rather than eyeballed; the composites above are from the same WCAG maths used in the #222 review