### PR TITLE
fix: classify every privileged group as Volume II

### DIFF
--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1072,9 +1072,16 @@ const RISCVExplorer = () => {
     for (const ext of extensions.standard || []) {
       if (['S', 'U', 'H', 'N'].includes(ext.id)) vol2Ids.add(ext.id);
     }
-    for (const ext of extensions.s_mem || []) vol2Ids.add(ext.id);
-    for (const ext of extensions.s_interrupt || []) vol2Ids.add(ext.id);
-    for (const ext of extensions.s_trap || []) vol2Ids.add(ext.id);
+    // Every privileged group is Volume II. Derived from the key prefix rather
+    // than listed by name: enumerating them meant a new group could be added to
+    // the catalogue, rendered in the grid, and still fall through to Volume I.
+    // s_counters did exactly that when it was introduced (#251), so its four
+    // counter extensions were dimmed under the Volume II filter and highlighted
+    // under Volume I.
+    for (const [group, members] of Object.entries(extensions)) {
+      if (!group.startsWith('s_')) continue;
+      for (const ext of members || []) vol2Ids.add(ext.id);
+    }
 
     const vol1Ids = new Set(Array.from(allIds).filter((id) => !vol2Ids.has(id)));
     return {

--- a/tests/data-integrity.test.mjs
+++ b/tests/data-integrity.test.mjs
@@ -162,3 +162,33 @@ test('extensions carry a UDB version, and it is well formed', () => {
     `expected most of the catalogue to carry a version, got ${withVersion}`
   );
 });
+
+/*
+ * The volume filter used to name each privileged group explicitly, so adding
+ * s_counters in #251 rendered its tiles in the grid while leaving them
+ * classified as Volume I: dimmed under the Volume II filter and highlighted
+ * under Volume I. Every s_* group in the catalogue must reach vol2Ids, whether
+ * the code derives them by prefix or lists them one by one.
+ */
+test('every privileged catalog group is classified as Volume II', () => {
+  const src = readFileSync(join(here, '..', 'src', 'risc_v_visualizer.jsx'), 'utf8');
+  const start = src.indexOf('const volumeMembership');
+  assert.ok(start !== -1, 'volumeMembership helper not found');
+  const end = src.indexOf('}, []);', start);
+  assert.ok(end !== -1, 'end of volumeMembership helper not found');
+  const block = src.slice(start, end);
+
+  const privileged = Object.keys(catalog).filter((group) => group.startsWith('s_'));
+  assert.ok(privileged.length > 0, 'expected at least one s_* group in the catalog');
+
+  const derivesByPrefix = /startsWith\('s_'\)/.test(block);
+  if (derivesByPrefix) return;
+
+  for (const group of privileged) {
+    assert.ok(
+      block.includes(`extensions.${group}`),
+      `${group} is a privileged group but volumeMembership never adds it to vol2Ids, ` +
+        'so its extensions would be treated as Volume I',
+    );
+  }
+});


### PR DESCRIPTION
## What this changes

The volume filter now derives the privileged set from the group key prefix instead of listing groups by name, and a regression test guards it.

## The defect

`volumeMembership` listed the privileged groups explicitly:

```js
for (const ext of extensions.s_mem || []) vol2Ids.add(ext.id);
for (const ext of extensions.s_interrupt || []) vol2Ids.add(ext.id);
for (const ext of extensions.s_trap || []) vol2Ids.add(ext.id);
```

Adding `s_counters` in #251 rendered its tiles in the grid but never added them to `vol2Ids`. Since `vol1Ids` is everything minus `vol2Ids`, `Smcdeleg`, `Smcntrpmf`, `Ssccfg` and `Sscounterenw` fell through to **Volume I** — dimmed when filtering for Volume II, highlighted when filtering for Volume I. Backwards for machine- and supervisor-mode counter extensions.

This was my regression in #251.

## Why not the one-line fix

Adding `s_counters` to the list would work today, but **the list is the defect**: nothing connects adding a group to updating this helper, so the next group lands the same way. Deriving by prefix covers any `s_*` group by construction.

## The test

Asserts every `s_*` group in the catalogue reaches `vol2Ids`, accepting **either** prefix derivation **or** an explicit list — so it constrains the behaviour rather than the implementation, and does not break if someone later goes back to enumerating.

I verified it actually catches the bug rather than merely passing: reinstating the old code fails it with

```
s_counters is a privileged group but volumeMembership never adds it to vol2Ids,
so its extensions would be treated as Volume I
```

## How it was verified

- `npm run lint` clean, `npm test` **250 passing / 0 failing** (251 total, 1 pre-existing environmental skip), `npm run build` succeeds.
- Regression test confirmed failing against the pre-fix code and passing after.
- In the browser with the Volume II filter active: `Smcdeleg` renders at opacity **1.0**, identical to `Sv39`, while unprivileged `Zba` dims to **0.2**.

- [x] `npm test` passes
- [x] `npm run build` succeeds

## Sign-off

- [x] Every commit is signed off (`git commit -s`), per the [DCO](../DCO)