### PR TITLE
chore: v1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "riscv-extensions-landscape",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "riscv-extensions-landscape",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "lucide-react": "^0.294.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riscv-extensions-landscape",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "",
   "main": "index.js",
   "homepage": "https://riscv.github.io/riscv-extensions-landscape/",


### PR DESCRIPTION
Fourteen commits since `v1.1.1`. A minor rather than a patch: six add user-facing capability.

## New

| | |
|---|---|
| #222 | Expanded full-screen instruction details modal |
| #223 | Comparison dock and enhanced diff matrix |
| #234 | A profile's optional extensions offered in the builder |
| #235 | `oneOf` parameters are choosable and reach the exported YAML |
| #221 | UDB architecture configuration export for riscv-arch-test |
| #219 | UDB extension version captured during sync |

## Fixed

| | |
|---|---|
| #231 | Profile filter labelled for what it does — it highlights, it does not select |
| #233 | Profile menu no longer renders off-screen on narrow viewports |
| #228 | Light-theme classes the expand modal left half-remapped |
| #224 | Export popover readable on light |

## Data and tooling

| | |
|---|---|
| #230, #220 | Extension data synced from riscv-unified-db |
| #229 | The sync bot's commits now pass the DCO gate |
| #227 | `AGENTS.md` for AI agent contributors |

Also in #234, found while cross-checking profiles against UDB: **RVB23 carried no bit-manipulation extensions**, so the B profile generated a `-march` string without any. Confirmed against the ratified `rvb23-profile.adoc` and fixed.

240 tests pass; CI validates every generated `-march` against clang.