### PR TITLE
feat: use the official RISC-V wordmark in the header and footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ no code changed. An entry that disappears takes any saved selection or `-march`
 string referencing it with it, and that is the change most likely to affect
 someone silently. Each release below records its catalogue size.
 
+## [Unreleased]
+
+### Changed
+
+- The header and footer now carry the official RISC-V wordmark in place of the
+  generic circuit icon and the words "RISC-V", so the title reads as the mark
+  followed by "ISA Explorer". The mark is inlined from
+  `riscv/docs-resources/images/risc-v_logo.svg`; its gold is fixed and its
+  lettering follows the theme, navy on light and white on dark, matching the two
+  official variants
+
 ## [1.4.0] - 2026-09-01
 
 Data release. Catalogue **228 → 219 entries**, 17 → 18 groups.

--- a/src/RiscvLogo.jsx
+++ b/src/RiscvLogo.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+// The official RISC-V wordmark, from riscv/docs-resources/images/risc-v_logo.svg.
+//
+// Inlined rather than imported: webpack here only has an asset rule for .png,
+// and inlining lets the wordmark follow the theme without shipping two files.
+// The gold is the brand gold and does not move. The lettering is `currentColor`
+// so it can be navy on light and white on dark, which is what the official
+// colour and white variants do; `--riscv-logo-ink` carries that swap.
+//
+// The two nested transforms come from the source file and must be kept: the
+// path data is in a 3800-unit space that the matrix flips and the scale
+// reduces into the 483x76.6 viewBox.
+export default function RiscvLogo({ height = '1em', className = '', title = 'RISC-V' }) {
+  // Width comes from CSS, not the attribute: width="auto" is not a valid SVG
+  // length, so as an attribute it falls back to 100% and the mark claims the
+  // whole row, which pushed the title into a wrap. As CSS on a replaced element
+  // with an intrinsic ratio, `width: auto` resolves from the height and viewBox.
+  return (
+    <svg
+      viewBox="0 0 483.01334 76.599998"
+      role="img"
+      aria-label={title}
+      className={className}
+      style={{ height, width: 'auto', color: 'var(--riscv-logo-ink)', display: 'block', flex: 'none' }}
+    >
+      <title>{title}</title>
+      <g transform="matrix(1.3333333,0,0,-1.3333333,0,76.6)">
+        <g transform="scale(0.1)">
+        <path fill="#F3AB0D" d="m 321.398,394.781 c 0,-83.511 -50.644,-159.398 -149.281,-177.176 L 311.27,53.1445 323.859,70.7969 574.465,425.184 V 574.461 H 167.051 c 103.703,-10.125 154.347,-96.133 154.347,-179.68" />
+        <path fill="currentColor" d="M 392.188,25.3398 576.926,283.469 V 0 H 373.672 Z M 35.4609,293.59 h 96.1331 c 70.801,0 106.289,50.547 106.289,101.191 0,50.68 -35.488,98.731 -106.289,98.731 L 0,493.512 V 0 H 245.535 L 35.4609,253.066 v 40.524" />
+        <path fill="currentColor" d="m 1419.67,478.328 h 83.54 V 86.0117 h -83.54 V 478.328" />
+        <path fill="currentColor" d="m 2000.97,171.859 -434.5,0.254 V 86.0117 h 437.78 c 32.87,0 60.8,12.7149 83.54,35.4613 22.75,22.715 35.46,50.64 35.46,83.507 0,32.872 -12.71,60.676 -35.46,83.547 -22.74,22.743 -50.67,35.336 -83.54,35.336 l -318.47,2.379 c -18.78,0.141 -33.96,15.332 -34.1,34.106 v 0 0 c 0.14,18.867 15.46,34.097 34.33,34.113 l 437.24,0.32 v 83.547 h -437.8 c -32.99,0 -60.8,-12.719 -83.51,-35.461 -22.74,-22.746 -35.47,-50.679 -35.47,-83.547 0,-32.863 12.73,-60.672 35.47,-83.507 22.71,-22.747 50.52,-32.868 83.51,-32.868 l 318.11,-0.015 c 18.9,0 34.19,-15.352 34.12,-34.242 v 0 0 c 0.07,-20.329 -16.39,-36.836 -36.71,-36.829" />
+        <path fill="currentColor" d="m 2358.55,478.328 h 361.91 v -83.547 h -361.91 c -30.28,0 -55.62,-9.996 -78.49,-32.867 -22.75,-22.742 -32.86,-48.051 -32.86,-78.445 0,-30.274 10.11,-55.617 32.86,-78.489 22.87,-22.707 48.21,-32.867 78.49,-32.867 h 361.91 l -0.02,-86.1013 h -361.71 c -53.14,0 -98.82,20.3713 -136.87,58.3013 -37.93,37.96 -55.62,83.539 -55.62,136.683 0,53.117 17.69,98.731 55.62,136.656 38.05,40.395 83.54,60.676 136.69,60.676" />
+        <path fill="currentColor" d="M 1358.99,86.0117 1247.65,240.445 c 30.27,2.5 55.61,12.621 75.89,35.368 22.74,22.835 35.45,50.644 35.45,83.507 0,32.868 -12.71,60.801 -35.45,83.547 -22.75,22.742 -50.68,35.461 -83.55,35.461 H 802.188 V 86.0117 h 83.546 V 240.445 H 1143.86 L 1255.21,86.0117 Z m -124,234.7613 -349.256,0.622 v 70.793 l 352.726,0.718 c 19.01,0.039 34.47,-15.316 34.56,-34.332 v 0 0 c -0.09,-20.926 -17.1,-37.836 -38.03,-37.801" />
+        <path fill="#F3AB0D" d="M 3137.99,86.0117 2908.74,478.328 h 98.13 l 179.19,-311.269 179.3,311.269 h 96.62 L 3234.12,86.0117" />
+        <path fill="#F3AB0D" d="m 2771.13,318.926 h 164.47 v -75.981 h -164.47 v 75.981" />
+        <path fill="currentColor" d="m 3551.73,418.332 h 6.6 c 7.72,0 13.96,2.566 13.96,8.809 0,5.507 -4.04,9.179 -12.85,9.179 -3.68,0 -6.24,-0.367 -7.71,-0.734 z m -0.37,-34.144 h -13.95 v 60.207 c 5.51,1.097 13.22,1.835 23.13,1.835 11.38,0 16.52,-1.835 20.93,-4.402 3.3,-2.574 5.86,-7.344 5.86,-13.219 0,-6.613 -5.13,-11.75 -12.48,-13.949 v -0.738 c 5.88,-2.195 9.18,-6.606 11.02,-14.684 1.84,-9.179 2.94,-12.851 4.4,-15.05 h -15.05 c -1.83,2.199 -2.93,7.707 -4.77,14.683 -1.1,6.609 -4.77,9.547 -12.48,9.547 h -6.61 z m -37.08,31.57 c 0,-26.797 19.82,-48.09 46.99,-48.09 26.44,0 45.89,21.293 45.89,47.723 0,26.8 -19.45,48.464 -46.25,48.464 -26.81,0 -46.63,-21.664 -46.63,-48.097 z m 108.3,0 c 0,-34.141 -26.8,-60.938 -61.67,-60.938 -34.51,0 -62.05,26.797 -62.05,60.938 0,33.406 27.54,60.211 62.05,60.211 34.87,0 61.67,-26.805 61.67,-60.211" />
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,9 @@
   --riscv-muted: #414157;
 
   --riscv-gold: #f5c542;
+  /* The RISC-V wordmark's lettering. White on dark, official navy on light,
+     matching the two official logo variants. The gold in the mark is fixed. */
+  --riscv-logo-ink: #ffffff;
   --riscv-gold-dim: rgba(245, 197, 66, 0.12);
   --riscv-gold-glow: rgba(245, 197, 66, 0.2);
 
@@ -523,6 +526,7 @@ pre,
      gold    #8f6408   4.86:1   AA body
    ────────────────────────────────────────────────────────────────────────── */
 :root[data-theme='light'] {
+  --riscv-logo-ink: #283272;
   --riscv-bg: #f7f5fb;
   /* Catalogue chip accents, one step down the ramp from their dark
      counterparts. Measured on white: 4.75:1 (orange) through 6.55:1 (violet),

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -74,6 +74,7 @@ import {
   buildCombinedCatalog,
 } from './marchUtils.js';
 import { resolveSelection } from './isaGraph.js';
+import RiscvLogo from './RiscvLogo.jsx';
 import { PROFILES } from './profiles.js';
 import PROFILE_OPTIONAL from './profile-optional.json';
 import { buildIsaConfigYaml } from './exportUtils.js';
@@ -1976,9 +1977,13 @@ const RISCVExplorer = () => {
                   earned a line of its own above the grid. */}
               <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-1">
                 <div className="flex items-center gap-3">
-                  <CircuitBoard size={22} style={{ color: 'var(--riscv-gold)' }} />
+                  {/* The wordmark stands in for the words "RISC-V", so the
+                      heading reads "RISC-V ISA Explorer" with the mark doing
+                      the first half. Sized in em so it tracks the h1 across
+                      the md breakpoint instead of needing its own step. */}
+                  <RiscvLogo height="0.82em" className="text-2xl md:text-3xl" />
                   <h1
-                    className="text-2xl md:text-3xl font-black tracking-tight"
+                    className="text-2xl md:text-3xl font-black tracking-tight whitespace-nowrap"
                     style={{
                       background:
                         'linear-gradient(90deg, var(--riscv-title-a) 0%, var(--riscv-title-b) 50%, var(--riscv-title-a) 100%)',
@@ -1986,7 +1991,7 @@ const RISCVExplorer = () => {
                       WebkitTextFillColor: 'transparent',
                     }}
                   >
-                    RISC-V ISA Explorer
+                    ISA Explorer
                     {/* Rides the title like an exponent. Inside the h1 on
                         purpose, so it tracks the title's last letter at any
                         size instead of being positioned against a width that
@@ -4114,9 +4119,9 @@ const RISCVExplorer = () => {
           }}
         >
           <div className="flex items-center gap-2">
-            <CircuitBoard size={14} style={{ color: 'var(--riscv-gold)' }} />
+            <RiscvLogo height="14px" />
             <span className="font-semibold" style={{ color: 'var(--riscv-text-2)' }}>
-              RISC-V ISA Explorer
+              ISA Explorer
             </span>
             <span style={{ color: 'var(--riscv-border-2)' }}>·</span>
             <span>

--- a/tests/render-smoke.test.mjs
+++ b/tests/render-smoke.test.mjs
@@ -82,9 +82,16 @@ test('the header, the counts and the builder control are present', () => {
   // is "Extensions", not "EXTENSIONS". Assert the rendered text, not the styled
   // appearance.
   const text = dom.window.document.body.textContent;
-  for (const expected of ['RISC-V ISA Explorer', 'Extensions', 'ISA Configuration Builder']) {
+  for (const expected of ['ISA Explorer', 'Extensions', 'ISA Configuration Builder']) {
     assert.ok(text.includes(expected), `page text is missing "${expected}"`);
   }
+
+  // "RISC-V" is the wordmark rather than text, so it is not in textContent as
+  // part of the title. Assert the accessible name instead: a screen reader
+  // still announces "RISC-V ISA Explorer", and this catches the mark being
+  // dropped or losing its label, which a text search never would.
+  const marks = dom.window.document.querySelectorAll('svg[aria-label="RISC-V"]');
+  assert.ok(marks.length >= 1, 'the RISC-V wordmark should be present with an accessible name');
 
   // The count comes from the catalogue, so this proves the data loaded rather
   // than merely that a shell painted.


### PR DESCRIPTION
The header paired a generic circuit-board glyph with the words "RISC-V ISA Explorer". The mark now stands in for the words, so it reads as the RISC-V wordmark followed by "ISA Explorer", in the header and the footer.

## Where it comes from

`riscv/docs-resources/images/risc-v_logo.svg`, inlined as `src/RiscvLogo.jsx` rather than imported: webpack here only has an asset rule for `.png`, and inlining lets the lettering follow the theme without shipping two files or adding a build rule.

The gold is the brand gold and does not move. The lettering is `currentColor`, driven by a new `--riscv-logo-ink`: navy `#283272` on light, white on dark. That is what the official colour and white variants do, so neither theme shows an off-brand mark.

The two nested transforms from the source file are preserved. The path data is in a 3800-unit space that the matrix flips and the scale reduces into the 483x76.6 viewBox.

## Verified in a browser, not only in CI

Both mistakes below were invisible to lint, build and tests, and only showed up on the page:

- `width="auto"` is not a valid SVG length, so as an **attribute** it fell back to 100%. The mark claimed the entire row and pushed the title into a two-line wrap. Width now comes from CSS, where `auto` resolves against the intrinsic ratio. Measured 155x25px in the header, 88x14px in the footer, both matching the 6.31:1 viewBox.
- The wordmark's cap height fills its viewBox, so matching the font size made it visibly larger than the text next to it. Set to `0.82em` to match optically rather than numerically.

Checked in both themes and at both sites, and confirmed `--riscv-logo-ink` resolves to `rgb(40, 50, 114)` under `data-theme=light`.

## Test change

`tests/render-smoke.test.mjs` asserted the string "RISC-V ISA Explorer" in `textContent`. "RISC-V" is now a mark, so the test checks the accessible name on the svg instead. A screen reader still announces the full name, and the new assertion catches the mark being dropped or losing its label, which a text search would not.

## Also

Adds an `[Unreleased]` section to CHANGELOG.md, which had none, so user-visible changes have somewhere to land between releases.

lint clean, build OK, 251 of 252 tests passing.