### PR TITLE
feat: Berkeley Blue and California Gold for the title, and a taller wordmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ someone silently. Each release below records its catalogue size.
   followed by "ISA Explorer". Geometry and colours come from the RISC-V brand
   kit's primary horizontal logo: the Color variant on light, White / Yellow on
   dark, each used verbatim rather than one tinted to imitate the other
+- "ISA Explorer" in the header is now a flat Berkeley Blue on light and
+  California Gold on dark, the two UC Berkeley colours, in place of the previous
+  gold gradient. The wordmark beside it is sized so the words never stand taller
+  than the mark
 
 ## [1.4.0] - 2026-09-01
 

--- a/src/index.css
+++ b/src/index.css
@@ -28,8 +28,11 @@
 
   /* Wordmark gradient. Bright amber reads on black and disappears on white, so
      the light theme swaps in a deeper pair. */
-  --riscv-title-a: #f5c542;
-  --riscv-title-b: #fde68a;
+  /* "ISA Explorer" in the header. California Gold on dark, Berkeley Blue on
+     light: the two UC Berkeley colours, where RISC-V started. A flat colour
+     rather than the previous gradient, so the words sit beside the wordmark
+     as type instead of competing with it. */
+  --riscv-title: #fdb515;
 
   --riscv-violet: #8b7cf8;
   --riscv-violet-dim: rgba(139, 124, 248, 0.12);
@@ -574,8 +577,7 @@ pre,
   --riscv-violet: #6d5bd0;
   --riscv-violet-dim: rgba(109, 91, 208, 0.1);
 
-  --riscv-title-a: #8a5a00;
-  --riscv-title-b: #b8860b;
+  --riscv-title: #003262;
 
   --riscv-success: #14866a;
   --riscv-danger: #c2334d;

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -1981,24 +1981,19 @@ const RISCVExplorer = () => {
                       heading reads "RISC-V ISA Explorer" with the mark doing
                       the first half. Sized in em so it tracks the h1 across
                       the md breakpoint instead of needing its own step. */}
-                  <RiscvLogo height="0.82em" className="text-2xl md:text-3xl" />
+                  <RiscvLogo height="1.15em" className="text-2xl md:text-3xl" />
                   <h1
                     className="text-2xl md:text-3xl font-black tracking-tight whitespace-nowrap"
-                    style={{
-                      background:
-                        'linear-gradient(90deg, var(--riscv-title-a) 0%, var(--riscv-title-b) 50%, var(--riscv-title-a) 100%)',
-                      WebkitBackgroundClip: 'text',
-                      WebkitTextFillColor: 'transparent',
-                    }}
+                    style={{ color: 'var(--riscv-title)' }}
                   >
                     ISA Explorer
                     {/* Rides the title like an exponent. Inside the h1 on
                         purpose, so it tracks the title's last letter at any
                         size instead of being positioned against a width that
-                        changes with the viewport. The h1 paints its text with
-                        a clipped gradient and a transparent fill, which a
-                        child inherits — so the class re-declares
-                        -webkit-text-fill-color or this would render invisible. */}
+                        changes with the viewport. The class keeps its own
+                        -webkit-text-fill-color: harmless now the title is a
+                        flat colour, and it is what kept this readable back
+                        when the h1 painted itself with a clipped gradient. */}
                     <sup
                       className="riscv-preview-sup"
                       title="This site is a technical preview — verify anything load-bearing against the ratified specification."


### PR DESCRIPTION
## Colour

"ISA Explorer" was a three-stop gold gradient painted through a clipped background with a transparent text fill. It is now a flat colour, the two UC Berkeley colours, which is where RISC-V started:

| theme | colour | |
|---|---|---|
| light | Berkeley Blue | `#003262` |
| dark | California Gold | `#FDB515` |

Flat rather than a gradient because the words sit right beside the wordmark, and a gradient there reads as a second piece of artwork competing with the logo where type should just be type.

`--riscv-title-a` and `--riscv-title-b` are replaced by a single `--riscv-title`; they had no other user. The clip-and-transparent-fill machinery goes with them. The preview `sup` keeps its own `-webkit-text-fill-color`, which is harmless now and is exactly what kept it readable while the gradient was there.

## Size

The wordmark goes 0.82em to 1.15em, so the title is never the taller of the two. Measured at the md breakpoint: mark **34.5px** against a **30px** title, with the mark's letters sitting a shade above the cap height of the words.

## Verified in the browser, both themes

```
dark   --riscv-title #fdb515  ->  rgb(253, 181, 21)
light  --riscv-title #003262  ->  rgb(0, 50, 98)
```

## One thing worth a look

Berkeley Blue `#003262` is a near neighbour of the wordmark's own navy `#2C356D`. They are distinguishable on screen and it reads as deliberate, but if you want more separation between the mark and the words on light, that is the knob.

lint clean, build OK, 251 of 252 tests passing.