### PR TITLE
test: scope privilege_extensions assertion to its own block

### DIFF
--- a/tests/export.test.mjs
+++ b/tests/export.test.mjs
@@ -138,3 +138,41 @@ test('the UDB export is reproducible', () => {
   assert.equal(a, b);
   assert.ok(!/Generated:/.test(a), 'no timestamp');
 });
+
+/**
+ * A regression test that cannot go red is not a regression test.
+ *
+ * The first attempt at this assertion matched `^  - Sdext$` against the whole
+ * document. Privileged extensions are emitted in the general `extensions:` list
+ * as well, so the match landed there and the test passed even when nothing had
+ * reached `privilege_extensions:` at all. Scope every assertion to the block it
+ * is actually about.
+ */
+const section = (yaml, key) => {
+  const lines = yaml.split('\n');
+  const start = lines.indexOf(`${key}:`);
+  if (start === -1) return null;
+  const items = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^[A-Za-z_]/.test(lines[i])) break; // next top-level key ends the block
+    const m = /^ {2}- (\S+)$/.exec(lines[i]);
+    if (m) items.push(m[1]);
+  }
+  return items;
+};
+
+test('every S-mode privileged family reaches privilege_extensions', () => {
+  // One representative per S-family. Sd* and Su* were classified as ordinary
+  // multi-letter extensions and silently fell through to `extensions:`.
+  const families = ['Sdext', 'Sdtrig', 'Sddbltrp', 'Supm', 'Smepmp', 'Sv39'];
+  const { yaml } = buildIsaConfigYaml(resolve(['RV64I', ...families]), ALL);
+  const priv = section(yaml, 'privilege_extensions');
+
+  assert.ok(priv, 'the export must contain a privilege_extensions block');
+  for (const ext of families) {
+    assert.ok(
+      priv.includes(ext),
+      `${ext} must appear under privilege_extensions; that block holds [${priv.join(', ')}]`,
+    );
+  }
+});


### PR DESCRIPTION
Follow-up to #259, which fixes `isPrivilegeTag()` so that `Sd*` and `Su*` extensions reach `privilege_extensions:` in the exported YAML.

## Why

The regression test added in #259 asserts each extension with

```js
new RegExp(`^ {2}- ${ext}$`, 'm')
```

matched against the whole exported document. Privileged extensions are also emitted in the general `extensions:` list, so the assertion is satisfied there and never checks that anything reached `privilege_extensions:`. Reverting the predicate fix while keeping that test leaves it green, so it does not guard the behaviour it was written for.

## What this adds

A `section(yaml, key)` helper that returns the list items under a single top-level key, and a test that asserts each S-mode family member inside the `privilege_extensions:` block specifically.

There is deliberately no "must not appear under `extensions:`" assertion. Privileged extensions legitimately appear in both lists once the fix is applied, so that assertion would be wrong.

## Verification

Against current `main`, the test fails, which is the point:

```
✖ every S-mode privileged family reaches privilege_extensions
  AssertionError: Sdext must appear under privilege_extensions;
  that block holds [Smepmp, Sv39, Sm]
```

With #259's one-line predicate change applied locally, the suite is green at 14/14.

## Expect CI to be red

This test encodes behaviour that `main` does not have yet. **It is expected to fail until #259 merges**, at which point it goes green with no further change. If a red check on `main` is not wanted in the interim, this can be marked with node:test's `{ todo: ... }` option instead, or simply held until #259 lands and merged after it. Happy to do either.
