### PR TITLE
ci: require a changelog entry for a version bump, and document releasing

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,113 @@
+name: Changelog
+
+# Two jobs in one, both cheap:
+#
+#   1. A release must carry its changelog entry. If a PR bumps the version in
+#      package.json, CHANGELOG.md must gain a matching `## [x.y.z]` heading.
+#      This is the whole point of the file: a changelog nobody is forced to
+#      update is worse than none, because it looks authoritative while it rots.
+#
+#   2. A catalogue change reports which entry ids moved. Not a failure — the
+#      weekly UDB sync bot changes the catalogue on its own schedule and has no
+#      business writing prose. It is printed so whoever writes the release entry
+#      has the list without diffing two tags by hand, which is exactly the step
+#      that produced two wrong counts while CHANGELOG.md was being written.
+#
+# Deliberately a plain script, for the same reason dco.yml is one: a gate of
+# this size is not worth granting a token to code we do not control.
+
+on:
+  pull_request:
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: A version bump carries its changelog entry
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -uo pipefail
+
+          base_ver=$(git show "$BASE_SHA:package.json" 2>/dev/null \
+            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{console.log(JSON.parse(s).version)}catch{console.log("")}})')
+          head_ver=$(node -e 'console.log(require("./package.json").version)')
+
+          echo "base version: ${base_ver:-unknown}"
+          echo "head version: $head_ver"
+
+          if [ "$base_ver" = "$head_ver" ]; then
+            echo "no version change; nothing to enforce"
+            exit 0
+          fi
+
+          echo "version bumped $base_ver -> $head_ver"
+
+          if [ ! -f CHANGELOG.md ]; then
+            echo "FAIL: the version was bumped but CHANGELOG.md does not exist"
+            exit 1
+          fi
+
+          # The heading format is Keep a Changelog: "## [1.4.0] - 2026-09-01".
+          if grep -qE "^## \[${head_ver}\]" CHANGELOG.md; then
+            echo "ok: CHANGELOG.md has a section for $head_ver"
+          else
+            echo ""
+            echo "---"
+            echo "FAIL: package.json is at $head_ver but CHANGELOG.md has no"
+            echo "      '## [$head_ver]' section."
+            echo ""
+            echo "Add one before merging. See the Releasing section of"
+            echo "CONTRIBUTING.md for what a release entry is expected to carry."
+            echo "---"
+            exit 1
+          fi
+
+      - name: Report catalogue entries added or removed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -uo pipefail
+          CAT=src/riscv_extensions.json
+
+          if git diff --quiet "$BASE_SHA" -- "$CAT"; then
+            echo "catalogue unchanged"
+            exit 0
+          fi
+
+          git show "$BASE_SHA:$CAT" > /tmp/base_catalogue.json 2>/dev/null || echo '{}' > /tmp/base_catalogue.json
+
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const ids = (p) => {
+            try {
+              const d = JSON.parse(fs.readFileSync(p, 'utf8'));
+              return new Set(Object.values(d).flat().map((e) => e.id));
+            } catch {
+              return new Set();
+            }
+          };
+          const before = ids('/tmp/base_catalogue.json');
+          const after = ids('src/riscv_extensions.json');
+          const removed = [...before].filter((i) => !after.has(i)).sort();
+          const added = [...after].filter((i) => !before.has(i)).sort();
+
+          console.log(`entries: ${before.size} -> ${after.size}`);
+          if (removed.length) console.log(`removed (${removed.length}): ${removed.join(', ')}`);
+          if (added.length) console.log(`added   (${added.length}): ${added.join(', ')}`);
+          if (!removed.length && !added.length) {
+            console.log('no entry ids added or removed; content changed only');
+          }
+          if (removed.length) {
+            console.log('');
+            console.log('A removed entry invalidates any saved selection or -march');
+            console.log('string that referenced it. Record these in CHANGELOG.md');
+            console.log('under the release that ships them.');
+          }
+          NODE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,58 @@ Each of these exists because it was once broken:
 - If you found something surprising along the way, put it in the description.
   Several of the sharpest bugs here were found while fixing something else.
 
+## Releasing
+
+Releases are cut by hand. There is no release bot, and the version lives in one
+place: `package.json` (with `package-lock.json` following it).
+
+### Choosing the number
+
+The catalogue in `src/riscv_extensions.json` is the product, so **a release that
+changes what the catalogue contains is a minor bump even when no code changed**.
+An entry that disappears takes any saved selection or `-march` string that
+referenced it with it, and a reader should not have to open the diff to discover
+that. Reserve a patch for fixes that leave the entry set intact.
+
+### Steps
+
+```bash
+git checkout -b chore/release-X.Y.Z
+npm version --no-git-tag-version X.Y.Z      # package.json + package-lock.json
+```
+
+Add the release section to `CHANGELOG.md`. CI will reject the pull request if the
+version moved and no `## [X.Y.Z]` heading appeared, so this is not optional. The
+Changelog workflow also prints which catalogue entry ids were added or removed
+against the base — take that list, do not retype it from memory. It was written
+because hand-counting produced two wrong numbers in a row.
+
+Then verify, open the pull request, and merge it once CI is green:
+
+```bash
+npm run lint && npm run build && npm test
+```
+
+After the release commit is on `main`:
+
+```bash
+git checkout main && git pull
+git tag -a vX.Y.Z <sha> -m "vX.Y.Z"
+git push origin vX.Y.Z
+gh release create vX.Y.Z --verify-tag --title "vX.Y.Z" --notes-file <notes>
+```
+
+Use the changelog section as the release notes, so the tag and the file cannot
+disagree.
+
+### What a release entry carries
+
+- The catalogue size, as `before -> after`, whenever it moved
+- Every entry id added or removed, named individually. A rename is stated as a
+  rename, with both ids, so nobody reads it as an extension disappearing
+- Any change to exported output, since that breaks consumers silently
+- The pull request number against each line
+
 ## Reporting problems
 
 Open an issue with what you did, what you expected, and what happened. For


### PR DESCRIPTION
CHANGELOG.md landed in #262 with nothing to keep it current. This adds the gate and writes down the process.

## The gate

`.github/workflows/changelog.yml`, plain bash and node for the same reason `dco.yml` is: a check this size is not worth granting a token to code we do not control.

**Fails** only when `package.json`'s version moves without a matching `## [x.y.z]` heading appearing in CHANGELOG.md.

**Reports, without failing**, which catalogue entry ids were added or removed against the base. Deliberately not a failure: the weekly UDB sync bot opens catalogue PRs on its own schedule and has no business writing prose. It is printed so whoever writes the release entry has the list instead of diffing two tags by hand, which is the step that produced two wrong counts while #262 was being written (nine versus ten removals, and a rename filed under the wrong PR).

## Verified locally

- version with a matching section (1.4.0) passes
- version with no section (1.9.9) fails
- delta script against v1.3.0..main reproduces the real figures: 228 to 219, removed 10, added 1

Also checked that the node heredoc terminator still lands at column 0 after YAML block-scalar stripping, which is an easy way to ship a broken workflow.

## The docs

`CONTRIBUTING.md` gains a Releasing section: how to pick the number (a catalogue content change is a minor bump even with no code change), the bump and tag commands, and what a release entry has to carry. It was previously reverse-engineered from #247 every time.

lint clean, build OK, 251 of 252 tests passing.