### PR TITLE
fix: keep the profile menu inside the viewport

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -632,6 +632,34 @@ const RISCVExplorer = () => {
   const [builderMode, setBuilderMode] = useState(false);
   const [workspacePanelOpen, setWorkspacePanelOpen] = useState(false);
   const [profileMenuOpen, setProfileMenuOpen] = useState(false);
+  const profileMenuRef = React.useRef(null);
+
+  // Keep the profile menu inside the viewport (#232).
+  //
+  // It is absolutely positioned against a trigger that moves as the toolbar
+  // wraps, so no fixed anchor works: right-aligned it ran off the left edge at
+  // 500px, left-aligned it ran off the right edge at 360px. position: fixed is
+  // not available either — .builder-toolbar and .riscv-toolbar both set
+  // backdrop-filter, which makes them the containing block for fixed
+  // descendants, so the menu would clamp to the toolbar rather than the screen.
+  // So measure once on open and shift it back into view.
+  React.useLayoutEffect(() => {
+    if (!profileMenuOpen) return undefined;
+    const clamp = () => {
+      const el = profileMenuRef.current;
+      if (!el) return;
+      el.style.transform = 'none';
+      const rect = el.getBoundingClientRect();
+      const margin = 8;
+      let dx = 0;
+      if (rect.right > window.innerWidth - margin) dx = window.innerWidth - margin - rect.right;
+      if (rect.left + dx < margin) dx = margin - rect.left;
+      el.style.transform = dx ? `translateX(${Math.round(dx)}px)` : 'none';
+    };
+    clamp();
+    window.addEventListener('resize', clamp);
+    return () => window.removeEventListener('resize', clamp);
+  }, [profileMenuOpen]);
   const [quickExportOpen, setQuickExportOpen] = useState(false);
   const [quickExportIncludeInstr, setQuickExportIncludeInstr] = useState(true);
 
@@ -2198,6 +2226,7 @@ const RISCVExplorer = () => {
 
                             {profileMenuOpen && (
                               <div
+                                ref={profileMenuRef}
                                 className="builder-menu"
                                 style={{
                                   position: 'absolute',
@@ -2207,7 +2236,8 @@ const RISCVExplorer = () => {
                                   display: 'flex',
                                   flexDirection: 'column',
                                   borderRadius: 10,
-                                  minWidth: 300,
+                                  minWidth: 'min(300px, calc(100vw - 24px))',
+                                  maxWidth: 'calc(100vw - 24px)',
                                   overflow: 'hidden',
                                 }}
                               >


### PR DESCRIPTION
Closes #232.

The "Start from profile" dropdown rendered partly off-screen on narrow viewports — at 500px its bounding box started at `-108`. The profile names were cut off, and so was the footer explaining that the action replaces the current selection, so on a phone the builder's most destructive control lost its warning.

## Why the simple fixes do not work

**No static anchor works.** The menu is absolutely positioned against a trigger that moves as the toolbar wraps:

| Anchor | 500px | 360px |
|---|---|---|
| `right: 0` (original) | overflows left (`-108`) | — |
| `left: 0` | fine | overflows right (`472` vs `360`) |

**`position: fixed` is unavailable.** Both `.builder-toolbar` (`backdrop-filter: blur(24px)`, plus a transform) and `.riscv-toolbar` (`blur(8px)`) are ancestors, and an element with `backdrop-filter` becomes the containing block for `fixed` descendants. The menu would clamp to the toolbar rather than the viewport — the same stacking trap that has bitten this file before.

## The change

Measure the menu when it opens and translate it back inside the viewport with an 8px margin, re-running on resize. The anchor stays `right: 0`, so desktop rendering is byte-identical — the computed shift is zero there.

## Verification

Checked in a browser at three viewports, per `AGENTS.md`:

| Viewport | Menu box | Shift applied | Clipped |
|---|---|---|---|
| 360 | 8 → 308 | `translateX(25px)` | no |
| 500 | 8 → 308 | `translateX(117px)` | no |
| 1440 | 1098 → 1398 | none | no |

At 360 every profile row is fully inside the viewport and the complete footer is readable. No page overflow at any width.

`npm test` 235 pass, lint and build clean.