### PR TITLE
data: remove seven unsourced entries and correct Zimt

### DIFF
--- a/src/isa-dependency-graph.json
+++ b/src/isa-dependency-graph.json
@@ -92,10 +92,6 @@
       "requires": [],
       "verified": "none"
     },
-    "K": {
-      "requires": [],
-      "verified": "none"
-    },
     "M": {
       "requires": [
         {
@@ -447,10 +443,6 @@
       "requires": [],
       "verified": "none"
     },
-    "Sscntrcfg": {
-      "requires": [],
-      "verified": "none"
-    },
     "Sscofpmf": {
       "requires": [],
       "verified": "udb"
@@ -492,10 +484,6 @@
       "verified": "udb"
     },
     "Ssdtso": {
-      "requires": [],
-      "verified": "none"
-    },
-    "Sshpmcfg": {
       "requires": [],
       "verified": "none"
     },
@@ -1361,10 +1349,6 @@
       "verified": "udb"
     },
     "Zimt": {
-      "requires": [],
-      "verified": "none"
-    },
-    "Zitagelide": {
       "requires": [],
       "verified": "none"
     },

--- a/src/isa-dependency-graph.json
+++ b/src/isa-dependency-graph.json
@@ -517,10 +517,6 @@
         }
       ]
     },
-    "Ssptead": {
-      "requires": [],
-      "verified": "none"
-    },
     "Ssqosid": {
       "requires": [
         {
@@ -1063,10 +1059,6 @@
         }
       ]
     },
-    "Zcmlsd": {
-      "requires": [],
-      "verified": "none"
-    },
     "Zcmop": {
       "requires": [
         {
@@ -1310,10 +1302,6 @@
           "ref": "Zicntr.yaml requirements.extension"
         }
       ]
-    },
-    "Zicntrpmf": {
-      "requires": [],
-      "verified": "none"
     },
     "Zicond": {
       "requires": [],

--- a/src/isa-dependency-graph.json
+++ b/src/isa-dependency-graph.json
@@ -1324,14 +1324,6 @@
       "requires": [],
       "verified": "udb"
     },
-    "Zilsm*": {
-      "requires": [],
-      "verified": "none"
-    },
-    "Zilsm<x>b": {
-      "requires": [],
-      "verified": "none"
-    },
     "Zilsme": {
       "requires": [],
       "verified": "none"

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -27917,26 +27917,6 @@
       "version": "2.0.0"
     },
     {
-      "id": "Zilsm*",
-      "name": "Zilsm*",
-      "short": "Streaming Mem (pattern)",
-      "tags": [],
-      "desc": "Streaming Mem (pattern)",
-      "use": "Wildcard for Zilsm<x>b family",
-      "url": "https://github.com/riscv/riscv-isa-manual",
-      "instructions": {}
-    },
-    {
-      "id": "Zilsm<x>b",
-      "name": "Zilsm<x>b",
-      "short": "Streaming Mem (x-byte)",
-      "tags": [],
-      "desc": "Streaming Mem (x-byte)",
-      "use": "Line-size specific streaming ops",
-      "url": "https://github.com/riscv/riscv-isa-manual",
-      "instructions": {}
-    },
-    {
       "id": "Zilsme",
       "name": "Zilsme",
       "short": "Streaming Stores (exclusive)",

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -5106,17 +5106,6 @@
       "version": "1.0.0"
     },
     {
-      "id": "K",
-      "name": "K",
-      "short": "Crypto Umbrella (Scalar + Vector)",
-      "tags": [],
-      "desc": "Crypto Umbrella (Scalar + Vector)",
-      "use": "Top-level tag signaling bundled Zk*/Zvk* NIST & ShangMi crypto support",
-      "discontinued": 0,
-      "instructions": {},
-      "url": "https://github.com/riscv/riscv-isa-manual"
-    },
-    {
       "id": "M",
       "name": "M",
       "short": "Integer Multiply/Divide",
@@ -28484,20 +28473,10 @@
     {
       "id": "Zimt",
       "name": "Zimt",
-      "short": "Time Instructions",
+      "short": "Memory Tagging",
       "tags": [],
-      "desc": "Time Instructions",
-      "use": "Extended time/TIMECMP instructions",
-      "url": "https://github.com/riscv/riscv-isa-manual",
-      "instructions": {}
-    },
-    {
-      "id": "Zitagelide",
-      "name": "Zitagelide",
-      "short": "Tag & ELIDE",
-      "tags": [],
-      "desc": "Tag & ELIDE",
-      "use": "Tagged-memory / elide behaviors",
+      "desc": "Tags 16-byte memory chunks and checks the tag on each pointer dereference, catching use-after-free and overruns.",
+      "use": "Detecting use-after-free and out-of-bounds accesses",
       "url": "https://github.com/riscv/riscv-isa-manual",
       "instructions": {}
     },
@@ -29319,16 +29298,6 @@
       "version": "1.0.0"
     },
     {
-      "id": "Sscntrcfg",
-      "name": "Sscntrcfg",
-      "short": "S-Mode Counter Config",
-      "tags": [],
-      "desc": "S-Mode Counter Config",
-      "use": "Supervisor counter configuration",
-      "url": "https://github.com/riscv/riscv-isa-manual",
-      "instructions": {}
-    },
-    {
       "id": "Sscofpmf",
       "name": "Sscofpmf",
       "short": "Counter Overflow & Filtering",
@@ -29373,16 +29342,6 @@
         }
       },
       "version": "1.0.0"
-    },
-    {
-      "id": "Sshpmcfg",
-      "name": "Sshpmcfg",
-      "short": "S-Mode HPM Config",
-      "tags": [],
-      "desc": "S-Mode HPM Config",
-      "use": "Supervisor HPM configuration",
-      "url": "https://github.com/riscv/riscv-isa-manual",
-      "instructions": {}
     },
     {
       "id": "Smrnmi",

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -18537,16 +18537,6 @@
       "state": "ratified",
       "ratification_date": "2025-02",
       "version": "1.0"
-    },
-    {
-      "id": "Zcmlsd",
-      "name": "Zcmlsd",
-      "short": "Compressed Mem-Loop",
-      "tags": [],
-      "desc": "Compressed Mem-Loop",
-      "use": "Compact memcpy/memset-style sequences",
-      "url": "https://github.com/riscv/riscv-isa-manual",
-      "instructions": {}
     }
   ],
   "z_float": [
@@ -27370,16 +27360,6 @@
       "version": "2.0.0"
     },
     {
-      "id": "Zicntrpmf",
-      "name": "Zicntrpmf",
-      "short": "Counter Filtering",
-      "tags": [],
-      "desc": "Counter Filtering",
-      "use": "Mode-based filtering for counters",
-      "url": "https://github.com/riscv/riscv-isa-manual",
-      "instructions": {}
-    },
-    {
       "id": "Zicsr",
       "name": "Zicsr",
       "short": "CSR Access",
@@ -30471,16 +30451,6 @@
       "tags": [],
       "desc": "VS CSR",
       "use": "Vector state control at S-mode",
-      "url": "https://github.com/riscv/riscv-isa-manual",
-      "instructions": {}
-    },
-    {
-      "id": "Ssptead",
-      "name": "Ssptead",
-      "short": "Sup PTE A/D (legacy)",
-      "tags": [],
-      "desc": "Superseded name for Svade, where a page fault is raised so software must set page-table A and D bits.",
-      "use": "Legacy name for Svade-style semantics",
       "url": "https://github.com/riscv/riscv-isa-manual",
       "instructions": {}
     },


### PR DESCRIPTION
## What this changes

Closes #255. Acts on the validated part of section 3 of #250. **228 entries → 221.**

### Removed — the correct extension is already in the catalogue

| Removed | Superseded by | Evidence |
|---|---|---|
| `Zicntrpmf` | `Smcntrpmf` | Not in UDB/docs/toolchain; clang rejects `zicntrpmf` and parses `smcntrpmf` |
| `Zcmlsd` | `Zclsd` | Pre-ratification spelling; binutils review records the change to `zclsd` |
| `Ssptead` | `Svade` | Profiles changelog records the rename; clang rejects `ssptead` |
| `Sscntrcfg` | `Ssccfg` | UDB `Ssccfg` = "Supervisor-mode counter configuration"; no public `Sscntrcfg` |
| `Sshpmcfg` | `Ssccfg` | Same bucket — `Ssccfg` covers the `hpmeventN` aliases as well as `cyclecfg`/`instretcfg` |
| `K` | `Zk` | The ratified scalar-crypto shorthand is `Zk`, already listed, in UDB, and what `SHORTHAND_BUNDLES` models. No spec defines a single-letter `K` |

On `K`: this is the **scalar** bundle. The vector equivalent is `Zvk`, a different extension operating on `v0–v31` — not a counterpart, and untouched here.

### Removed — withdrawn from its own specification

**`Zitagelide`.** Its only home was the memory-tagging work, and the current `riscv/riscv-memory-tagging` source does not mention it at all. A selectable extension whose spec has dropped it invites configurations that cannot be built.

### Corrected rather than removed

**`Zimt` is real, and was described as something else entirely.** The catalogue said "Time Instructions". `riscv/riscv-memory-tagging` defines it as the memory-tagging extension — it "divides address space of the program in equal memory chunks of 16 bytes", defines tagged-pointer construction, tag-management instructions and tag checks on dereference, and depends on pointer masking. Its label, description and use case now say so.

Its group is unchanged pending the wider decision in #250.

## Two corrections to #250 itself

1. **These are duplicates, not "names that look mistaken".** In each case the correct entry is already present, so the fix is removal, not a rename.
2. **`Sscntrcfg` and `Sshpmcfg` were wrongly filed** by me under "appears in no specification", which implied nothing covers the feature. `Ssccfg` does, and is already listed. That moves them from the hard decision into this safe set.

## Still deliberately untouched

- **`Zilsp`** — looks like a distinct NXP load/store-pair draft, not a misspelling of `Zilsd`.
- **`Smdid`** — `Smsdid` is not in the catalogue, so it is a rename, not a duplicate.
- The remaining section 1–2 entries, which have **no** counterpart, so removing them would delete the only way to express the feature.

## How it was verified

- `npm run lint` clean, `npm test` **250 passing / 0 failing**, `npm run build` succeeds.
- `npm run graph:check` — **no drift across 221 nodes**.
- Before removal: none of the seven is in UDB, each had an empty dependency node, nothing in the graph depended on any of them, none is referenced outside the two data files, and `profiles.js` references none.
- `RV64I` + `Zk` still assembles to `rv64i_zk`, confirming removing `K` left the crypto shorthand path intact.
- `Zimt` sourced directly from the `riscv/riscv-memory-tagging` AsciiDoc, which mentions it 24 times; `Zitagelide` appears zero times there.

- [x] `npm test` passes
- [x] `npm run build` succeeds

## Sign-off

- [x] Every commit is signed off (`git commit -s`), per the [DCO](../DCO)
