### PR TITLE
data: finish the regrouping that #251 left half done

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -3241,7 +3241,7 @@ const RISCVExplorer = () => {
                           className="text-[11px] uppercase tracking-widest font-semibold"
                           style={{ color: 'var(--riscv-text-3)' }}
                         >
-                          Memory (Sv)
+                          Memory & Addressing
                         </h4>
                         <span className="text-[11px]" style={{ color: 'var(--riscv-text-3)' }}>
                           {extensions.s_mem.length}

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -23198,510 +23198,6 @@
       "state": "ratified",
       "ratification_date": "2024-07",
       "version": "1.0.0"
-    },
-    {
-      "id": "Zimop",
-      "name": "Zimop",
-      "short": "May-Be-Ops (NOP family)",
-      "tags": [
-        "rv_zimop"
-      ],
-      "desc": "Reserves encodings that simply write zero today, letting later extensions redefine them without breaking old code.",
-      "use": "Reserved NOP encodings for future",
-      "url": "https://docs.riscv.org/reference/isa/unpriv/zimop.html",
-      "instructions": {
-        "MOP.R.0": {
-          "encoding": "100000011100-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x81c04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.1": {
-          "encoding": "100000011101-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x81d04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.2": {
-          "encoding": "100000011110-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x81e04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.3": {
-          "encoding": "100000011111-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x81f04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.4": {
-          "encoding": "100001011100-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x85c04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.5": {
-          "encoding": "100001011101-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x85d04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.6": {
-          "encoding": "100001011110-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x85e04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.7": {
-          "encoding": "100001011111-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x85f04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.8": {
-          "encoding": "100010011100-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x89c04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.9": {
-          "encoding": "100010011101-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x89d04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.10": {
-          "encoding": "100010011110-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x89e04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.11": {
-          "encoding": "100010011111-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x89f04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.12": {
-          "encoding": "100011011100-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x8dc04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.13": {
-          "encoding": "100011011101-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x8dd04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.14": {
-          "encoding": "100011011110-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x8de04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.15": {
-          "encoding": "100011011111-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x8df04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.16": {
-          "encoding": "110000011100-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc1c04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.17": {
-          "encoding": "110000011101-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc1d04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.18": {
-          "encoding": "110000011110-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc1e04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.19": {
-          "encoding": "110000011111-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc1f04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.20": {
-          "encoding": "110001011100-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc5c04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.21": {
-          "encoding": "110001011101-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc5d04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.22": {
-          "encoding": "110001011110-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc5e04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.23": {
-          "encoding": "110001011111-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc5f04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.24": {
-          "encoding": "110010011100-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc9c04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.25": {
-          "encoding": "110010011101-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc9d04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.26": {
-          "encoding": "110010011110-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc9e04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.27": {
-          "encoding": "110010011111-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc9f04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.28": {
-          "encoding": "110011011100-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xcdc04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.29": {
-          "encoding": "110011011101-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xcdd04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.30": {
-          "encoding": "110011011110-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xcde04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.R.31": {
-          "encoding": "110011011111-----100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xcdf04073",
-          "mask": "0xfff0707f"
-        },
-        "MOP.RR.0": {
-          "encoding": "1000001----------100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x82004073",
-          "mask": "0xfe00707f"
-        },
-        "MOP.RR.1": {
-          "encoding": "1000011----------100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x86004073",
-          "mask": "0xfe00707f"
-        },
-        "MOP.RR.2": {
-          "encoding": "1000101----------100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x8a004073",
-          "mask": "0xfe00707f"
-        },
-        "MOP.RR.3": {
-          "encoding": "1000111----------100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0x8e004073",
-          "mask": "0xfe00707f"
-        },
-        "MOP.RR.4": {
-          "encoding": "1100001----------100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc2004073",
-          "mask": "0xfe00707f"
-        },
-        "MOP.RR.5": {
-          "encoding": "1100011----------100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xc6004073",
-          "mask": "0xfe00707f"
-        },
-        "MOP.RR.6": {
-          "encoding": "1100101----------100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xca004073",
-          "mask": "0xfe00707f"
-        },
-        "MOP.RR.7": {
-          "encoding": "1100111----------100-----1110011",
-          "variable_fields": [
-            "rd",
-            "rs1",
-            "rs2"
-          ],
-          "extension": [
-            "rv_zimop"
-          ],
-          "match": "0xce004073",
-          "mask": "0xfe00707f"
-        }
-      },
-      "state": "ratified",
-      "ratification_date": "2024-03",
-      "version": "1.0.0"
     }
   ],
   "z_crypto": [
@@ -28502,6 +27998,510 @@
       "instructions": {}
     },
     {
+      "id": "Zimop",
+      "name": "Zimop",
+      "short": "May-Be-Ops (NOP family)",
+      "tags": [
+        "rv_zimop"
+      ],
+      "desc": "Reserves encodings that simply write zero today, letting later extensions redefine them without breaking old code.",
+      "use": "Reserved NOP encodings for future",
+      "url": "https://docs.riscv.org/reference/isa/unpriv/zimop.html",
+      "instructions": {
+        "MOP.R.0": {
+          "encoding": "100000011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x81c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.1": {
+          "encoding": "100000011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x81d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.2": {
+          "encoding": "100000011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x81e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.3": {
+          "encoding": "100000011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x81f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.4": {
+          "encoding": "100001011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x85c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.5": {
+          "encoding": "100001011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x85d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.6": {
+          "encoding": "100001011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x85e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.7": {
+          "encoding": "100001011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x85f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.8": {
+          "encoding": "100010011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x89c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.9": {
+          "encoding": "100010011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x89d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.10": {
+          "encoding": "100010011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x89e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.11": {
+          "encoding": "100010011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x89f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.12": {
+          "encoding": "100011011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8dc04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.13": {
+          "encoding": "100011011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8dd04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.14": {
+          "encoding": "100011011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8de04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.15": {
+          "encoding": "100011011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8df04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.16": {
+          "encoding": "110000011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc1c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.17": {
+          "encoding": "110000011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc1d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.18": {
+          "encoding": "110000011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc1e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.19": {
+          "encoding": "110000011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc1f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.20": {
+          "encoding": "110001011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc5c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.21": {
+          "encoding": "110001011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc5d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.22": {
+          "encoding": "110001011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc5e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.23": {
+          "encoding": "110001011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc5f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.24": {
+          "encoding": "110010011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc9c04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.25": {
+          "encoding": "110010011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc9d04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.26": {
+          "encoding": "110010011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc9e04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.27": {
+          "encoding": "110010011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc9f04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.28": {
+          "encoding": "110011011100-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xcdc04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.29": {
+          "encoding": "110011011101-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xcdd04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.30": {
+          "encoding": "110011011110-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xcde04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.R.31": {
+          "encoding": "110011011111-----100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xcdf04073",
+          "mask": "0xfff0707f"
+        },
+        "MOP.RR.0": {
+          "encoding": "1000001----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x82004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.1": {
+          "encoding": "1000011----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x86004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.2": {
+          "encoding": "1000101----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8a004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.3": {
+          "encoding": "1000111----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0x8e004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.4": {
+          "encoding": "1100001----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc2004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.5": {
+          "encoding": "1100011----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xc6004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.6": {
+          "encoding": "1100101----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xca004073",
+          "mask": "0xfe00707f"
+        },
+        "MOP.RR.7": {
+          "encoding": "1100111----------100-----1110011",
+          "variable_fields": [
+            "rd",
+            "rs1",
+            "rs2"
+          ],
+          "extension": [
+            "rv_zimop"
+          ],
+          "match": "0xce004073",
+          "mask": "0xfe00707f"
+        }
+      },
+      "state": "ratified",
+      "ratification_date": "2024-03",
+      "version": "1.0.0"
+    },
+    {
       "id": "Zimt",
       "name": "Zimt",
       "short": "Time Instructions",
@@ -29184,6 +29184,21 @@
       "ratification_date": "2024-10",
       "behavior": "A machine-level extension that provides pointer masking for the next lower privilege mode\n(S/HS if S-mode is implemented, or U-mode otherwise).",
       "version": "1.0.0"
+    },
+    {
+      "id": "Smpmpmt",
+      "name": "Smpmpmt",
+      "short": "PMP-Based Memory Types",
+      "tags": [],
+      "desc": "A memory-type field in each PMP entry overrides the physical memory attributes for accesses that match it.",
+      "use": "Overriding memory attributes per PMP region",
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {},
+      "long_name": "PMP-based Memory Types Extension",
+      "type": "privileged",
+      "state": "frozen",
+      "behavior": "The Smpmpmt extension provides a mechanism analogous to Svpbmt but associated\nwith the PMP registers rather than page-table entries.\nA new WARL field, MT (Memory Type), is added in the unallocated bits 6--5 in\neach PMP configuration register.\nThe MT field of the lowest-numbered PMP register that an",
+      "version": "0.6"
     }
   ],
   "s_interrupt": [
@@ -30498,21 +30513,6 @@
       "use": "Trap behavior when not taken",
       "url": "https://github.com/riscv/riscv-isa-manual",
       "instructions": {}
-    },
-    {
-      "id": "Smpmpmt",
-      "name": "Smpmpmt",
-      "short": "PMP-Based Memory Types",
-      "tags": [],
-      "desc": "A memory-type field in each PMP entry overrides the physical memory attributes for accesses that match it.",
-      "use": "Overriding memory attributes per PMP region",
-      "url": "https://github.com/riscv/riscv-isa-manual",
-      "instructions": {},
-      "long_name": "PMP-based Memory Types Extension",
-      "type": "privileged",
-      "state": "frozen",
-      "behavior": "The Smpmpmt extension provides a mechanism analogous to Svpbmt but associated\nwith the PMP registers rather than page-table entries.\nA new WARL field, MT (Memory Type), is added in the unallocated bits 6--5 in\neach PMP configuration register.\nThe MT field of the lowest-numbered PMP register that an",
-      "version": "0.6"
     },
     {
       "id": "Smtdeleg",


### PR DESCRIPTION
Three follow-ups from review of #251. All three are fair; the first two are gaps in that PR rather than new problems.

## 1. `Smpmpmt` joins the other PMP entries

It was left in Trap/Debug while `Smepmp`, `Smmpm` and `Smnpm` moved to Memory. UDB calls it the **PMP-based Memory Types Extension**, and it is the PMP analogue of `Svpbmt`, which was already in that group.

Worth noting: #249 had already corrected this entry's label to "PMP-Based Memory Types", so the information needed to move it was sitting in the file when #251 was written.

## 2. The Memory heading no longer said what the group contained

Renamed **Memory (Sv)** → **Memory & Addressing**.

After #251 the group holds `Ssccptr`, `Smvatag`, `Smepmp`, `Smmpm`, `Smnpm`, `Supm`, `Ssnpm` and `Sspm` alongside the `Sv*` entries — an "Sv" label described 10 of 23 members. #251 renamed "Security & CFI (Zi\*)" for precisely this reason and should have caught this at the same time.

I chose "Memory & Addressing" over "Memory (S/Sm/Sv)" so the heading does not need revisiting the next time a prefix moves in.

## 3. `Zimop` was not security

Moved from **Security & CFI** to **System**. Zimop reserves NOP-like encoding space that later extensions can redefine; CFI happens to be a consumer of that space, not what the extension is.

The catalogue was already inconsistent with itself here: `Zcmop`, the compressed counterpart, was filed under Compressed rather than Security.

Security & CFI is now `Smcfiss`, `Zicfilp`, `Zicfiss` — all genuinely CFI, so the heading is now accurate too.

## Not changed

`RERI` and `HTI` remain in Trap/Debug, as the review agreed: whether platform specifications belong in the catalogue at all is section 1 of #250, not a grouping question.

## How it was verified

- `npm run lint` clean, `npm test` **249 passing / 0 failing**, `npm run build` succeeds.
- `npm run graph:check` — **no drift across 228 nodes**.
- Asserted programmatically that all 228 entries survive and **every group keeps its original order**.
- In the browser: Memory & Addressing renders 23 entries including `Smpmpmt`, Security & CFI renders 3, `Zimop` renders under System, total still 228.

- [x] `npm test` passes
- [x] `npm run build` succeeds

## If this touches ISA data

- [x] Cited the source: riscv-unified-db `long_name` for `Smpmpmt`, `Zimop` and `Svpbmt`.
- [x] Regenerated rather than hand-edited, where a generator exists — n/a. Group membership has no generator.

## Sign-off

- [x] Every commit is signed off (`git commit -s`), per the [DCO](../DCO)