### PR TITLE
ci: make the UDB sync bot's commits pass the DCO gate

### DIFF
--- a/.github/workflows/sync-udb-extensions.yml
+++ b/.github/workflows/sync-udb-extensions.yml
@@ -78,6 +78,15 @@ jobs:
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
         with:
           commit-message: 'feat: sync extension data from riscv-unified-db'
+          # The DCO gate matches the Signed-off-by trailer against the commit
+          # author (%an <%ae>), while this action's `signoff` writes the trailer
+          # from the *committer*. They differ by default — `author` falls back to
+          # whoever triggered the run — so the trailer would never match. Pinning
+          # both to the bot makes the sign-off valid, and keeps sync commits from
+          # being attributed to whoever happened to click "Run workflow".
+          author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          signoff: true
           title: 'feat: sync extension data from UDB'
           body: |
             Automated sync from [riscv-unified-db](https://github.com/riscv/riscv-unified-db).

--- a/tests/sync-tooling.test.mjs
+++ b/tests/sync-tooling.test.mjs
@@ -161,3 +161,31 @@ test('the graph matches upstream, when a UDB checkout is available', (t) => {
   }
   assert.equal(status, 0, stdout);
 });
+
+test('the sync bot signs off as the same identity it authors as', () => {
+  // The DCO gate compares the Signed-off-by trailer against the commit author
+  // (%an <%ae>), but create-pull-request writes that trailer from the
+  // *committer*, and defaults `author` to whoever triggered the run. Left at
+  // the defaults the two never match and every weekly sync PR fails DCO.
+  //
+  // Worth a test because the failure is invisible until the cron fires: the
+  // workflow only runs on a schedule, so a regression here surfaces as a
+  // blocked PR on a Monday morning rather than a red check on the change
+  // that caused it.
+  const wf = fs.readFileSync(
+    path.join(root, '.github', 'workflows', 'sync-udb-extensions.yml'),
+    'utf8',
+  );
+
+  const author = wf.match(/^\s*author:\s*'(.+)'\s*$/m);
+  const committer = wf.match(/^\s*committer:\s*'(.+)'\s*$/m);
+
+  assert.ok(author, 'the create-pull-request step must pin an explicit author');
+  assert.ok(committer, 'the create-pull-request step must pin an explicit committer');
+  assert.equal(
+    author[1],
+    committer[1],
+    'author and committer must be the same identity, or the sign-off cannot match',
+  );
+  assert.match(wf, /^\s*signoff:\s*true\s*$/m, 'the sync commit must be signed off');
+});


### PR DESCRIPTION
The weekly UDB sync PR (#225) fails `check-sign-off`. Its commits carry no `Signed-off-by` trailer.

## Why the obvious fix would not have worked

`peter-evans/create-pull-request` has a `signoff` input, but at the pinned SHA its inputs are:

| Input | Default |
|---|---|
| `committer` | `github-actions[bot] <41898282+…>` |
| `author` | `${{ github.actor }} <…>` — whoever triggered the run |
| `signoff` | adds the trailer *"by the committer"* |

`dco.yml` matches the trailer against the **author** (`%an <%ae>`, lines 44 and 63). With the defaults, `signoff: true` would write `github-actions[bot]` into a commit authored by a human, and the gate would still fail — just with a more confusing message.

## The change

Pin `author` and `committer` to the same bot identity and enable `signoff`, so author, committer and trailer all agree.

Pinning `author` also fixes a second problem that had nothing to do with DCO: sync commits were being attributed to whoever last clicked "Run workflow" — `41f842c` on the current sync branch is authored by a human who only dispatched it. `git blame` on generated data now points at the bot that generated it.

## Test

`tests/sync-tooling.test.mjs` asserts author and committer are pinned, identical, and that `signoff` is on.

This workflow runs on a weekly cron, so a regression would not show up on the PR that caused it — it would surface days later as a blocked sync PR. Verified the guard actually fails: removing `signoff` and drifting `author` from `committer` each trip their own assertion.

## Follow-up, not in this PR

The existing `automated/sync-udb-extensions` branch keeps its two non-compliant commits, so #225 stays blocked. Since the branch is pure generated data, the clean path is to close #225, delete the branch, and let the next run rebuild it.