### PR TITLE
fix: About is not a warning, and says its piece on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ someone silently. Each release below records its catalogue size.
 - The usage blurb is now behind an **About** button in the header row, between
   the counts and Report an issue, instead of three lines of prose above the
   grid. It cost roughly 100px above the fold to say something a returning
-  visitor already knows
+  visitor already knows. Hovering the button shows the same text without
+  opening anything
 
 - The header and footer now carry the official RISC-V wordmark in place of the
   generic circuit icon and the words "RISC-V", so the title reads as the mark

--- a/src/index.css
+++ b/src/index.css
@@ -1187,6 +1187,23 @@ pre,
   transform: translateX(-50%) translateY(0);
 }
 
+/* A tooltip carrying a sentence rather than a label. The base rule is
+   white-space: nowrap, which is right for "Switch to light theme" and useless
+   for prose: the About text would run off the viewport as a single line.
+   Higher specificity than the base rule, so it wins without !important.
+   Pair it with tooltip-bottom-right on anything in the header row: the default
+   tooltip sits above its trigger, and a control 34px from the top of the
+   viewport has nothing above it to sit in. */
+.tooltip-wide[data-tooltip]:hover::after {
+  white-space: normal;
+  width: max-content;
+  max-width: 330px;
+  text-align: left;
+  line-height: 1.55;
+  font-weight: 400;
+  padding: 8px 10px;
+}
+
 .tooltip-align-right[data-tooltip]:hover::after {
   left: auto;
   right: 0;

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -2055,9 +2055,9 @@ const RISCVExplorer = () => {
                     type="button"
                     ref={aboutTriggerRef}
                     onClick={() => setAboutOpen(true)}
-                    className="riscv-report-btn ml-3 inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[11px] font-bold whitespace-nowrap"
+                    className="riscv-btn tooltip-wide tooltip-bottom-right ml-3 inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[11px] font-bold whitespace-nowrap"
                     aria-haspopup="dialog"
-                    title="What this tool is and how to drive it"
+                    data-tooltip="Browse every ratified RISC-V extension, its instructions and their encodings. Select a tile for details, filter by profile or manual volume, and turn on ISA Builder to assemble a configuration and get a validated -march string. Compare puts extensions, instructions or profiles side by side."
                   >
                     <Info size={12} />
                     About


### PR DESCRIPTION
Two corrections to #268.

## It was red

I reused `.riscv-report-btn` for the markup, which carries the danger palette. About ended up sitting next to Report an issue looking like a second alarm. It uses `.riscv-btn` now, the neutral control style, so the two read as what they are: one is information, the other is a complaint.

## It only spoke when clicked

Hovering now shows the same text, via `data-tooltip`. That needed two things the existing tooltip could not do on its own:

- **The base rule is `white-space: nowrap`** — right for "Switch to light theme", useless for a 291-character sentence, which would have run off the viewport as one line. New `.tooltip-wide` relaxes it and caps the width at 330px.
- **The default tooltip sits above its trigger**, which is nowhere to go for a control 34px from the top of the viewport. That is why my first attempt rendered nothing visible. `tooltip-bottom-right` already existed for exactly this and is what the other header controls use.

Clicking still opens the full dialog with the formatting intact; hover is the quick read.

## Verified

Both themes, tooltip wrapping to six lines below the button. The light-theme tooltip override sets colours only, so the wrapping survives its higher specificity.

lint clean, build OK, 251 of 252 tests passing.