### PR TITLE
chore: release v1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "riscv-isa-explorer",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "riscv-isa-explorer",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "lucide-react": "^0.294.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "riscv-isa-explorer",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "",
   "main": "index.js",
   "homepage": "https://riscv.github.io/riscv-isa-explorer/",


### PR DESCRIPTION
Bumps `package.json` and `package-lock.json` to 1.4.0, matching the shape of #247.

**Minor, not a patch.** This is a data release. The catalogue went from 228
entries to 219, and a removed entry takes any saved selection or `-march` string
that referenced it with it. That is the change most likely to affect someone
silently, so the version should say "the catalogue changed" rather than "a bug
was fixed".

### Since v1.3.0

| | |
|---|---|
| #249 | a real description and use case for every extension |
| #251, #252 | regroup the misfiled extensions |
| #253 | classify every privileged group as Volume II |
| #254 | remove nine unsourced entries and correct Zimt |
| #257 | sync extension data from riscv-unified-db |
| #259 | recognize all S-mode privileged extension families in YAML exports |
| #260 | scope the privilege_extensions assertion to its own block |

### Catalogue delta, 228 to 219

Removed (10): `K`, `Sscntrcfg`, `Sshpmcfg`, `Ssptead`, `Zccid`, `Zcmlsd`,
`Zicntrpmf`, `Zilsm*`, `Zilsm<x>b`, `Zitagelide`

Added (1): `Ziccid`

`Zccid` to `Ziccid` is a rename rather than a loss. The rest appeared in no
specification, or were naming prefixes and mistaken spellings, and are covered by
#250. Note that `Zilsm*` and `Zilsm<x>b` were literal entry ids, glob characters
and all.

### Export behaviour

#259 changes what the YAML export produces: privileged extensions from the Sd*
and Su* families now appear under `privilege_extensions:` where they previously
fell through to the general `extensions:` list. Anything parsing the export
should expect the corrected placement.

### Verification

`npm run lint && npm run build && npm test` clean, 251 of 252 passing, 1 skipped.
