### PR TITLE
feat: let a configuration choose its oneOf parameters

### DIFF
--- a/src/WorkspacePanel.jsx
+++ b/src/WorkspacePanel.jsx
@@ -65,6 +65,8 @@ export default function WorkspacePanel({
   onSelectInstruction,
   seedProfile,
   profileOptional,
+  paramChoices,
+  onSetParam,
 }) {
   const [marchTab, setMarchTab] = React.useState('encode');
   const [marchInput, setMarchInput] = React.useState('');
@@ -162,7 +164,9 @@ export default function WorkspacePanel({
     const { yaml } = buildIsaConfigYaml(
       Array.from(workspaceIds),
       allExts,
-      format === 'landscape' ? { includeInstructions } : { format },
+      format === 'landscape'
+        ? { includeInstructions, paramChoices }
+        : { format, paramChoices },
     );
     const blob = new Blob([yaml], { type: 'text/yaml' });
     const url = URL.createObjectURL(blob);
@@ -890,12 +894,48 @@ export default function WorkspacePanel({
                             <span style={{ fontFamily: 'monospace', fontSize: 11, color: 'var(--riscv-text)' }}>{prm.name}</span>
                             <span style={{ fontFamily: 'monospace', fontSize: 11, color: 'var(--riscv-gold)' }}>
                               {prm.kind === 'greaterThanOrEqual' ? `≥ ${prm.value}`
-                                : Array.isArray(prm.value) ? prm.value.length === 1 ? String(prm.value[0]) : `one of ${prm.value.length}`
-                                : String(prm.value)}
+                                : prm.kind === 'oneOf' && Array.isArray(prm.value)
+                                  ? (paramChoices?.[prm.name] ?? `choose one of ${prm.value.length}`)
+                                  : Array.isArray(prm.value) ? prm.value.join(', ') : String(prm.value)}
                             </span>
                           </div>
+                          {/* A oneOf constraint is the only kind that leaves a
+                              decision open — equal and includes are pinned by the
+                              extension that asks for them. Rendering the options
+                              as a dead "one of 2" was the whole of #216. */}
+                          {prm.kind === 'oneOf' && Array.isArray(prm.value) && prm.value.length > 1 && (
+                            <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', marginTop: 6 }}>
+                              {prm.value.map((option) => {
+                                const active = paramChoices?.[prm.name] === option;
+                                return (
+                                  <button
+                                    key={String(option)}
+                                    type="button"
+                                    onClick={() => onSetParam(prm.name, active ? null : option)}
+                                    aria-pressed={active}
+                                    title={active ? 'Clear this choice' : `Set ${prm.name} to ${option}`}
+                                    style={{
+                                      fontSize: 10, fontFamily: 'monospace', padding: '3px 8px',
+                                      borderRadius: 6, cursor: 'pointer', textAlign: 'left',
+                                      border: `1px solid ${active ? 'rgba(245,197,66,0.6)' : 'var(--riscv-tint-4)'}`,
+                                      background: active ? 'rgba(245,197,66,0.18)' : 'var(--riscv-tint-2)',
+                                      color: active ? 'var(--riscv-gold)' : 'var(--riscv-text-2)',
+                                    }}
+                                  >
+                                    {String(option)}
+                                  </button>
+                                );
+                              })}
+                            </div>
+                          )}
                           <div style={{ fontSize: 10, color: 'var(--riscv-text-3)', marginTop: 3 }}>
-                            required by {prm.from.join(', ')}
+                            {prm.kind === 'oneOf'
+                              ? `narrowed to these by ${prm.from.join(', ')}`
+                              : prm.kind === 'greaterThanOrEqual'
+                                // VLEN is settable — just not here. Saying it was
+                                // fixed would contradict the chips above it.
+                                ? `floor set by ${prm.from.join(', ')} — raise it with the buttons above`
+                                : `fixed by ${prm.from.join(', ')} — not separately settable`}
                           </div>
                           {prm.conflict && (
                             <div style={{ fontSize: 10, color: '#ff7a8a', marginTop: 4 }}>{prm.conflict}</div>

--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -107,6 +107,10 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
   const {
     includeInstructions = false,
     format = 'landscape',
+    // Values the user picked for oneOf parameters. A constraint list without
+    // the pick is not a configuration — the point of choosing is that the
+    // choice survives leaving the tool.
+    paramChoices = {},
   } = typeof options === 'boolean' ? { includeInstructions: options } : options;
   const warnings = [];
 
@@ -480,6 +484,10 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
         : (typeof prm.value === 'string' ? JSON.stringify(prm.value) : prm.value);
       lines.push(`    value: ${value}`);
       lines.push(`    required_by: [${prm.from.join(', ')}]`);
+      if (prm.kind === 'oneOf' && Object.prototype.hasOwnProperty.call(paramChoices, prm.name)) {
+        const picked = paramChoices[prm.name];
+        lines.push(`    chosen: ${typeof picked === 'string' ? JSON.stringify(picked) : picked}`);
+      }
       if (prm.reason) lines.push(`    reason: ${JSON.stringify(prm.reason)}`);
       // A conflict is left in the file on purpose: silently dropping it would
       // produce a configuration that looks valid and is not.

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -638,6 +638,18 @@ const RISCVExplorer = () => {
   // optional extensions (#217). Null once the workspace is cleared: the offer
   // only makes sense while the configuration still descends from the profile.
   const [seedProfile, setSeedProfile] = useState(null);
+  // Chosen values for oneOf parameters (#216). Only oneOf leaves a decision
+  // open — equal and includes are pinned by whichever extension asks for them —
+  // so this holds the handful of genuine choices, keyed by parameter name.
+  const [paramChoices, setParamChoices] = useState({});
+  const handleSetParam = React.useCallback((name, value) => {
+    setParamChoices((prev) => {
+      const next = { ...prev };
+      if (value === null || value === undefined) delete next[name];
+      else next[name] = value;
+      return next;
+    });
+  }, []);
 
   // Keep the profile menu inside the viewport (#232).
   //
@@ -2326,6 +2338,7 @@ const RISCVExplorer = () => {
                                 onClick={() => {
                                   setWorkspaceIds(new Set());
                                   setSeedProfile(null);
+                                  setParamChoices({});
                                 }}
                                 className="builder-action-rose flex-1 flex items-center justify-center py-1.5 text-rose-300 hover:bg-rose-500/30 hover:text-rose-100 hover:shadow-[0_0_12px_rgba(244,63,94,0.3)] transition-all duration-300 rounded-lg"
                               >
@@ -4820,6 +4833,8 @@ const RISCVExplorer = () => {
         onSetVlen={handleSetVlen}
         seedProfile={seedProfile}
         profileOptional={PROFILE_OPTIONAL}
+        paramChoices={paramChoices}
+        onSetParam={handleSetParam}
         onAddId={(id) => addWorkspaceIdsSmart(id, true)}
         onRemoveId={(id) =>
           setWorkspaceIds((prev) => {
@@ -4846,6 +4861,7 @@ const RISCVExplorer = () => {
         onClear={() => {
           setWorkspaceIds(new Set());
           setSeedProfile(null);
+          setParamChoices({});
         }}
         onLoadIds={(ids) => {
           setWorkspaceIds(new Set()); // clear

--- a/tests/isa-graph.test.mjs
+++ b/tests/isa-graph.test.mjs
@@ -30,6 +30,7 @@ import {
   vlenExtension,
 } from '../src/isaGraph.js';
 import { PROFILES } from '../src/profiles.js';
+import { buildIsaConfigYaml } from '../src/exportUtils.js';
 
 const catalogIds = (() => {
   const file = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'src', 'riscv_extensions.json');
@@ -444,4 +445,30 @@ test('a vector extension holds the VLEN floor above a lower request', () => {
   desired.add('Zvl32b');
   const { resolved } = resolveSelection({ selected: [...desired], base: 'RV64I' });
   assert.equal(impliedVlen(resolved), 64, 'Zve64x should hold the floor at 64');
+});
+
+test('a chosen oneOf value reaches the exported configuration', () => {
+  // resolveParams narrows the field but cannot pick: LRSC_RESERVATION_STRATEGY
+  // rendered as "one of 2" with no way to choose, which was #216. A choice that
+  // does not survive export is not a configuration decision, just a highlight.
+  // A base ISA is required or the export refuses to build.
+  const ids = ['RV64I', 'Za64rs', 'Zic64b'];
+  const picked = 'reserve naturally-aligned 64-byte region';
+  const catalog = JSON.parse(
+    fs.readFileSync(path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'src', 'riscv_extensions.json'), 'utf8'),
+  );
+  const allExts = Object.values(catalog).flat();
+
+  const { yaml } = buildIsaConfigYaml(ids, allExts, {
+    paramChoices: { LRSC_RESERVATION_STRATEGY: picked },
+  });
+  assert.match(yaml, /LRSC_RESERVATION_STRATEGY:/);
+  assert.match(yaml, new RegExp(`chosen: "${picked}"`));
+
+  // Without a choice the field is absent rather than guessed at.
+  const { yaml: bare } = buildIsaConfigYaml(ids, allExts, {});
+  assert.ok(!bare.includes('chosen:'), 'nothing should be chosen when the user has not chosen');
+
+  // A parameter with no decision to make never gains one.
+  assert.match(bare, /CACHE_BLOCK_SIZE:/);
 });


### PR DESCRIPTION
Closes #216.

The report is that nothing but VLEN can be set. The parameters were already *listed* — but only one of the four constraint kinds leaves a decision open, and that one had no control.

| Kind | Count | Decision to make? | Before |
|---|---|---|---|
| `equal` | 6 | No — the extension pins it | shown, correctly unsettable |
| `includes` | 7 | No | shown, correctly unsettable |
| `greaterThanOrEqual` | 6 | Yes, all VLEN | already settable via the Zvl\*b buttons |
| `oneOf` | 3 | **Yes** | rendered as the dead text **"one of 2"** |

`CACHE_BLOCK_SIZE`, named in the report, is `equal = 64` imposed by `Zic64b`. It genuinely cannot be set — but the UI never said so, so it read as missing functionality rather than a fixed value.

## Changes

**`oneOf` parameters are now buttons.** `LRSC_RESERVATION_STRATEGY` and `U_MODE_ENDIANNESS` can be chosen; clicking the active one clears it.

**The pick survives export.** A choice that vanishes when the configuration leaves the tool is a highlight, not a decision. `buildIsaConfigYaml` takes a `paramChoices` option and emits `chosen:` beside the constraint. Absent a choice, no `chosen:` line is written rather than a guess.

**The others explain themselves** — "fixed by `Zicclsm` — not separately settable" instead of a bare value.

## Corrected during browser verification

The footer initially labelled VLEN "fixed … not separately settable", directly contradicting the VLEN buttons rendered immediately above it. It now reads "floor set by … — raise it with the buttons above". Caught by looking at the rendered page, not by a test.

## Verification

- Browser at 1440px: the two `LRSC_RESERVATION_STRATEGY` options render as buttons; clicking one moves `aria-pressed` false → true; the VLEN wording no longer contradicts itself
- New test asserts a chosen value reaches the YAML, that nothing is chosen when the user has not chosen, and that a parameter with no decision never gains one
- 240 pass, lint and build clean

## Note

`resolveParams` in `isaGraph.js` already did the hard part — merging floors, unions, intersections and reporting conflicts. This is a view over data that was already correct.