### PR TITLE
feat(compare): list the instructions an extension carries, not just how many

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ someone silently. Each release below records its catalogue size.
 
 ### Changed
 
+- Comparing extensions now lists every instruction each one carries, not just a
+  count. The chips container is bounded so the list wraps instead of stretching
+  its column: an unbounded 30-chip row grew the column to 2000px and pushed the
+  second extension off the viewport entirely
+
 - The usage blurb is now behind an **About** button in the header row, between
   the counts and Report an issue, instead of three lines of prose above the
   grid. It cost roughly 100px above the fold to say something a returning

--- a/src/CompareView.jsx
+++ b/src/CompareView.jsx
@@ -54,7 +54,7 @@ function Cell({ row, value, bitDiff }) {
 
   if (row.render === 'chips') {
     return (
-      <div className="flex flex-wrap gap-1">
+      <div className="compare-chips flex flex-wrap gap-1">
         {value.map((item) => (
           <span
             key={item}

--- a/src/compareModel.js
+++ b/src/compareModel.js
@@ -103,6 +103,17 @@ const EXTENSION_FIELDS = [
     render: 'mono',
     get: (e) => countOf(e.instructions),
   },
+  // The count answers "how many", which is the wrong question when the reason
+  // for putting two extensions side by side is to see what each one actually
+  // gives you. Mnemonics are the keys of the instructions object, the same
+  // shape encodingMap.js and marchUtils.js read. Sorted so the two columns line
+  // up for the eye; the diff highlight then does the rest.
+  {
+    key: 'instruction_list',
+    label: 'Instruction list',
+    render: 'chips',
+    get: (e) => listOrNull(Object.keys(e.instructions || {}).sort()),
+  },
   { key: 'csr_count', label: 'CSRs', render: 'mono', get: (e) => countOf(e.csrs) },
   { key: 'members', label: 'Members', render: 'chips', get: (e) => listOrNull(e.members) },
   {

--- a/src/index.css
+++ b/src/index.css
@@ -1291,6 +1291,17 @@ pre,
   display: grid;
   min-width: max-content;
 }
+
+/* The grid is min-width: max-content so several columns scroll rather than
+   squash. That works while every cell is short. An instruction list is not:
+   30 chips laid out on one line give the cell a max-content width of about
+   2000px, which the column then takes, pushing the second extension off the
+   viewport entirely. flex-wrap never fires because the column grew to fit.
+   Bounding the chips container caps what it contributes to max-content, so the
+   chips wrap and the columns stay comparable side by side. */
+.compare-chips {
+  max-width: 30rem;
+}
 .compare-head {
   position: sticky;
   top: 0;


### PR DESCRIPTION
Comparing two extensions is usually a question about what each one gives you. The comparison answered "how many": F and D both showed a number and nothing else, when the useful fact is that one is the `.S` instructions and the other the `.D` ones. It now lists them.

Mnemonics are the keys of the `instructions` object, the shape `encodingMap.js` and `marchUtils.js` already read, so this is one new field descriptor and no new data. Sorted, so the columns line up for the eye and the existing diff highlight does the rest.

## The layout bug this exposed

`.compare-grid` is `min-width: max-content` so several columns scroll rather than squash. That works while every cell is short. Thirty chips on one line are not short:

| | before | after |
|---|---|---|
| column width | 2072px | 832px |
| grid width (2 extensions) | **4324px** | **1844px** |
| fits a 1910px viewport | no | yes |

The second extension was pushed off the viewport entirely, and `flex-wrap` never fired because the column had grown to fit the chips on one line. Capping `.compare-chips` at 30rem caps what the cell contributes to max-content, so the chips wrap and the columns stay comparable.

Six columns still scroll horizontally, which is the intended behaviour and unchanged.

## One thing worth knowing

**V carries 627 instructions, which renders as a 3125px-tall cell** and pushes CSRs, Members, Requires, Description and Specification well below the fold. That is accurate and arguably unusable. I have not capped it, because the ask was to show all of them. If it becomes a problem the fix is a cap with a "show all" toggle rather than dropping the list.

Verified in the browser at 2 and 6 columns. lint clean, build OK, 251 of 252 tests passing.