### PR TITLE
chore: release v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "riscv-isa-explorer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "riscv-isa-explorer",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "lucide-react": "^0.294.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riscv-isa-explorer",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "",
   "main": "index.js",
   "homepage": "https://riscv.github.io/riscv-isa-explorer/",


### PR DESCRIPTION
## What this changes

Bumps `package.json` from 1.2.0 to 1.3.0 for the v1.3.0 tag. No source changes.

## Why

Eight changes have landed since v1.2.0, several of them new capability, so a minor bump: the rename to RISC-V ISA Explorer (#238, #239, #240), the profile mandatory-set lock (#237), the full-screen ISA builder studio (#244), the kapa.ai assistant (#241) and its draggable launcher (#245), and the atomics grouping fix (#246).

## How it was verified

Version touched through `npm version --no-git-tag-version` rather than by hand, so only the root package entries move: one line in `package.json` and the two root entries in `package-lock.json`. No dependency pin is altered.

- [x] `npm test` passes
- [x] `npm run build` succeeds

## Sign-off

- [x] Every commit is signed off (`git commit -s`), per the [DCO](../DCO)