### PR TITLE
fix(export): fold shorthand bundles in riscv-config format and exclude conflicting base letters

### DIFF
--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -8,13 +8,13 @@
  *
  * COMPILER COMPATIBILITY SCOPE (per extension family):
  *   Scalar crypto (Zk, Zkn, Zks, Zbkb, etc.): supported since ~GCC 12-13 / LLVM 14-15.
- *   Vector crypto (Zvkned, Zvbb, Zvbc, Zvkg family): GCC 14+ / LLVM 18+ (stable).
+ *   Vector crypto (Zvkned, Zvbb, Zvbc family): requires GCC 14+ / non-experimental LLVM 18+.
  *   Zve/Zvl sub-profile tokens: exact min version unconfirmed; verify with your toolchain.
  *   Base/gc extensions: universally stable.
  *   Full details and CI gap: see marchUtils.js COMPILER VERIFICATION SCOPE.
  */
 
-import { buildMarchString, BASE_ISA_IDS, BASE_ISA_PREFIX_MAP } from './marchUtils.js';
+import { buildMarchString, BASE_ISA_IDS, BASE_ISA_PREFIX_MAP, SHORTHAND_BUNDLES } from './marchUtils.js';
 import { buildCombinedCatalog } from './marchUtils.js';
 import { resolveParams } from './isaGraph.js';
 import { DEPENDENCY_GRAPH } from './isaGraph.js';
@@ -161,6 +161,14 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
     }
 
     if (id.length === 1) {
+      if (idUpper === 'I' || idUpper === 'E') {
+        if (idUpper !== baseInfo.base.toUpperCase()) {
+          warnings.push(
+            `"${id}" was dropped: it names a base ISA that is mutually exclusive with ${baseInfo.id}.`,
+          );
+        }
+        continue;
+      }
       singleLetters.push(idUpper);
       allExtTokens.push(idUpper);
     } else {
@@ -374,7 +382,17 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
       .sort((a, b) => RC_LETTER_ORDER.indexOf(a) - RC_LETTER_ORDER.indexOf(b))
       .join('');
     const vPresent = rcSingles.includes('V');
-    const rcCandidates = vPresent ? zExts.filter((z) => !/^Zv(e|l)/i.test(z)) : zExts;
+    const shorthandAbsorbed = new Map();
+    for (const [shorthand, members] of Object.entries(SHORTHAND_BUNDLES)) {
+      if (selectedIds.includes(shorthand)) {
+        for (const member of members) shorthandAbsorbed.set(member, shorthand);
+      }
+    }
+    const rcCandidates = zExts.filter((z) => {
+      if (vPresent && /^Zv(e|l)/i.test(z)) return false;
+      if (shorthandAbsorbed.has(z)) return false;
+      return true;
+    });
     const rcKnown = rcCandidates.filter((z) => RISCV_CONFIG_SUB_EXTENSIONS.has(z)).sort(riscvConfigSort);
     const rcDropped = rcCandidates.filter((z) => !RISCV_CONFIG_SUB_EXTENSIONS.has(z)).sort();
     const rcAbsorbed = vPresent ? zExts.filter((z) => /^Zv(e|l)/i.test(z)).sort() : [];
@@ -395,6 +413,17 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
       rc.push(`# ${rcAbsorbed.length} vector sub-extension(s) folded into V, which is a shorthand`);
       rc.push(`# for Zve64d plus a 128-bit VLEN floor. riscv-config rejects a string`);
       rc.push(`# carrying both: ${rcAbsorbed.join(', ')}`);
+    }
+
+    for (const [shorthand, members] of Object.entries(SHORTHAND_BUNDLES)) {
+      if (!selectedIds.includes(shorthand)) continue;
+      const covered = members.filter((m) => zExts.includes(m)).sort();
+      if (covered.length) {
+        rc.push(``);
+        rc.push(`# ${covered.length} sub-extension(s) folded into ${shorthand}, which is a shorthand`);
+        rc.push(`# for its member subsets. riscv-config rejects a string`);
+        rc.push(`# carrying both: ${covered.join(', ')}`);
+      }
     }
 
     if (rcDropped.length) {

--- a/tests/export.test.mjs
+++ b/tests/export.test.mjs
@@ -176,3 +176,24 @@ test('every S-mode privileged family reaches privilege_extensions', () => {
     );
   }
 });
+
+test('shorthand bundles (Zkn, Zks, Zk) absorb their member subsets in the riscv-config format', () => {
+  // riscv-config: "In presence of Zkn the subsets must be ignored in the ISA string".
+  // clang tolerates the redundant form, but riscv-config rejects it outright.
+  // Same absorption rule as V folding its Zve* and Zvl* vector members.
+  const { yaml } = buildIsaConfigYaml(resolve(['RV64I', 'Zkn']), ALL, { format: 'riscv-config' });
+  const isa = yaml.match(/^ {2}ISA: (\S+)/m)[1];
+  assert.ok(isa.includes('Zkn'), `Zkn should be present in ISA string: ${isa}`);
+  for (const member of ['Zbkb', 'Zbkc', 'Zbkx', 'Zknd', 'Zkne', 'Zknh']) {
+    assert.ok(!isa.includes(member), `Zkn should absorb ${member} in riscv-config format: ${isa}`);
+  }
+  assert.match(yaml, /folded into Zkn/, 'the shorthand absorption should be stated in the file');
+});
+
+test('mutually exclusive base letters (I and E) are not emitted as extensions in export', () => {
+  const { yaml, warnings } = buildIsaConfigYaml(['RV32E', 'I', 'M'], ALL, { format: 'landscape' });
+  const isa = yaml.match(/^isa_string: (\S+)/m)[1];
+  assert.ok(!/rv32ei/i.test(isa), `mutually exclusive base letters must not be combined: ${isa}`);
+  assert.match(isa, /^RV32EM/);
+  assert.ok(warnings.some((w) => /mutually exclusive/i.test(w)));
+});


### PR DESCRIPTION
Closes #271.

Supersedes #272 with verified DCO sign-off matching the commit author email (`143588157+tagadearpit@users.noreply.github.com`).

### Summary of Changes

1. **Absorb shorthand bundles in `riscv-config` export format**:
   - In `src/exportUtils.js`, the `riscv-config` export comments explicitly note:
     ```javascript
     // V is a shorthand for Zve64d plus a 128-bit VLEN floor, so riscv-config
     // treats listing both as an error outright: "V and Zve* cannot exist
     // together". clang tolerates the redundant form, which is why -march keeps
     // it, but this format must not. Same rule as Zkn absorbing Zbkb.
     ```
   - While `V` absorbed `Zv(e|l)`, shorthand crypto bundles (`Zkn`, `Zks`, `Zk`) were not folded in `rcCandidates`. As a result, selecting `Zkn` emitted both the shorthand and its component subsets (`Zbkb`, `Zbkc`, `Zbkx`, etc.) in the `ISA:` string, which `riscv-config` rejects with *"In presence of Zkn the subsets must be ignored in the ISA string."*
   - Imported `SHORTHAND_BUNDLES` from `./marchUtils.js` and filtered out covered member subsets in `rcCandidates` when their shorthand is selected.
   - Emitted a comment block documenting the folded shorthand sub-extensions, matching the existing `V` folding pattern.

2. **Exclude mutually exclusive base letters from extensions in configuration exports**:
   - In `buildIsaConfigYaml`, single-letter extension filtering previously only excluded the chosen base's own letter (`l !== baseInfo.base.toUpperCase()`). If `I` was selected with `RV32E`, `I` remained in `filteredSingles`, producing `RV32EI` in `isa_string`, `rcIsa`, and listing `I` under `extensions:`.
   - Under RISC-V Unprivileged Specification §27, `I` and `E` specify mutually exclusive base integer architectures and cannot appear as extension letters.
   - Handled `I` and `E` explicitly during single-letter partitioning, ensuring neither is admitted as an extension letter and emitting an explicit warning if an incompatible base letter was selected.

3. **Tests**:
   - Added unit test in `tests/export.test.mjs` verifying that `Zkn` absorbs its member subsets (`Zbkb`, `Zbkc`, `Zbkx`, `Zknd`, `Zkne`, `Zknh`) in `riscv-config` format and notes the omission in comments.
   - Added unit test in `tests/export.test.mjs` verifying that mutually exclusive base letters (`I` and `E`) are not emitted as extensions and that appropriate warnings are generated.