### PR TITLE
chore: finish the rename in the proposal and workflow step names

### DIFF
--- a/.github/workflows/check-opcodes-drift.yml
+++ b/.github/workflows/check-opcodes-drift.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Checkout landscape repo
+      - name: Checkout the explorer repo
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Clone riscv-opcodes

--- a/.github/workflows/sync-udb-extensions.yml
+++ b/.github/workflows/sync-udb-extensions.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout landscape repo
+      - name: Checkout the explorer repo
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Clone riscv-unified-db

--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -1,4 +1,4 @@
-# RISC-V Extensions Landscape: Project Proposal
+# RISC-V ISA Explorer: Project Proposal
 
 ## 1. Problem Statement
 
@@ -16,7 +16,7 @@ raw data files that require tooling to interpret.
 
 ## 2. Project Vision
 
-The **RISC-V Extensions Landscape** is a web-based, interactive visualization and
+The **RISC-V ISA Explorer** is a web-based, interactive visualization and
 reference tool that makes the full RISC-V extension and instruction catalog
 accessible, searchable, and verifiable in a single page.
 


### PR DESCRIPTION
Stragglers from #238 and #239.

`PROPOSAL.md` kept the old display name in its title and opening paragraph — the slug pass replaced the URL there but not the name. Two workflow steps still read "Checkout landscape repo".

No remaining occurrences of the old name in tracked files.

240 tests pass, lint clean.