### PR TITLE
refactor(march): absorb shorthand bundles in one place, with an explicit rule

### DIFF
--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -17,7 +17,7 @@ import {
   buildMarchString,
   BASE_ISA_IDS,
   BASE_ISA_PREFIX_MAP,
-  SHORTHAND_BUNDLES,
+  absorbedByShorthand,
   COMPILER_COMPAT_NOTES,
 } from './marchUtils.js';
 import { buildCombinedCatalog } from './marchUtils.js';
@@ -387,12 +387,7 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
       .sort((a, b) => RC_LETTER_ORDER.indexOf(a) - RC_LETTER_ORDER.indexOf(b))
       .join('');
     const vPresent = rcSingles.includes('V');
-    const shorthandAbsorbed = new Map();
-    for (const [shorthand, members] of Object.entries(SHORTHAND_BUNDLES)) {
-      if (selectedIds.includes(shorthand)) {
-        for (const member of members) shorthandAbsorbed.set(member, shorthand);
-      }
-    }
+    const shorthandAbsorbed = absorbedByShorthand(selectedIds);
     const rcCandidates = zExts.filter((z) => {
       if (vPresent && /^Zv(e|l)/i.test(z)) return false;
       if (shorthandAbsorbed.has(z)) return false;
@@ -420,15 +415,23 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
       rc.push(`# carrying both: ${rcAbsorbed.join(', ')}`);
     }
 
-    for (const [shorthand, members] of Object.entries(SHORTHAND_BUNDLES)) {
-      if (!selectedIds.includes(shorthand)) continue;
-      const covered = members.filter((m) => zExts.includes(m)).sort();
-      if (covered.length) {
-        rc.push(``);
-        rc.push(`# ${covered.length} sub-extension(s) folded into ${shorthand}, which is a shorthand`);
-        rc.push(`# for its member subsets. riscv-config rejects a string`);
-        rc.push(`# carrying both: ${covered.join(', ')}`);
-      }
+    // Report the fold from the same map that performed it. Grouping
+    // SHORTHAND_BUNDLES independently used to contradict it: with Zk and Zkn
+    // both selected, Zbkb was absorbed once, by Zk, but was reported twice —
+    // as folded into Zkn and again into Zk.
+    const foldedBy = new Map(); // shorthand -> the members it actually absorbed
+    for (const z of zExts) {
+      const shorthand = shorthandAbsorbed.get(z);
+      if (!shorthand) continue;
+      if (!foldedBy.has(shorthand)) foldedBy.set(shorthand, []);
+      foldedBy.get(shorthand).push(z);
+    }
+    for (const [shorthand, covered] of [...foldedBy].sort((a, b) => a[0].localeCompare(b[0]))) {
+      covered.sort();
+      rc.push(``);
+      rc.push(`# ${covered.length} sub-extension(s) folded into ${shorthand}, which is a shorthand`);
+      rc.push(`# for its member subsets. riscv-config rejects a string`);
+      rc.push(`# carrying both: ${covered.join(', ')}`);
     }
 
     if (rcDropped.length) {

--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -415,10 +415,9 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
       rc.push(`# carrying both: ${rcAbsorbed.join(', ')}`);
     }
 
-    // Report the fold from the same map that performed it. Grouping
-    // SHORTHAND_BUNDLES independently used to contradict it: with Zk and Zkn
-    // both selected, Zbkb was absorbed once, by Zk, but was reported twice —
-    // as folded into Zkn and again into Zk.
+    // Report the fold from the map that performed it. Grouping the bundles
+    // separately contradicted it: with Zk and Zkn both selected, Zbkb was
+    // absorbed once, by Zk, yet reported as folded into Zkn and again into Zk.
     const foldedBy = new Map(); // shorthand -> the members it actually absorbed
     for (const z of zExts) {
       const shorthand = shorthandAbsorbed.get(z);

--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -183,6 +183,13 @@ export const SHORTHAND_BUNDLES = {
  * a bundle containing another lists it and then some -- Zk has nine members and
  * lists Zkn, which has six.
  *
+ * That reasoning covers containment. Siblings that overlap without containing
+ * each other -- Zk and Zks both claim Zbkb, neither contains the other -- have
+ * no natural winner, and the rule simply picks the larger. That is fine and
+ * deliberate: both bundles are in the string, both legitimately cover Zbkb, and
+ * what matters is that it is omitted exactly once and attributed the same way
+ * every run. The rule is chosen for determinism there, not correctness.
+ *
  * `bundles` is injectable only so the order-independence claim is testable:
  * pass the same bundles in a different key order and the result must match.
  * Production callers omit it.

--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -74,32 +74,16 @@ export const COMPILER_COMPAT_NOTES = [
 //       'B' was ratified March 2024 (Zba + Zbb + Zbs).
 //       'E' is an alternative base to 'I' (RV32E, RV64E: 16 GPRs).
 export const SINGLE_LETTER_CANONICAL_ORDER = [
-  'i',
-  'e',
-  'm',
-  'a',
-  'f',
-  'd',
-  'q',
-  'c',
-  'b',
-  'j',
-  't',
-  'p',
-  'v',
-  'n',
-  'h',
-  's',
-  'u',
+  'i', 'e', 'm', 'a', 'f', 'd', 'q', 'c', 'b', 'j', 't', 'p', 'v', 'n', 'h', 's', 'u'
 ];
 
 // Mapping from canonical base extension ID (in riscv_extensions.json) to prefix string
 export const BASE_ISA_PREFIX_MAP = {
-  RV32I: { xlen: 32, base: 'i', id: 'RV32I' },
-  RV64I: { xlen: 64, base: 'i', id: 'RV64I' },
-  RV32E: { xlen: 32, base: 'e', id: 'RV32E' },
-  RV64E: { xlen: 64, base: 'e', id: 'RV64E' },
-  RV128I: { xlen: 128, base: 'i', id: 'RV128I' },
+  'RV32I':  { xlen: 32,  base: 'i', id: 'RV32I' },
+  'RV64I':  { xlen: 64,  base: 'i', id: 'RV64I' },
+  'RV32E':  { xlen: 32,  base: 'e', id: 'RV32E' },
+  'RV64E':  { xlen: 64,  base: 'e', id: 'RV64E' },
+  'RV128I': { xlen: 128, base: 'i', id: 'RV128I' },
 };
 
 export const BASE_ISA_IDS = new Set(Object.keys(BASE_ISA_PREFIX_MAP));
@@ -178,32 +162,30 @@ const NON_ISA_EXTENSION_IDS = new Set(['RERI', 'HTI']);
 export const SHORTHAND_BUNDLES = {
   Zkn: ['Zbkb', 'Zbkc', 'Zbkx', 'Zknd', 'Zkne', 'Zknh'],
   Zks: ['Zbkb', 'Zbkc', 'Zbkx', 'Zksed', 'Zksh'],
-  Zk: ['Zbkb', 'Zbkc', 'Zbkx', 'Zknd', 'Zkne', 'Zknh', 'Zkn', 'Zkr', 'Zkt'],
+  Zk:  ['Zbkb', 'Zbkc', 'Zbkx', 'Zknd', 'Zkne', 'Zknh', 'Zkn', 'Zkr', 'Zkt'],
 };
 
 /**
  * Which shorthand, if any, covers each selected sub-extension.
  *
- * A shorthand must not appear in an ISA string alongside its own members, so
- * both the -march encoder and the riscv-config export need to know, for a given
- * selection, which members are absorbed and by what. That question was answered
- * by three separate copies of the same loop, which is a correctness risk rather
- * than mere duplication: bundles overlap, so the answer depends on which copy
- * assigns a shared member last.
+ * A shorthand must not sit in an ISA string beside its own members, so both the
+ * -march encoder and the riscv-config export need to know which members a given
+ * selection absorbs, and by what. That was answered by three copies of the same
+ * loop, which is a correctness risk rather than untidiness: the bundles overlap,
+ * so the answer depended on which copy assigned a shared member last.
  *
- * `Zbkb` and `Zknd` belong to both `Zkn` and `Zk`. Iterating SHORTHAND_BUNDLES
- * in declaration order gives them to `Zk`; iterating it reversed gives them to
- * `Zkn`. Reordering that object would therefore have silently changed the
- * output, and no test covered it.
+ * Zbkb and Zknd belong to both Zkn and Zk. Iterating SHORTHAND_BUNDLES in
+ * declaration order gives them to Zk; iterating it reversed gives them to Zkn.
+ * Reordering that object would have silently changed the output, untested.
  *
- * So the rule is explicit here rather than a side effect of key order: the
- * widest bundle wins. Assigning in ascending member count achieves that,
- * because a bundle that contains another necessarily lists it and then some —
- * `Zk` has nine members and lists `Zkn`, which has six.
+ * The rule is therefore stated here rather than emerging from key order: the
+ * widest bundle wins. Assigning in ascending member count achieves it, because
+ * a bundle containing another lists it and then some -- Zk has nine members and
+ * lists Zkn, which has six.
  *
- * `bundles` is injectable only so a test can prove the order-independence
- * claim: pass the same bundles in a different key order and the result has to
- * match. Production callers should omit it.
+ * `bundles` is injectable only so the order-independence claim is testable:
+ * pass the same bundles in a different key order and the result must match.
+ * Production callers omit it.
  *
  * @param {string[]} selectedIds
  * @param {Record<string, string[]>} [bundles=SHORTHAND_BUNDLES]
@@ -225,11 +207,7 @@ export function absorbedByShorthand(selectedIds, bundles = SHORTHAND_BUNDLES) {
 export const SATP_MODE_IDS = new Set(['Sv32', 'Sv39', 'Sv48', 'Sv57']);
 
 export const NON_MARCH_IDS = new Set([
-  'K',
-  'N',
-  'P',
-  'S',
-  'U', // privilege levels and UI grouping tags
+  'K', 'N', 'P', 'S', 'U',   // privilege levels and UI grouping tags
   ...SATP_MODE_IDS,
 ]); // B removed — ratified, decode-accept + explicit-encode
 
@@ -238,8 +216,8 @@ export const NON_MARCH_IDS = new Set([
 // ============================================================================
 export const DATA_PROVENANCE = {
   spec_reference: 'RISC-V Unprivileged ISA Specification, Chapter 27 (v20240411)',
-  compiler_docs: 'GCC 14.1 / LLVM 18.1 RISC-V Target Architecture Documentation',
-  validation: 'Automated schema-validation against riscv_extensions.json',
+  compiler_docs:  'GCC 14.1 / LLVM 18.1 RISC-V Target Architecture Documentation',
+  validation:     'Automated schema-validation against riscv_extensions.json',
   live_ci_testing:
     'CI does compile-check the generated -march strings against clang. Rows that ' +
     'need a newer clang than the job provides are skipped and reported, so the ' +
@@ -279,7 +257,8 @@ function buildLookup(allExts) {
  * @returns {boolean}
  */
 function isIncompatible(a, b) {
-  return (INCOMPATIBLE_WITH[a] || []).includes(b) || (INCOMPATIBLE_WITH[b] || []).includes(a);
+  return (INCOMPATIBLE_WITH[a] || []).includes(b)
+      || (INCOMPATIBLE_WITH[b] || []).includes(a);
 }
 
 /**
@@ -381,16 +360,15 @@ export function parseMarchString(marchStr, allExts) {
     if (ch === 'g') {
       out.gExpanded = true;
       out.warnings.push(
-        '"g" expanded to: ' +
-          G_EXPANSION_TOKENS.join(', ') +
-          '. Source: RISC-V ISA Spec §27 + GCC 12+/LLVM. ' +
-          'Encoder will always emit explicit tokens, never "g".',
+        '"g" expanded to: ' + G_EXPANSION_TOKENS.join(', ') +
+        '. Source: RISC-V ISA Spec §27 + GCC 12+/LLVM. ' +
+        'Encoder will always emit explicit tokens, never "g".'
       );
       for (const t of G_EXPANSION_TOKENS) tokens.push(t);
     } else if (ch === 'b') {
       out.warnings.push(
         '"b" expanded to: zba, zbb, zbs. Source: Ratified B extension (March 2024). ' +
-          'Encoder will emit explicit Z-extensions for broader toolchain compatibility.',
+        'Encoder will emit explicit Z-extensions for broader toolchain compatibility.'
       );
       tokens.push('zba', 'zbb', 'zbs', 'b');
     } else {
@@ -429,7 +407,7 @@ export function parseMarchString(marchStr, allExts) {
         out.unknownTokens.push(token);
         out.warnings.push(
           `"${token.toUpperCase()}" is in the extension catalog but is NOT a valid -march token ` +
-            `(UI grouping tag or non-ISA entry). It has been ignored.`,
+          `(UI grouping tag or non-ISA entry). It has been ignored.`
         );
         continue;
       }
@@ -487,11 +465,11 @@ export function buildMarchString(selectedIds, _allExts) {
   }
 
   // 1. Detect Base ISA
-  const baseId = selectedIds.find((id) => BASE_ISA_IDS.has(id));
+  const baseId = selectedIds.find(id => BASE_ISA_IDS.has(id));
   if (!baseId) {
     out.warnings.push(
       'Cannot generate a valid -march string without a base ISA. ' +
-        'Please select RV32I, RV64I, RV32E, RV64E, or RV128I.',
+      'Please select RV32I, RV64I, RV32E, RV64E, or RV128I.'
     );
     return out;
   }
@@ -509,7 +487,7 @@ export function buildMarchString(selectedIds, _allExts) {
   // Deliberately narrow. It is NOT "drop anything implied by something else" —
   // D implies F and both belong in the string. Only these three shorthands
   // absorb their members.
-  const absorbed = absorbedByShorthand(selectedIds); // member -> shorthand that covers it
+  const absorbed = absorbedByShorthand(selectedIds); // member -> shorthand covering it
 
   for (const id of selectedIds) {
     if (BASE_ISA_IDS.has(id)) continue;
@@ -523,10 +501,7 @@ export function buildMarchString(selectedIds, _allExts) {
     }
 
     if (SPEC_VERSION_TAG_PATTERN.test(id)) {
-      out.excluded.push({
-        id,
-        reason: 'Privileged spec version compliance tag — not an -march option',
-      });
+      out.excluded.push({ id, reason: 'Privileged spec version compliance tag — not an -march option' });
       continue;
     }
     if (NON_ISA_EXTENSION_IDS.has(id)) {
@@ -548,8 +523,7 @@ export function buildMarchString(selectedIds, _allExts) {
     if (id.toLowerCase() === 'b') {
       out.excluded.push({
         id: 'B',
-        reason:
-          'Ratified but pending broad toolchain support for single-letter "b". Explicit Zba_Zbb_Zbs emitted instead.',
+        reason: 'Ratified but pending broad toolchain support for single-letter "b". Explicit Zba_Zbb_Zbs emitted instead.'
       });
       continue;
     }
@@ -565,7 +539,7 @@ export function buildMarchString(selectedIds, _allExts) {
           reason: `Mutually exclusive with base ISA ${baseInfo.id} — the I and E base ISAs cannot be combined`,
         });
         out.warnings.push(
-          `"${id}" was dropped: it names a base ISA that is mutually exclusive with ${baseInfo.id}.`,
+          `"${id}" was dropped: it names a base ISA that is mutually exclusive with ${baseInfo.id}.`
         );
       }
       continue;
@@ -583,7 +557,7 @@ export function buildMarchString(selectedIds, _allExts) {
       });
       out.warnings.push(
         `"${id}" is not architecturally valid with ${baseInfo.id} and has been excluded ` +
-          `from the generated -march string.`,
+        `from the generated -march string.`
       );
       continue;
     }
@@ -605,11 +579,11 @@ export function buildMarchString(selectedIds, _allExts) {
 
   // Deduplicate tokens
   const uniqSingles = [...new Set(singles)];
-  const uniqMultis = [...new Set(multis)];
+  const uniqMultis  = [...new Set(multis)];
 
   const prefix = `rv${baseInfo.xlen}${baseInfo.base}`;
   const singleStr = uniqSingles.join('');
-  const multiStr = uniqMultis.length > 0 ? '_' + uniqMultis.join('_') : '';
+  const multiStr  = uniqMultis.length > 0 ? '_' + uniqMultis.join('_') : '';
 
   out.march = `${prefix}${singleStr}${multiStr}`;
   return out;
@@ -647,7 +621,7 @@ export function buildCombinedCatalog(selectedIds, allExts) {
   if (!selectedIds || selectedIds.length === 0) return [];
 
   const lookup = buildLookup(allExts);
-  const selectedBaseId = selectedIds.find((id) => BASE_ISA_IDS.has(id));
+  const selectedBaseId = selectedIds.find(id => BASE_ISA_IDS.has(id));
 
   // 1. Determine the True Owner for each tag in the catalog
   const tagToTrueOwner = new Map();
@@ -697,7 +671,7 @@ export function buildCombinedCatalog(selectedIds, allExts) {
 
       // CRITICAL: If the True Owner wasn't explicitly selected by the user, EXCLUDE IT.
       // This prevents "ghost" Zicsr instructions from appearing when only RV32I is selected.
-      if (!selectedIds.some((sel) => sel.toLowerCase() === trueOwner.id.toLowerCase())) {
+      if (!selectedIds.some(sel => sel.toLowerCase() === trueOwner.id.toLowerCase())) {
         continue;
       }
 
@@ -707,7 +681,7 @@ export function buildCombinedCatalog(selectedIds, allExts) {
 
       if (byKey.has(dedupKey)) {
         const entry = byKey.get(dedupKey);
-        if (!entry.sources.some((s) => s.extId === trueOwner.id)) {
+        if (!entry.sources.some(s => s.extId === trueOwner.id)) {
           entry.sources.push({ extId: trueOwner.id, extName: trueOwner.name || trueOwner.id });
         }
       } else {

--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -74,16 +74,32 @@ export const COMPILER_COMPAT_NOTES = [
 //       'B' was ratified March 2024 (Zba + Zbb + Zbs).
 //       'E' is an alternative base to 'I' (RV32E, RV64E: 16 GPRs).
 export const SINGLE_LETTER_CANONICAL_ORDER = [
-  'i', 'e', 'm', 'a', 'f', 'd', 'q', 'c', 'b', 'j', 't', 'p', 'v', 'n', 'h', 's', 'u'
+  'i',
+  'e',
+  'm',
+  'a',
+  'f',
+  'd',
+  'q',
+  'c',
+  'b',
+  'j',
+  't',
+  'p',
+  'v',
+  'n',
+  'h',
+  's',
+  'u',
 ];
 
 // Mapping from canonical base extension ID (in riscv_extensions.json) to prefix string
 export const BASE_ISA_PREFIX_MAP = {
-  'RV32I':  { xlen: 32,  base: 'i', id: 'RV32I' },
-  'RV64I':  { xlen: 64,  base: 'i', id: 'RV64I' },
-  'RV32E':  { xlen: 32,  base: 'e', id: 'RV32E' },
-  'RV64E':  { xlen: 64,  base: 'e', id: 'RV64E' },
-  'RV128I': { xlen: 128, base: 'i', id: 'RV128I' },
+  RV32I: { xlen: 32, base: 'i', id: 'RV32I' },
+  RV64I: { xlen: 64, base: 'i', id: 'RV64I' },
+  RV32E: { xlen: 32, base: 'e', id: 'RV32E' },
+  RV64E: { xlen: 64, base: 'e', id: 'RV64E' },
+  RV128I: { xlen: 128, base: 'i', id: 'RV128I' },
 };
 
 export const BASE_ISA_IDS = new Set(Object.keys(BASE_ISA_PREFIX_MAP));
@@ -162,14 +178,58 @@ const NON_ISA_EXTENSION_IDS = new Set(['RERI', 'HTI']);
 export const SHORTHAND_BUNDLES = {
   Zkn: ['Zbkb', 'Zbkc', 'Zbkx', 'Zknd', 'Zkne', 'Zknh'],
   Zks: ['Zbkb', 'Zbkc', 'Zbkx', 'Zksed', 'Zksh'],
-  Zk:  ['Zbkb', 'Zbkc', 'Zbkx', 'Zknd', 'Zkne', 'Zknh', 'Zkn', 'Zkr', 'Zkt'],
+  Zk: ['Zbkb', 'Zbkc', 'Zbkx', 'Zknd', 'Zkne', 'Zknh', 'Zkn', 'Zkr', 'Zkt'],
 };
+
+/**
+ * Which shorthand, if any, covers each selected sub-extension.
+ *
+ * A shorthand must not appear in an ISA string alongside its own members, so
+ * both the -march encoder and the riscv-config export need to know, for a given
+ * selection, which members are absorbed and by what. That question was answered
+ * by three separate copies of the same loop, which is a correctness risk rather
+ * than mere duplication: bundles overlap, so the answer depends on which copy
+ * assigns a shared member last.
+ *
+ * `Zbkb` and `Zknd` belong to both `Zkn` and `Zk`. Iterating SHORTHAND_BUNDLES
+ * in declaration order gives them to `Zk`; iterating it reversed gives them to
+ * `Zkn`. Reordering that object would therefore have silently changed the
+ * output, and no test covered it.
+ *
+ * So the rule is explicit here rather than a side effect of key order: the
+ * widest bundle wins. Assigning in ascending member count achieves that,
+ * because a bundle that contains another necessarily lists it and then some —
+ * `Zk` has nine members and lists `Zkn`, which has six.
+ *
+ * `bundles` is injectable only so a test can prove the order-independence
+ * claim: pass the same bundles in a different key order and the result has to
+ * match. Production callers should omit it.
+ *
+ * @param {string[]} selectedIds
+ * @param {Record<string, string[]>} [bundles=SHORTHAND_BUNDLES]
+ * @returns {Map<string, string>} member id -> the shorthand that absorbs it
+ */
+export function absorbedByShorthand(selectedIds, bundles = SHORTHAND_BUNDLES) {
+  const selected = new Set(selectedIds || []);
+  const absorbed = new Map();
+  const entries = Object.entries(bundles)
+    .filter(([shorthand]) => selected.has(shorthand))
+    .sort((a, b) => a[1].length - b[1].length);
+  for (const [shorthand, members] of entries) {
+    for (const member of members) absorbed.set(member, shorthand);
+  }
+  return absorbed;
+}
 
 /** The satp MODE values, kept separate so the exclusion reason can be accurate. */
 export const SATP_MODE_IDS = new Set(['Sv32', 'Sv39', 'Sv48', 'Sv57']);
 
 export const NON_MARCH_IDS = new Set([
-  'K', 'N', 'P', 'S', 'U',   // privilege levels and UI grouping tags
+  'K',
+  'N',
+  'P',
+  'S',
+  'U', // privilege levels and UI grouping tags
   ...SATP_MODE_IDS,
 ]); // B removed — ratified, decode-accept + explicit-encode
 
@@ -178,8 +238,8 @@ export const NON_MARCH_IDS = new Set([
 // ============================================================================
 export const DATA_PROVENANCE = {
   spec_reference: 'RISC-V Unprivileged ISA Specification, Chapter 27 (v20240411)',
-  compiler_docs:  'GCC 14.1 / LLVM 18.1 RISC-V Target Architecture Documentation',
-  validation:     'Automated schema-validation against riscv_extensions.json',
+  compiler_docs: 'GCC 14.1 / LLVM 18.1 RISC-V Target Architecture Documentation',
+  validation: 'Automated schema-validation against riscv_extensions.json',
   live_ci_testing:
     'CI does compile-check the generated -march strings against clang. Rows that ' +
     'need a newer clang than the job provides are skipped and reported, so the ' +
@@ -219,8 +279,7 @@ function buildLookup(allExts) {
  * @returns {boolean}
  */
 function isIncompatible(a, b) {
-  return (INCOMPATIBLE_WITH[a] || []).includes(b)
-      || (INCOMPATIBLE_WITH[b] || []).includes(a);
+  return (INCOMPATIBLE_WITH[a] || []).includes(b) || (INCOMPATIBLE_WITH[b] || []).includes(a);
 }
 
 /**
@@ -322,15 +381,16 @@ export function parseMarchString(marchStr, allExts) {
     if (ch === 'g') {
       out.gExpanded = true;
       out.warnings.push(
-        '"g" expanded to: ' + G_EXPANSION_TOKENS.join(', ') +
-        '. Source: RISC-V ISA Spec §27 + GCC 12+/LLVM. ' +
-        'Encoder will always emit explicit tokens, never "g".'
+        '"g" expanded to: ' +
+          G_EXPANSION_TOKENS.join(', ') +
+          '. Source: RISC-V ISA Spec §27 + GCC 12+/LLVM. ' +
+          'Encoder will always emit explicit tokens, never "g".',
       );
       for (const t of G_EXPANSION_TOKENS) tokens.push(t);
     } else if (ch === 'b') {
       out.warnings.push(
         '"b" expanded to: zba, zbb, zbs. Source: Ratified B extension (March 2024). ' +
-        'Encoder will emit explicit Z-extensions for broader toolchain compatibility.'
+          'Encoder will emit explicit Z-extensions for broader toolchain compatibility.',
       );
       tokens.push('zba', 'zbb', 'zbs', 'b');
     } else {
@@ -369,7 +429,7 @@ export function parseMarchString(marchStr, allExts) {
         out.unknownTokens.push(token);
         out.warnings.push(
           `"${token.toUpperCase()}" is in the extension catalog but is NOT a valid -march token ` +
-          `(UI grouping tag or non-ISA entry). It has been ignored.`
+            `(UI grouping tag or non-ISA entry). It has been ignored.`,
         );
         continue;
       }
@@ -427,11 +487,11 @@ export function buildMarchString(selectedIds, _allExts) {
   }
 
   // 1. Detect Base ISA
-  const baseId = selectedIds.find(id => BASE_ISA_IDS.has(id));
+  const baseId = selectedIds.find((id) => BASE_ISA_IDS.has(id));
   if (!baseId) {
     out.warnings.push(
       'Cannot generate a valid -march string without a base ISA. ' +
-      'Please select RV32I, RV64I, RV32E, RV64E, or RV128I.'
+        'Please select RV32I, RV64I, RV32E, RV64E, or RV128I.',
     );
     return out;
   }
@@ -449,11 +509,7 @@ export function buildMarchString(selectedIds, _allExts) {
   // Deliberately narrow. It is NOT "drop anything implied by something else" —
   // D implies F and both belong in the string. Only these three shorthands
   // absorb their members.
-  const absorbed = new Map(); // member -> shorthand that covers it
-  for (const [shorthand, members] of Object.entries(SHORTHAND_BUNDLES)) {
-    if (!selectedIds.includes(shorthand)) continue;
-    for (const member of members) absorbed.set(member, shorthand);
-  }
+  const absorbed = absorbedByShorthand(selectedIds); // member -> shorthand that covers it
 
   for (const id of selectedIds) {
     if (BASE_ISA_IDS.has(id)) continue;
@@ -467,7 +523,10 @@ export function buildMarchString(selectedIds, _allExts) {
     }
 
     if (SPEC_VERSION_TAG_PATTERN.test(id)) {
-      out.excluded.push({ id, reason: 'Privileged spec version compliance tag — not an -march option' });
+      out.excluded.push({
+        id,
+        reason: 'Privileged spec version compliance tag — not an -march option',
+      });
       continue;
     }
     if (NON_ISA_EXTENSION_IDS.has(id)) {
@@ -489,7 +548,8 @@ export function buildMarchString(selectedIds, _allExts) {
     if (id.toLowerCase() === 'b') {
       out.excluded.push({
         id: 'B',
-        reason: 'Ratified but pending broad toolchain support for single-letter "b". Explicit Zba_Zbb_Zbs emitted instead.'
+        reason:
+          'Ratified but pending broad toolchain support for single-letter "b". Explicit Zba_Zbb_Zbs emitted instead.',
       });
       continue;
     }
@@ -505,7 +565,7 @@ export function buildMarchString(selectedIds, _allExts) {
           reason: `Mutually exclusive with base ISA ${baseInfo.id} — the I and E base ISAs cannot be combined`,
         });
         out.warnings.push(
-          `"${id}" was dropped: it names a base ISA that is mutually exclusive with ${baseInfo.id}.`
+          `"${id}" was dropped: it names a base ISA that is mutually exclusive with ${baseInfo.id}.`,
         );
       }
       continue;
@@ -523,7 +583,7 @@ export function buildMarchString(selectedIds, _allExts) {
       });
       out.warnings.push(
         `"${id}" is not architecturally valid with ${baseInfo.id} and has been excluded ` +
-        `from the generated -march string.`
+          `from the generated -march string.`,
       );
       continue;
     }
@@ -545,11 +605,11 @@ export function buildMarchString(selectedIds, _allExts) {
 
   // Deduplicate tokens
   const uniqSingles = [...new Set(singles)];
-  const uniqMultis  = [...new Set(multis)];
+  const uniqMultis = [...new Set(multis)];
 
   const prefix = `rv${baseInfo.xlen}${baseInfo.base}`;
   const singleStr = uniqSingles.join('');
-  const multiStr  = uniqMultis.length > 0 ? '_' + uniqMultis.join('_') : '';
+  const multiStr = uniqMultis.length > 0 ? '_' + uniqMultis.join('_') : '';
 
   out.march = `${prefix}${singleStr}${multiStr}`;
   return out;
@@ -587,7 +647,7 @@ export function buildCombinedCatalog(selectedIds, allExts) {
   if (!selectedIds || selectedIds.length === 0) return [];
 
   const lookup = buildLookup(allExts);
-  const selectedBaseId = selectedIds.find(id => BASE_ISA_IDS.has(id));
+  const selectedBaseId = selectedIds.find((id) => BASE_ISA_IDS.has(id));
 
   // 1. Determine the True Owner for each tag in the catalog
   const tagToTrueOwner = new Map();
@@ -637,7 +697,7 @@ export function buildCombinedCatalog(selectedIds, allExts) {
 
       // CRITICAL: If the True Owner wasn't explicitly selected by the user, EXCLUDE IT.
       // This prevents "ghost" Zicsr instructions from appearing when only RV32I is selected.
-      if (!selectedIds.some(sel => sel.toLowerCase() === trueOwner.id.toLowerCase())) {
+      if (!selectedIds.some((sel) => sel.toLowerCase() === trueOwner.id.toLowerCase())) {
         continue;
       }
 
@@ -647,7 +707,7 @@ export function buildCombinedCatalog(selectedIds, allExts) {
 
       if (byKey.has(dedupKey)) {
         const entry = byKey.get(dedupKey);
-        if (!entry.sources.some(s => s.extId === trueOwner.id)) {
+        if (!entry.sources.some((s) => s.extId === trueOwner.id)) {
           entry.sources.push({ extId: trueOwner.id, extName: trueOwner.name || trueOwner.id });
         }
       } else {

--- a/tests/export.test.mjs
+++ b/tests/export.test.mjs
@@ -299,3 +299,24 @@ test('the vector crypto note names its family by prefix, not by enumeration', ()
   assert.ok(note, 'a vector crypto note should exist');
   assert.match(note, /Zvk\*/, 'name the family by prefix so it cannot drift as members are added');
 });
+
+test('an absorbed extension is reported once, by the bundle that absorbed it', () => {
+  // The fold and the comment describing it used to be computed separately, so
+  // with Zk and Zkn both selected Zbkb was absorbed once, by Zk, and reported
+  // twice: as folded into Zkn and again into Zk. Two answers, one question.
+  const { yaml } = buildIsaConfigYaml(
+    ['RV64I', 'Zk', 'Zkn', 'Zbkb', 'Zbkc', 'Zbkx', 'Zknd', 'Zkne', 'Zknh', 'Zkr', 'Zkt'],
+    ALL,
+    { format: 'riscv-config' },
+  );
+  const blocks = [...yaml.matchAll(/folded into (\w+)[\s\S]*?carrying both: ([^\n]+)/g)];
+  assert.equal(
+    blocks.length,
+    1,
+    `overlapping bundles must yield one fold comment, got ${blocks.length}`,
+  );
+  assert.equal(blocks[0][1], 'Zk', 'the wider bundle is the one that absorbed them');
+  const listed = blocks[0][2].split(',').map((t) => t.trim());
+  assert.equal(new Set(listed).size, listed.length, 'no extension listed twice');
+  assert.ok(listed.includes('Zbkb'), `Zbkb should be reported as folded: ${listed.join(', ')}`);
+});

--- a/tests/march.test.mjs
+++ b/tests/march.test.mjs
@@ -16,6 +16,8 @@ import {
   SMART_DEPENDENCIES,
   INCOMPATIBLE_WITH,
   NON_MARCH_IDS,
+  SHORTHAND_BUNDLES,
+  absorbedByShorthand,
 } from '../src/marchUtils.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -83,7 +85,11 @@ test('every dependency target exists in the catalog', () => {
   for (const [ext, deps] of Object.entries(SMART_DEPENDENCIES)) {
     for (const d of deps) if (!ids.has(d)) missing.push(`${ext} -> ${d}`);
   }
-  assert.deepEqual(missing, [], `dependencies pointing at non-existent extensions:\n  ${missing.join('\n  ')}`);
+  assert.deepEqual(
+    missing,
+    [],
+    `dependencies pointing at non-existent extensions:\n  ${missing.join('\n  ')}`,
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -106,20 +112,14 @@ test('[defect] I and E cannot both be selected', () => {
   // buildMarchString filters only the base's own letter, so an E base with I
   // also selected yields rv32ei..., which no toolchain accepts.
   const r = march(['RV32E', 'I']);
-  assert.ok(
-    !/^rv32ei/.test(r.march ?? ''),
-    `produced mutually exclusive base letters: ${r.march}`,
-  );
+  assert.ok(!/^rv32ei/.test(r.march ?? ''), `produced mutually exclusive base letters: ${r.march}`);
 });
 
 test('[defect] F implies Zicsr', () => {
   // F defines fcsr/frm/fflags, so it depends on Zicsr; GCC's riscv_ext_info
   // encodes the same implication. Absent here, a config with F but no Zicsr
   // resolves without complaint.
-  assert.ok(
-    SMART_DEPENDENCIES.F?.includes('Zicsr'),
-    'SMART_DEPENDENCIES has no F -> Zicsr entry',
-  );
+  assert.ok(SMART_DEPENDENCIES.F?.includes('Zicsr'), 'SMART_DEPENDENCIES has no F -> Zicsr entry');
 });
 
 // ---------------------------------------------------------------------------
@@ -169,4 +169,47 @@ test('suffix-stripping does not resolve naming-prefix/umbrella typos (e.g. zve32
   const p4 = parseMarchString('rv64i_sm1p11', ALL);
   assert.deepEqual(p4.resolvedIds, ['RV64I', 'Sm1p11']);
   assert.deepEqual(p4.unknownTokens, []);
+});
+
+test('a shared member is absorbed by the widest bundle that claims it', () => {
+  // Zbkb and Zknd belong to both Zkn and Zk, and Zk lists Zkn among its own
+  // members, so Zk is the wider claim and has to win. This used to be decided
+  // by whichever entry Object.entries reached last, which made it a property of
+  // how SHORTHAND_BUNDLES happens to be declared rather than of the ISA.
+  const absorbed = absorbedByShorthand(['Zk', 'Zkn', 'Zks']);
+  assert.equal(absorbed.get('Zbkb'), 'Zk');
+  assert.equal(absorbed.get('Zknd'), 'Zk');
+  assert.equal(absorbed.get('Zkn'), 'Zk', 'Zk lists Zkn, so it absorbs it');
+  assert.equal(absorbed.get('Zksed'), 'Zks', 'Zksed is claimed only by Zks');
+});
+
+test('absorption does not depend on the order SHORTHAND_BUNDLES is declared in', () => {
+  // The declared order happens to put Zk last, so simply iterating the object
+  // gives the right answer today and a test that only checks the outcome would
+  // pass even if the rule were deleted. Feed the same bundles in a different
+  // key order instead: widest-wins has to survive that, key order cannot.
+  const selected = Object.keys(SHORTHAND_BUNDLES);
+  const reversed = Object.fromEntries(Object.entries(SHORTHAND_BUNDLES).reverse());
+  const asDeclared = absorbedByShorthand(selected);
+  const asReversed = absorbedByShorthand(selected, reversed);
+  assert.ok(asDeclared.size > 0, 'the fixture should absorb something');
+  assert.deepEqual(
+    [...asDeclared].sort(),
+    [...asReversed].sort(),
+    'reordering SHORTHAND_BUNDLES must not change which shorthand absorbs a member',
+  );
+  // and the surviving answer is the widest claimant, not merely a stable one
+  for (const [member, shorthand] of asDeclared) {
+    const claimants = selected.filter((s) => SHORTHAND_BUNDLES[s].includes(member));
+    const widest = claimants.reduce((a, b) =>
+      SHORTHAND_BUNDLES[b].length > SHORTHAND_BUNDLES[a].length ? b : a,
+    );
+    assert.equal(shorthand, widest, `${member} should be absorbed by ${widest}, not ${shorthand}`);
+  }
+});
+
+test('nothing is absorbed without a shorthand, and the input may be empty', () => {
+  assert.equal(absorbedByShorthand(['RV64I', 'Zbkb']).size, 0, 'a bare member absorbs nothing');
+  assert.equal(absorbedByShorthand([]).size, 0);
+  assert.equal(absorbedByShorthand(undefined).size, 0, 'must not throw on no selection');
 });


### PR DESCRIPTION
Closes #274.

Shorthand-bundle absorption was implemented **three** times, not the two the issue reported: in `buildMarchString`, in the `riscv-config` export path, and again in the loop that writes the comment reporting the fold.

Three copies of one rule is a correctness risk here rather than untidiness, because the bundles overlap and the answer depended on which copy assigned a shared member last.

## The latent bug, confirmed before fixing

`Zbkb` and `Zknd` belong to both `Zkn` and `Zk`, and `Zk` additionally lists `Zkn` itself:

| member | declared order | reversed order |
|---|---|---|
| `Zbkb` | `Zk` | **`Zkn`** |
| `Zknd` | `Zk` | **`Zkn`** |
| `Zkn` | `Zk` | `Zk` |
| `Zksed` | `Zks` | `Zks` |

Reordering `SHORTHAND_BUNDLES` would have silently changed both the `-march` string and the exported ISA string. Nothing tested it.

## The fix

`absorbedByShorthand(selectedIds, bundles = SHORTHAND_BUNDLES)` is exported beside `SHORTHAND_BUNDLES` and called from all three sites. The rule is now **stated rather than emergent**: the widest bundle wins, implemented by assigning in ascending member count, because a bundle containing another lists it and then some — `Zk` has nine members and lists `Zkn`, which has six.

For siblings that overlap without containing each other (`Zk` and `Zks` both claim `Zbkb`), there is no natural winner and the rule picks the larger. That is deliberate, and it is about determinism rather than correctness: both bundles are in the string, both legitimately cover `Zbkb`, and what matters is that it is omitted exactly once and attributed identically every run. The JSDoc says so explicitly, so the justification does not prove less than it appears to.

## A third bug the issue did not mention

The comment block grouped bundles independently of the map that performed the fold, so the output contradicted itself. With `Zk` and `Zkn` both selected, `Zbkb` was absorbed **once**, by `Zk`, but reported **twice**:

```
# ... folded into Zkn ... carrying both: Zbkb, Zbkc, Zbkx, Zknd, Zkne, Zknh
# ... folded into Zk  ... carrying both: Zbkb, Zbkc, Zbkx, Zkn, Zknd, Zkne, Zknh, Zkr, Zkt
```

It now derives from the same map: one block, naming the bundle that actually absorbed them.

## Behaviour

No ISA string changes for any ordinary selection. `Zkn`, `Zks`, `Zk`, `Zk+Zks` and `Zkn+V+Zve64d` all produce byte-identical output to `main`. The only observable change is the fold comment, which is now correct.

## Tests

Four added, all mutation-checked: reversing the sort fails three, deleting it fails the order-independence test.

The `bundles` parameter exists so that last test is possible at all. Without it the test could only check the outcome, and the declared order already yields the right answer — so it passed even with the sort deleted. That is a test that cannot fail, which is worse than no test.

262 pass, 0 fail. `npm run build` and `npm run lint` green.

## Review

Reviewed by two independent models before pushing; both approved with zero findings. They split usefully on the widest-wins rule: one probed its general soundness and found it arbitrary for sibling overlaps, the other probed the practical consequence and found it benign. Both were right, and together they showed the JSDoc justified only the containment half while reading as though it covered everything. That is what `205e10e` fixes.

Not verified: nobody fed a generated config to a real `riscv-config`. CI's clang check covers `-march` strings, not that format.
