### PR TITLE
fix: name the profile filter for what it does

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1872,13 +1872,18 @@ const RISCVExplorer = () => {
                     }}
                   >
                     {/* Profiles. Wraps at 320px, where the label plus four buttons
-                      measured 338px and ran past the edge. */}
+                      measured 338px and ran past the edge — so the label stays one
+                      short word rather than spelling the action out.
+                      "Highlight", not "Profile": these chips are a lens over the
+                      catalogue and write nothing, while the builder's "Start from
+                      profile" replaces the workspace. Both said "profile" and looked
+                      alike, so the pair read as duplication (#212). */}
                     <div className="flex flex-wrap items-center gap-2">
                       <span
                         className="text-[11px] uppercase tracking-widest font-semibold"
                         style={{ color: 'var(--riscv-text-3)' }}
                       >
-                        Profile
+                        Highlight
                       </span>
                       <div className="flex flex-wrap gap-1.5">
                         {Object.keys(profiles).map((profile) => (
@@ -1897,6 +1902,11 @@ const RISCVExplorer = () => {
                                 })
                               }
                               aria-pressed={activeProfile === profile}
+                              title={
+                                activeProfile === profile
+                                  ? `Stop highlighting ${profile}`
+                                  : `Highlight the extensions in ${profile} — does not change your ISA configuration`
+                              }
                               className={[
                                 'px-3 py-1.5 text-[12px] rounded-lg transition-all duration-200 font-medium',
                                 activeProfile === profile


### PR DESCRIPTION
Closes #212.

The report asked why profiles appear in two places, how they interact, and why selecting one does not set the other. They are not duplicates — they do different jobs — but nothing in the UI said so.

| | Main frame chips | Builder "Start from profile" |
|---|---|---|
| Writes | nothing | `setWorkspaceIds(new Set())` then `addWorkspaceIdsSmart(list)` |
| Effect | `isHighlightedByProfile` + `isDimmed` — a lens over the catalogue | replaces the workspace |
| Job | *show me what is in RVA23* | *build from RVA23* |

They stay independent deliberately: highlighting RVA23 to read it must not overwrite a configuration in progress, and seeding a configuration must not re-filter the catalogue being picked from. `risc_v_visualizer.jsx` already carries a comment explaining why the seed replaces rather than merges — mixing would "silently produce a configuration matching neither".

So this is a labelling defect, not an architectural one.

## Change

The filter row label goes from **Profile** to **Highlight**, and each chip gains a title: *"Highlight the extensions in RVA23 — does not change your ISA configuration"*.

One short word, not "Filter by profile": the comment above that row records it already overran at 320px with the old label plus four buttons, and a longer label would regress narrow viewports. Verified at a 500px viewport — no horizontal overflow.

## What I did not change

I first added a "Replaces the current selection" hint under the builder's menu header. On rendering it, the menu already ends with *"Replaces the current selection. Dependencies are resolved automatically, so the result may include more than the profile lists."* — the hint duplicated that sentence verbatim, so it was dropped. The builder side already explains itself; only the main frame was ambiguous.

## Verification

Checked in a browser rather than by assertion, per `AGENTS.md`:

- label renders, `textTransform: uppercase` applies, row is 355px with no body overflow
- both chip titles read correctly
- `npm test` 235 pass, `npm run lint` and `npm run build` clean

## Separate finding, not fixed here

At a 500px viewport the "Start from profile" dropdown is clipped off the left edge — its bounding box starts at `-108`. Pre-existing and horizontal, so unrelated to this change, but worth its own issue.