### PR TITLE
feat: add the kapa.ai assistant to the page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -34,6 +34,54 @@
        favicon.svg dropped into public/ would 404 in production without
        anything failing. One source, and it cannot silently go missing. -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%22-4 -4 85 85%22%3E%3Cpath d=%22M42.853 23.963c0 11.134-6.752 21.253-19.904 23.623l18.554 21.928 1.678-2.354 33.414-47.25V.005H22.273c13.828 1.35 20.58 12.818 20.58 23.958%22 fill=%22%23f3ab0d%22/%3E%3Cpath d=%22M52.292 73.221l24.631-34.417V76.6h-27.1zM4.728 37.455h12.818c9.44 0 14.172-6.74 14.172-13.492 0-6.758-4.732-13.165-14.172-13.165H0V76.6h32.738L4.728 42.858v-5.403M189.29 12.823h11.138v52.309h-11.139v-52.31m77.507 40.863l-57.933-.033v11.48h58.37c4.383 0 8.107-1.696 11.139-4.728 3.033-3.03 4.728-6.752 4.728-11.135s-1.695-8.09-4.728-11.14c-3.032-3.032-6.756-4.71-11.139-4.71l-42.462-.318a4.581 4.581 0 01-4.547-4.547 4.582 4.582 0 014.577-4.549l58.299-.042v-11.14h-58.373c-4.399 0-8.107 1.696-11.135 4.728-3.032 3.033-4.73 6.757-4.73 11.14 0 4.381 1.698 8.09 4.73 11.134 3.028 3.033 6.736 4.382 11.135 4.382l42.414.002a4.549 4.549 0 014.55 4.566 4.893 4.893 0 01-4.895 4.91m47.677-40.862h48.255v11.14h-48.255c-4.037 0-7.416 1.332-10.465 4.382-3.033 3.032-4.381 6.407-4.381 10.46 0 4.036 1.348 7.415 4.381 10.464 3.05 3.028 6.428 4.383 10.465 4.383h48.255l-.003 11.48h-48.228c-7.085 0-13.176-2.716-18.249-7.774-5.057-5.061-7.416-11.138-7.416-18.224 0-7.082 2.359-13.164 7.416-18.22 5.073-5.387 11.139-8.091 18.225-8.091M181.199 65.132L166.353 44.54c4.036-.334 7.415-1.683 10.119-4.716 3.032-3.045 4.727-6.753 4.727-11.134 0-4.383-1.695-8.107-4.727-11.14-3.033-3.032-6.757-4.728-11.14-4.728h-58.374v52.309h11.14V44.54h34.417l14.846 20.59zM164.665 33.83l-46.567-.083v-9.439l47.03-.095a4.6 4.6 0 014.608 4.577 5.062 5.062 0 01-5.07 5.04%22 fill=%22%23283272%22/%3E%3Cpath d=%22M418.399 65.132l-30.567-52.31h13.084l23.892 41.503 23.907-41.502h12.882l-30.381 52.309m-61.732-31.055h21.93v10.13h-21.93v-10.13%22 fill=%22%23f3ab0d%22/%3E%3Cpath d=%22M473.564 20.822h.88c1.03 0 1.861-.342 1.861-1.174 0-.734-.538-1.224-1.713-1.224-.49 0-.832.049-1.028.098zm-.05 4.553h-1.86v-8.028c.735-.146 1.763-.244 3.085-.244 1.517 0 2.202.244 2.79.587.44.343.782.979.782 1.762 0 .882-.684 1.567-1.664 1.86v.098c.784.293 1.224.881 1.469 1.958.245 1.224.392 1.714.587 2.007h-2.007c-.244-.293-.39-1.028-.636-1.958-.147-.881-.636-1.273-1.664-1.273h-.881zm-4.943-4.21c0 3.574 2.642 6.413 6.265 6.413 3.525 0 6.119-2.84 6.119-6.363 0-3.574-2.594-6.462-6.167-6.462-3.575 0-6.217 2.888-6.217 6.413zm14.44 0c0 4.553-3.574 8.126-8.223 8.126-4.601 0-8.273-3.573-8.273-8.125 0-4.455 3.672-8.029 8.273-8.029 4.65 0 8.223 3.574 8.223 8.029%22 fill=%22%23283272%22/%3E%3C/svg%3E">
+  <!-- kapa.ai assistant: an AI Q&A widget over the RISC-V documentation corpus,
+       so a question raised while building a config can be answered without
+       leaving the page.
+
+       The website id is a public client-side identifier, not a secret: kapa
+       gates question submission server-side on the domain allowlist configured
+       in the dashboard, so this string is inert anywhere but riscv.github.io.
+
+       data-color-scheme-selector points the widget at the same [data-theme]
+       attribute the app writes on <html> (see risc_v_visualizer.jsx), so the
+       widget follows the theme toggle instead of shipping its own.
+
+       Ctrl/Cmd+K is deliberately NOT handed to kapa - the app already binds it
+       to focus the extension search.
+
+       The launcher is resized down from kapa's default: its label ships at
+       18px in a fixed-width button, which clips "Ask AI" and makes the whole
+       control shout over a dense catalogue page. Sizing the label and letting
+       the button size to its content gives a ~62x57 chip instead of 72x80.
+
+       The logo is inlined for the same reason as the favicon above: the build
+       has no copy plugin, so a file dropped into public/ would 404 in
+       production without anything failing.
+
+       It is the RISC-V mark alone, not the stacked lockup: kapa paints it at
+       32px, where a 1.28:1 wordmark turns to mush, and the modal header already
+       spells the product name out beside it. The mark sits on its own navy chip
+       because kapa has no dark-mode logo attribute and the widget follows the
+       theme toggle - a bare mark would lose its navy strokes on the dark modal
+       and its white ones on the light modal. The chip reads on both. -->
+  <script
+    async
+    src="https://widget.kapa.ai/kapa-widget.bundle.js"
+    data-website-id="6105ba2e-b339-4c3e-83a2-3867bcc2e75e"
+    data-project-name="RISC-V ISA Explorer"
+    data-project-color="#2C356D"
+    data-project-logo="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%22-16%20-16%20109%20109%22%3E%3Crect%20x%3D%22-16%22%20y%3D%22-16%22%20width%3D%22109%22%20height%3D%22109%22%20rx%3D%2224%22%20fill%3D%22%232C356D%22%2F%3E%3Cpath%20d%3D%22M42.853%2023.963c0%2011.134-6.752%2021.253-19.904%2023.623l18.554%2021.928%201.678-2.354%2033.414-47.25V.005H22.273c13.828%201.35%2020.58%2012.818%2020.58%2023.958%22%20fill%3D%22%23F4B01B%22%2F%3E%3Cpath%20d%3D%22M52.292%2073.221l24.631-34.417V76.6h-27.1zM4.728%2037.455h12.818c9.44%200%2014.172-6.74%2014.172-13.492%200-6.758-4.732-13.165-14.172-13.165H0V76.6h32.738L4.728%2042.858v-5.403M189.29%2012.823h11.138v52.309h-11.139v-52.31m77.507%2040.863l-57.933-.033v11.48h58.37c4.383%200%208.107-1.696%2011.139-4.728%203.033-3.03%204.728-6.752%204.728-11.135s-1.695-8.09-4.728-11.14c-3.032-3.032-6.756-4.71-11.139-4.71l-42.462-.318a4.581%204.581%200%2001-4.547-4.547%204.582%204.582%200%20014.577-4.549l58.299-.042v-11.14h-58.373c-4.399%200-8.107%201.696-11.135%204.728-3.032%203.033-4.73%206.757-4.73%2011.14%200%204.381%201.698%208.09%204.73%2011.134%203.028%203.033%206.736%204.382%2011.135%204.382l42.414.002a4.549%204.549%200%20014.55%204.566%204.893%204.893%200%2001-4.895%204.91m47.677-40.862h48.255v11.14h-48.255c-4.037%200-7.416%201.332-10.465%204.382-3.033%203.032-4.381%206.407-4.381%2010.46%200%204.036%201.348%207.415%204.381%2010.464%203.05%203.028%206.428%204.383%2010.465%204.383h48.255l-.003%2011.48h-48.228c-7.085%200-13.176-2.716-18.249-7.774-5.057-5.061-7.416-11.138-7.416-18.224%200-7.082%202.359-13.164%207.416-18.22%205.073-5.387%2011.139-8.091%2018.225-8.091M181.199%2065.132L166.353%2044.54c4.036-.334%207.415-1.683%2010.119-4.716%203.032-3.045%204.727-6.753%204.727-11.134%200-4.383-1.695-8.107-4.727-11.14-3.033-3.032-6.757-4.728-11.14-4.728h-58.374v52.309h11.14V44.54h34.417l14.846%2020.59zM164.665%2033.83l-46.567-.083v-9.439l47.03-.095a4.6%204.6%200%20014.608%204.577%205.062%205.062%200%2001-5.07%205.04%22%20fill%3D%22%23ffffff%22%2F%3E%3Cpath%20d%3D%22M418.399%2065.132l-30.567-52.31h13.084l23.892%2041.503%2023.907-41.502h12.882l-30.381%2052.309m-61.732-31.055h21.93v10.13h-21.93v-10.13%22%20fill%3D%22%23F4B01B%22%2F%3E%3Cpath%20d%3D%22M473.564%2020.822h.88c1.03%200%201.861-.342%201.861-1.174%200-.734-.538-1.224-1.713-1.224-.49%200-.832.049-1.028.098zm-.05%204.553h-1.86v-8.028c.735-.146%201.763-.244%203.085-.244%201.517%200%202.202.244%202.79.587.44.343.782.979.782%201.762%200%20.882-.684%201.567-1.664%201.86v.098c.784.293%201.224.881%201.469%201.958.245%201.224.392%201.714.587%202.007h-2.007c-.244-.293-.39-1.028-.636-1.958-.147-.881-.636-1.273-1.664-1.273h-.881zm-4.943-4.21c0%203.574%202.642%206.413%206.265%206.413%203.525%200%206.119-2.84%206.119-6.363%200-3.574-2.594-6.462-6.167-6.462-3.575%200-6.217%202.888-6.217%206.413zm14.44%200c0%204.553-3.574%208.126-8.223%208.126-4.601%200-8.273-3.573-8.273-8.125%200-4.455%203.672-8.029%208.273-8.029%204.65%200%208.223%203.574%208.223%208.029%22%20fill%3D%22%23ffffff%22%2F%3E%3C%2Fsvg%3E"
+    data-color-scheme-selector="[data-theme='dark']"
+    data-launcher-button-image-height="24"
+    data-launcher-button-image-width="24"
+    data-launcher-button-width="auto"
+    data-launcher-button-height="auto"
+    data-launcher-button-padding="9px 12px"
+    data-launcher-button-border-radius="14px"
+    data-launcher-button-label-font-size="12px"
+    data-launcher-button-label-line-height="1.1"
+    data-user-analytics-fingerprint-enabled="false"
+  ></script>
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
## What this changes

Adds the kapa.ai assistant to the page: an AI Q&A widget over the RISC-V
documentation corpus, reachable from an "Ask AI" launcher in the bottom-right
corner.

The whole integration is one `<script>` tag in `public/index.html`.
HtmlWebpackPlugin emits it into `dist/index.html` and the deploy job
force-pushes `dist/` wholesale, so neither the build nor the workflow needed
changing. The site sends no CSP, so there was nothing to allowlist on our side
either.

## Why

A question raised while assembling an ISA configuration ("what did RVA23 add
over RVA22?", "what does Zba actually give me?") currently means leaving the
tool to go and read a spec. This answers it in place, with citations back to
the source documents.

## How it was verified

Checked in Chrome against the production bundle (`npm run build` +
`python3 -m http.server -d dist`), and then against the **live site** by
injecting the identical tag into `https://riscv.github.io/riscv-isa-explorer/`
in-browser, to confirm the domain allowlist and question submission work on the
real origin before merging.

- Real questions answered end to end on both origins. On the live origin,
  "Which extensions does RVA23 require that RVA22 did not?" returned the
  correct RVA23S64 mandatory set (Ss1p13, Svnapot, Sstc, Sscofpmf, Ssnpm,
  Ssu64xl, Sha) with working source citations.
- Both themes, toggled live in both directions: the widget ground follows the
  app (`rgb(23,23,26)` dark, `rgb(255,255,255)` light) and the logo stays
  legible on each.
- Launcher checked on a dark page and a light page at desktop width.

Three deliberate departures from kapa's defaults, each with a reason:

- **`data-color-scheme-selector` points at `[data-theme='dark']`** - the same
  attribute the app already writes on `<html>`, so the widget follows the theme
  toggle rather than shipping a second, independent one.
- **Ctrl/Cmd+K is not handed to kapa.** The app already binds it to focus the
  extension search (`risc_v_visualizer.jsx:921`) and the widget would have
  stolen it.
- **Fingerprinting is off.** kapa enables browser fingerprinting by default,
  which is more identification than an anonymous reference page needs.

Two things needed design work rather than defaults:

- **The logo is the RISC-V mark on a navy chip, inlined as a data URI.**
  Inlined because the build has no copy plugin, exactly as the favicon comment
  above it explains. The mark alone because kapa paints it at 24px, where the
  stacked wordmark lockup turns to mush and duplicates the product name already
  printed beside it. On a chip because kapa has **no dark-mode logo attribute**
  while the widget follows the theme toggle - so a bare mark loses its white
  strokes on the light modal and its navy ones on the dark modal. The chip
  reads on both.
- **The launcher is sized down.** kapa's label ships at 18px inside a
  fixed-width button with `overflow: hidden`, which clipped "Ask AI" to
  "Ask A". Sizing the label and letting the button size to its content gives
  62x63 instead of 72x80, which sits better over a dense catalogue page.

- [x] `npm test` passes (240 pass, 1 skipped, 0 fail)
- [x] `npm run build` succeeds

## Sign-off

- [x] Every commit is signed off (`git commit -s`), per the [DCO](../DCO)
