### PR TITLE
feat: hold a profile's mandatory set in place, and say what the tool is for

### DIFF
--- a/src/WorkspacePanel.jsx
+++ b/src/WorkspacePanel.jsx
@@ -67,6 +67,8 @@ export default function WorkspacePanel({
   profileOptional,
   paramChoices,
   onSetParam,
+  baselineLocked,
+  onToggleBaseline,
 }) {
   const [marchTab, setMarchTab] = React.useState('encode');
   const [marchInput, setMarchInput] = React.useState('');
@@ -563,6 +565,37 @@ export default function WorkspacePanel({
           {/* Populated state */}
           {!isEmpty && (
             <Section label="Selected Extensions" count={workspaceIds.size} icon={<Cpu size={11} />}>
+              {seedProfile && (
+                <div style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                  gap: 10, marginBottom: 10, padding: '7px 10px', borderRadius: 7,
+                  background: 'var(--riscv-tint-1)', border: '1px solid var(--riscv-tint-3)',
+                }}>
+                  <span style={{ fontSize: 10.5, color: 'var(--riscv-text-3)', lineHeight: 1.45 }}>
+                    {baselineLocked
+                      ? `The ${seedProfile} mandatory set is held in place — removing one would leave a configuration that is no longer ${seedProfile}.`
+                      : `The ${seedProfile} baseline is released. Removing a mandatory extension will leave a configuration that no longer satisfies ${seedProfile}.`}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={onToggleBaseline}
+                    aria-pressed={baselineLocked}
+                    title={baselineLocked
+                      ? `Allow removing extensions ${seedProfile} mandates`
+                      : `Hold the ${seedProfile} mandatory set in place again`}
+                    style={{
+                      flexShrink: 0, fontSize: 10, fontWeight: 700, letterSpacing: '0.04em',
+                      textTransform: 'uppercase', padding: '4px 9px', borderRadius: 6,
+                      cursor: 'pointer',
+                      border: `1px solid ${baselineLocked ? 'rgba(245,197,66,0.5)' : 'var(--riscv-tint-4)'}`,
+                      background: baselineLocked ? 'rgba(245,197,66,0.15)' : 'var(--riscv-tint-2)',
+                      color: baselineLocked ? 'var(--riscv-gold)' : 'var(--riscv-text-2)',
+                    }}
+                  >
+                    {baselineLocked ? 'Locked' : 'Released'}
+                  </button>
+                </div>
+              )}
               <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
                 {workspaceExts.map(ext => (
                   <ExtChip

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -642,6 +642,12 @@ const RISCVExplorer = () => {
   // open — equal and includes are pinned by whichever extension asks for them —
   // so this holds the handful of genuine choices, keyed by parameter name.
   const [paramChoices, setParamChoices] = useState({});
+  // Whether the seeding profile's mandatory set is held in place (#214).
+  // Certification work needs a floor that cannot be silently reverted — dropping
+  // H from RVA23 leaves something that is no longer RVA23 — but exploring what a
+  // profile would be without one of its extensions is also legitimate, so the
+  // floor is releasable rather than absolute.
+  const [baselineLocked, setBaselineLocked] = useState(true);
   const handleSetParam = React.useCallback((name, value) => {
     setParamChoices((prev) => {
       const next = { ...prev };
@@ -683,6 +689,19 @@ const RISCVExplorer = () => {
   // Smart lock: live reverse-lookup of dependencies
   const lockedExtensions = React.useMemo(() => {
     const locked = new Map(); // ext -> [things requiring it]
+
+    // The seeding profile is itself a reason an extension cannot be removed.
+    // Same map, same UI: tiles and the panel already refuse removal and name
+    // whatever holds a lock, so the floor needs no separate treatment.
+    if (seedProfile && baselineLocked) {
+      for (const id of PROFILES[seedProfile] || []) {
+        if (workspaceIds.has(id)) {
+          if (!locked.has(id)) locked.set(id, []);
+          locked.get(id).push(seedProfile);
+        }
+      }
+    }
+
     const selected = Array.from(workspaceIds);
     for (const ext of selected) {
       const deps = SMART_DEPENDENCIES[ext] || [];
@@ -694,7 +713,7 @@ const RISCVExplorer = () => {
       }
     }
     return locked;
-  }, [workspaceIds]);
+  }, [workspaceIds, seedProfile, baselineLocked]);
 
   // Smart dependency and mutually-exclusive handler
   const addWorkspaceIdsSmart = React.useCallback(
@@ -1895,6 +1914,27 @@ const RISCVExplorer = () => {
                 </div>
               </div>
 
+              {/* What the tool is, and what to do with it (#209). The front page
+                  named the subject and showed counts, but never said what the
+                  page was for or how to drive it — a visitor had to infer the
+                  whole interaction from the controls. Two lines, above the
+                  controls they describe, rather than a tour nobody reads. */}
+              <p
+                className="riscv-usage mt-3 mb-1 text-[12.5px] leading-relaxed"
+                style={{ color: 'var(--riscv-text-2)', maxWidth: '76ch' }}
+              >
+                Browse every ratified RISC-V extension, its instructions and their
+                encodings.{' '}
+                <span style={{ color: 'var(--riscv-text-3)' }}>
+                  Select a tile for details, filter by profile or manual volume, and
+                  turn on <strong style={{ color: 'var(--riscv-text-2)', fontWeight: 600 }}>ISA Builder</strong>{' '}
+                  to assemble a configuration and get a validated{' '}
+                  <code style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '0.95em' }}>-march</code>{' '}
+                  string. <strong style={{ color: 'var(--riscv-text-2)', fontWeight: 600 }}>Compare</strong>{' '}
+                  puts extensions, instructions or profiles side by side.
+                </span>
+              </p>
+
               {/* Controls Area.
                   items-end right-aligns children, so a child wider than this
                   column is pushed off the LEFT edge rather than overflowing the
@@ -2283,6 +2323,7 @@ const RISCVExplorer = () => {
                                       setWorkspaceIds(new Set());
                                       addWorkspaceIdsSmart(list);
                                       setSeedProfile(name);
+                                      setBaselineLocked(true);
                                       setProfileMenuOpen(false);
                                     }}
                                     style={{
@@ -2339,6 +2380,7 @@ const RISCVExplorer = () => {
                                   setWorkspaceIds(new Set());
                                   setSeedProfile(null);
                                   setParamChoices({});
+                                  setBaselineLocked(true);
                                 }}
                                 className="builder-action-rose flex-1 flex items-center justify-center py-1.5 text-rose-300 hover:bg-rose-500/30 hover:text-rose-100 hover:shadow-[0_0_12px_rgba(244,63,94,0.3)] transition-all duration-300 rounded-lg"
                               >
@@ -4835,6 +4877,8 @@ const RISCVExplorer = () => {
         profileOptional={PROFILE_OPTIONAL}
         paramChoices={paramChoices}
         onSetParam={handleSetParam}
+        baselineLocked={baselineLocked}
+        onToggleBaseline={() => setBaselineLocked((v) => !v)}
         onAddId={(id) => addWorkspaceIdsSmart(id, true)}
         onRemoveId={(id) =>
           setWorkspaceIds((prev) => {
@@ -4862,6 +4906,7 @@ const RISCVExplorer = () => {
           setWorkspaceIds(new Set());
           setSeedProfile(null);
           setParamChoices({});
+          setBaselineLocked(true);
         }}
         onLoadIds={(ids) => {
           setWorkspaceIds(new Set()); // clear


### PR DESCRIPTION
Closes #214. Closes #209.

Two small gaps from the tech-preview review, taken together because both are a few lines.

## #214 — the profile baseline

Seeded from RVA23, the builder allowed `H` to be removed, leaving a configuration that no longer satisfies RVA23 while still presenting itself as descended from it. Certification use cases need that floor to hold.

This turned out to be cheap because the pieces already existed: `lockedExtensions` is a `Map<ext, [reasons]>` already threaded to tiles and the panel, already disabling removal and naming whatever holds the lock, and `seedProfile` arrived with #234. The profile is simply another reason:

```
H  →  "Required by RVA23, Sha, Shtvala, Shvstvala"   (remove disabled)
```

**Releasable, not absolute.** Exploring what RVA23 would be without one of its extensions is legitimate, so the panel carries a Locked / Released control with a line stating the consequence. Releasing drops the profile floor and **leaves genuine dependency locks intact** — 29 chips stay locked because F is required by D and so on, which is correct.

The lock resets to held whenever a new profile seeds or the workspace is cleared.

## #209 — what the tool is for

The front page named its subject and showed counts, but never said what the page does or how to drive it. Two lines above the controls, naming the same controls the reader is about to see — `ISA Builder`, `Compare` — rather than a tour nobody reads.

## Verification

Browser-checked per `AGENTS.md`:

| Check | Result |
|---|---|
| `H` removable while locked | no — disabled, reason names RVA23 |
| Toggle → Released | `aria-pressed` true → false, warning text swaps |
| `V` removable after release | yes |
| Dependency locks survive release | yes — 29 chips still locked |
| Usage text at 390px | 366px wide, inside the viewport, no page overflow |

240 tests pass; lint and build clean.

## Note

The chip tooltip reads "Required by RVA23 — remove dependent first". The trailing clause is `ExtChip`'s generic wording and reads slightly oddly when the holder is a profile rather than an extension. Left alone rather than special-cased; the part that matters names the profile.