### PR TITLE
ci: limit the changelog workflow's token to contents: read

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,6 +19,12 @@ name: Changelog
 on:
   pull_request:
 
+# The job only reads the repository: it checks out the head, reads package.json
+# and CHANGELOG.md on both sides, and prints a diff of catalogue entry ids. It
+# never writes, so the token gets nothing beyond read.
+permissions:
+  contents: read
+
 jobs:
   changelog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Addresses the CodeQL comment on #263 (alert #4, `actions/missing-workflow-permissions`).

The workflow added in #263 set no `permissions` block, so it inherited the repository default. The job only reads: it checks out the head, reads `package.json` and `CHANGELOG.md` on both sides of the merge base, and prints which catalogue entry ids moved. It writes nothing, so `contents: read` is the whole requirement.

My mistake, and worth stating plainly: the alert was on #263 before it merged. It sat behind a `CodeQL=NEUTRAL` status that I saw and did not open.

## Two related alerts, deliberately not touched here

The same rule is open against two older workflows:

- **#1 `ci.yml`** — safe to fix the same way. Its `deploy` job already declares `contents: write` at job level, which overrides a workflow-level default, so adding `permissions: contents: read` at the top would not affect publishing to gh-pages.
- **#2 `dco.yml`** — reads commits only, so `contents: read` covers it.

Both are one-line additions and would close the remaining alerts of this class, but they are not this PR's change. Happy to do them separately.