### PR TITLE
fix(export): recognize all S-mode privileged extension families in YAML exports

### DIFF
--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -24,7 +24,7 @@ const INVALID_ISA_TOKENS = new Set(['K', 'P']);
 
 // Privilege / virtual-memory extension prefix patterns
 function isPrivilegeTag(id) {
-  return /^S[vms]/i.test(id) || id.toLowerCase().startsWith('sm') || id.toLowerCase().startsWith('ss');
+  return /^S[a-z0-9]/i.test(id);
 }
 
 /**
@@ -183,8 +183,7 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
   zExts.sort((a, b) => a.localeCompare(b));
 
   // 5. Build the ISA march-like string
-  const basePrefix = `RV${baseInfo.xlen}${baseInfo.base.toUpperCase()}`;
-  const singlesStr = filteredSingles.join('');
+  const basePrefix = `RV${baseInfo.xlen}${baseInfo.base.toUpperCase()}`;\n  const singlesStr = filteredSingles.join('');
   const zStr       = zExts.length > 0 ? zExts.join('_') : '';
   const isaString  = `${basePrefix}${singlesStr}${zStr ? (singlesStr ? '_' : '') + zStr : ''}`;
 

--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -183,7 +183,8 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
   zExts.sort((a, b) => a.localeCompare(b));
 
   // 5. Build the ISA march-like string
-  const basePrefix = `RV${baseInfo.xlen}${baseInfo.base.toUpperCase()}`;\n  const singlesStr = filteredSingles.join('');
+  const basePrefix = `RV${baseInfo.xlen}${baseInfo.base.toUpperCase()}`;
+  const singlesStr = filteredSingles.join('');
   const zStr       = zExts.length > 0 ? zExts.join('_') : '';
   const isaString  = `${basePrefix}${singlesStr}${zStr ? (singlesStr ? '_' : '') + zStr : ''}`;
 

--- a/tests/export.test.mjs
+++ b/tests/export.test.mjs
@@ -138,3 +138,16 @@ test('the UDB export is reproducible', () => {
   assert.equal(a, b);
   assert.ok(!/Generated:/.test(a), 'no timestamp');
 });
+
+test('privileged extensions across all S-mode families appear under privilege_extensions', () => {
+  const selected = ['RV64I', 'Sdext', 'Sdtrig', 'Sddbltrp', 'Supm', 'Smepmp', 'Sv39'];
+  const { yaml } = buildIsaConfigYaml(resolve(selected), ALL, { format: 'landscape' });
+  assert.match(yaml, /privilege_extensions:/);
+  for (const ext of ['Sdext', 'Sdtrig', 'Sddbltrp', 'Supm', 'Smepmp', 'Sv39']) {
+    assert.match(
+      yaml,
+      new RegExp(`^ {2}- ${ext}$`, 'm'),
+      `${ext} must be listed under privilege_extensions in YAML export`,
+    );
+  }
+});


### PR DESCRIPTION
Closes #258.

### Summary of Changes

In `src/exportUtils.js`, `isPrivilegeTag` is used to classify privilege and supervisor-level extensions so they are emitted under the `privilege_extensions:` section in the exported YAML configuration.

Previously, `isPrivilegeTag` was defined as:
```javascript
function isPrivilegeTag(id) {
  return /^S[vms]/i.test(id) || id.toLowerCase().startsWith('sm') || id.toLowerCase().startsWith('ss');
}
```

This pattern only captured `Sv*`, `Sm*`, and `Ss*`, missing other S-mode privileged extensions present in the catalogue:
- **`Sd*` debug / double-trap extensions**: `Sddbltrp`, `Sdext`, `Sdtrig`, `Sdtrigepm`, `Sdtrigpend`
- **`Su*` pointer masking extensions**: `Supm` (User-mode pointer masking in supervisor environments)

As a result, selecting `Sd*` or `Supm` extensions omitted them from `privilege_extensions:` in the exported YAML, causing them to fall through to the unprivileged multi-letter handling branch.

### Fix
- Generalize `isPrivilegeTag` to `/^S[a-z0-9]/i.test(id)`, covering all multi-letter S-mode extension families (`Sd*`, `Sm*`, `Ss*`, `Su*`, `Sv*`, etc.) while leaving single-letter `S` to be handled as a standard single-letter extension.
- Add an automated regression test in `tests/export.test.mjs` asserting that extensions across all S-mode families (`Sdext`, `Sdtrig`, `Sddbltrp`, `Supm`, `Smepmp`, `Sv39`) are correctly included in `privilege_extensions:` in the YAML export.

### Verification
- Tested with Node.js test runner (`node --test tests/export.test.mjs`).
- All regression test assertions pass.