### PR TITLE
fix(ui): collapse the details panel, pin it, and let it be dismissed

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1350,7 +1350,7 @@ pre,
 /* Header toolbar. A full-width plate holding filters on the left and actions
    on the right. Full width on purpose: every clipping bug in this header came
    from packing thirteen controls into a right-hand column narrower than they
-   needed, where an overflow-x-hidden root cut the surplus off instead of
+   needed, where an overflow-x-clip root cut the surplus off instead of
    wrapping it. A full-width row wraps. */
 .riscv-toolbar {
   padding: 8px 12px;
@@ -1915,4 +1915,27 @@ pre,
   .ask-ai-btn {
     animation: none;
   }
+}
+
+/* Selected Details dismiss.
+   Previously styled with slate-* literals because it only appeared on mobile,
+   over a dark surface. It is visible in both themes now, so it takes its
+   colours from the tokens like everything else.
+
+   It borrows the report palette rather than a new red: those tokens are already
+   theme-aware and already read as "this removes/reports something". Red suits a
+   dismiss in a way it did not suit the About control, which is informational. */
+.riscv-panel-dismiss {
+  color: var(--riscv-report-fg);
+  background: var(--riscv-report-tint);
+  border: 1px solid transparent;
+}
+.riscv-panel-dismiss:hover {
+  color: var(--riscv-report-fg);
+  background: var(--riscv-report-tint-hover);
+  border-color: var(--riscv-report-edge);
+}
+.riscv-panel-dismiss:focus-visible {
+  outline: 2px solid var(--riscv-report-fg);
+  outline-offset: 2px;
 }

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -860,7 +860,8 @@ const RISCVExplorer = () => {
         instructionExpandOpen ||
         compareOpen ||
         quickExportOpen ||
-        profileMenuOpen
+        profileMenuOpen ||
+        workspacePanelOpen
       ) {
         return;
       }
@@ -877,6 +878,7 @@ const RISCVExplorer = () => {
     compareOpen,
     quickExportOpen,
     profileMenuOpen,
+    workspacePanelOpen,
   ]);
 
   const [quickExportIncludeInstr, setQuickExportIncludeInstr] = useState(true);
@@ -3435,12 +3437,25 @@ const RISCVExplorer = () => {
             )}
           </div>
 
+          {/*
+            The announcement lives out here, not on the panel.
+
+            The panel is display:none until something is selected, and a node
+            that is display:none is not in the accessibility tree, so an
+            aria-live region on it would be created and populated in the same
+            render. Screen readers only announce changes to live regions that
+            already existed, so that combination announces nothing. This node
+            is always mounted and only its text changes.
+          */}
+          <div className="sr-only" role="status" aria-live="polite">
+            {selectedExt ? `${selectedExt.id} details opened` : ''}
+          </div>
+
           {/* ─── Sidebar ─────────────────────────────────────────────────── */}
           <div
             id="detail-panel"
             role="region"
             aria-label="Selected extension details"
-            aria-live="polite"
             className={`lg:col-span-4 mt-6 lg:mt-0 ${
               selectedExt ? 'panel-open' : 'hidden'
             }`}

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -840,6 +840,45 @@ const RISCVExplorer = () => {
     return () => window.removeEventListener('resize', clamp);
   }, [profileMenuOpen]);
   const [quickExportOpen, setQuickExportOpen] = useState(false);
+
+  // Escape dismisses the Selected Details panel, matching the button's tooltip.
+  //
+  // Deliberately last in line: every dialog that can sit above the panel is
+  // checked first, so Escape closes the topmost thing rather than quietly
+  // clearing the selection underneath an open modal. Those dialogs each stop
+  // propagation on their own listener, but they are mounted conditionally and
+  // this one is not, so the guard is what keeps the ordering honest rather
+  // than relying on listener registration order.
+  React.useEffect(() => {
+    if (!selectedExt) return undefined;
+    const onKeyDown = (e) => {
+      if (e.key !== 'Escape') return;
+      if (
+        aboutOpen ||
+        encoderValidatorOpen ||
+        encodingMapOpen ||
+        instructionExpandOpen ||
+        compareOpen ||
+        quickExportOpen ||
+        profileMenuOpen
+      ) {
+        return;
+      }
+      setSelectedExt(null);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [
+    selectedExt,
+    aboutOpen,
+    encoderValidatorOpen,
+    encodingMapOpen,
+    instructionExpandOpen,
+    compareOpen,
+    quickExportOpen,
+    profileMenuOpen,
+  ]);
+
   const [quickExportIncludeInstr, setQuickExportIncludeInstr] = useState(true);
 
   // Smart lock: live reverse-lookup of dependencies, plus the seeding profile's
@@ -1973,7 +2012,7 @@ const RISCVExplorer = () => {
 
   return (
     <div
-      className="min-h-screen relative overflow-x-hidden"
+      className="min-h-screen relative overflow-x-clip"
       style={{ background: 'var(--riscv-bg)', color: 'var(--riscv-text)' }}
     >
       {/* Skip link. First thing in the tab order, visible only once focused.
@@ -2027,7 +2066,7 @@ const RISCVExplorer = () => {
                   </h1>
                 </div>
                 {/* Counts. Wrappable on purpose: this sits inside an
-                    overflow-x-hidden root that clips rather than scrolls, so on
+                    overflow-x-clip root that clips rather than scrolls, so on
                     a narrow screen they drop below the title instead of off the
                     edge. */}
                 <div className="flex flex-wrap items-center gap-x-2 text-[11px]">
@@ -2085,7 +2124,7 @@ const RISCVExplorer = () => {
                   items-end right-aligns children, so a child wider than this
                   column is pushed off the LEFT edge rather than overflowing the
                   right. At 390px that put the controls at left:-179 inside an
-                  overflow-x-hidden root, which clips rather than scrolls, so the
+                  overflow-x-clip root, which clips rather than scrolls, so the
                   profile buttons and the builder toggle could not be reached at
                   all. Stretch until there is room to right-align.
                   min-w-0 because a flex item defaults to min-width:auto and
@@ -2799,7 +2838,9 @@ const RISCVExplorer = () => {
             tabIndex={-1}
             role="region"
             aria-label="Extension catalogue"
-            className="lg:col-span-8 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 auto-rows-min"
+            className={`${
+              selectedExt ? 'lg:col-span-8' : 'lg:col-span-12'
+            } grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 auto-rows-min`}
           >
             {/* Search Bar */}
             <div className="col-span-full mb-2 flex items-center gap-3">
@@ -2925,10 +2966,10 @@ const RISCVExplorer = () => {
 
                 {/* 3. Z-Extensions */}
                 <div
-                  className="col-span-full grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 pt-5"
+                  className="col-span-full columns-1 md:columns-2 xl:columns-3 gap-4 pt-5"
                   style={{ borderTop: '1px solid var(--riscv-border)' }}
                 >
-                  <div className="space-y-2.5">
+                  <div className="space-y-2.5 break-inside-avoid mb-4">
                     <div className="flex items-center gap-2">
                       <Binary size={12} style={{ color: '#a78bfa' }} />
                       <h3
@@ -2954,7 +2995,7 @@ const RISCVExplorer = () => {
                     </div>
                   </div>
 
-                  <div className="space-y-2.5">
+                  <div className="space-y-2.5 break-inside-avoid mb-4">
                     <div className="flex items-center gap-2">
                       <Shuffle size={12} style={{ color: '#fbbf24' }} />
                       <h3
@@ -2980,7 +3021,7 @@ const RISCVExplorer = () => {
                     </div>
                   </div>
 
-                  <div className="space-y-2.5">
+                  <div className="space-y-2.5 break-inside-avoid mb-4">
                     <div className="flex items-center gap-2">
                       <Layers size={12} style={{ color: '#818cf8' }} />
                       <h3
@@ -3006,7 +3047,7 @@ const RISCVExplorer = () => {
                     </div>
                   </div>
 
-                  <div className="space-y-2.5">
+                  <div className="space-y-2.5 break-inside-avoid mb-4">
                     <div className="flex items-center gap-2">
                       <FlaskConical size={12} style={{ color: '#f472b6' }} />
                       <h3
@@ -3032,7 +3073,7 @@ const RISCVExplorer = () => {
                     </div>
                   </div>
 
-                  <div className="space-y-2.5">
+                  <div className="space-y-2.5 break-inside-avoid mb-4">
                     <div className="flex items-center gap-2">
                       <Database size={12} style={{ color: '#38bdf8' }} />
                       <h3
@@ -3058,7 +3099,7 @@ const RISCVExplorer = () => {
                     </div>
                   </div>
 
-                  <div className="space-y-2.5">
+                  <div className="space-y-2.5 break-inside-avoid mb-4">
                     <div className="flex items-center gap-2">
                       <Activity size={12} style={{ color: '#e879f9' }} />
                       <h3
@@ -3084,7 +3125,7 @@ const RISCVExplorer = () => {
                     </div>
                   </div>
 
-                  <div className="space-y-2.5">
+                  <div className="space-y-2.5 break-inside-avoid mb-4">
                     <div className="flex items-center gap-2">
                       <Zap size={12} style={{ color: '#2dd4bf' }} />
                       <h3
@@ -3110,7 +3151,7 @@ const RISCVExplorer = () => {
                     </div>
                   </div>
 
-                  <div className="space-y-2.5">
+                  <div className="space-y-2.5 break-inside-avoid mb-4">
                     <div className="flex items-center gap-2">
                       <Shield size={12} style={{ color: '#f87171' }} />
                       <h3
@@ -3136,7 +3177,7 @@ const RISCVExplorer = () => {
                     </div>
                   </div>
 
-                  <div className="space-y-2.5">
+                  <div className="space-y-2.5 break-inside-avoid mb-4">
                     <div className="flex items-center gap-2">
                       <KeyRound size={12} style={{ color: '#94a3b8' }} />
                       <h3
@@ -3162,7 +3203,7 @@ const RISCVExplorer = () => {
                     </div>
                   </div>
 
-                  <div className="space-y-2.5">
+                  <div className="space-y-2.5 break-inside-avoid mb-4">
                     <div className="flex items-center gap-2">
                       <Lock size={12} style={{ color: '#c4b5fd' }} />
                       <h3
@@ -3188,7 +3229,7 @@ const RISCVExplorer = () => {
                     </div>
                   </div>
 
-                  <div className="space-y-2.5">
+                  <div className="space-y-2.5 break-inside-avoid mb-4">
                     <div className="flex items-center gap-2">
                       <Settings2 size={12} style={{ color: '#fb923c' }} />
                       <h3
@@ -3214,7 +3255,7 @@ const RISCVExplorer = () => {
                     </div>
                   </div>
 
-                  <div className="space-y-2.5">
+                  <div className="space-y-2.5 break-inside-avoid mb-4">
                     <div className="flex items-center gap-2">
                       <MemoryStick size={12} style={{ color: '#fdba74' }} />
                       <h3
@@ -3400,7 +3441,9 @@ const RISCVExplorer = () => {
             role="region"
             aria-label="Selected extension details"
             aria-live="polite"
-            className={`lg:col-span-4 mt-6 lg:mt-0 ${selectedExt ? 'panel-open' : ''}`}
+            className={`lg:col-span-4 mt-6 lg:mt-0 ${
+              selectedExt ? 'panel-open' : 'hidden'
+            }`}
           >
             <div
               className="sticky top-6 riscv-card backdrop-blur-sm min-h-[400px] max-h-[calc(100vh-3rem)] flex flex-col overflow-hidden"
@@ -3419,12 +3462,21 @@ const RISCVExplorer = () => {
                     Selected Details
                   </h2>
                 </div>
-                {/* Mobile Close Button */}
+                {/*
+                  Dismiss. Was lg:hidden, from when the panel was permanently
+                  open on desktop and there was nothing to dismiss it to. Now
+                  that it collapses and the catalogue reclaims the width, a
+                  desktop reader needs the same way out as a mobile one.
+
+                  Themed rather than slate-*: those literals only ever resolved
+                  correctly against the dark surface it used to sit on.
+                */}
                 <button
                   type="button"
                   onClick={() => setSelectedExt(null)}
                   aria-label="Close details panel"
-                  className="lg:hidden p-1 rounded-md text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors"
+                  title="Close (Esc)"
+                  className="p-1 rounded-md transition-colors riscv-panel-dismiss"
                 >
                   <X size={16} />
                 </button>


### PR DESCRIPTION
Closes #279.

Four coupled fixes to the Selected Details panel and the catalogue layout. They ship together because fixing any one alone leaves the UI in a worse state than before.

## 1. The empty panel was clipping the catalogue

It held `lg:col-span-4` whether or not anything was selected, so a third of the viewport was reserved for a card reading "No Extension Selected" while the catalogue ran underneath it. At 1568px the `RV128I` tile was sliced in half and the third column of every group below was truncated.

The panel is no longer rendered until there is a selection, and the catalogue takes all twelve columns until then. Base ISA now shows all five tiles; single-letter extensions fit eight per row instead of seven and a half.

## 2. `position: sticky` on the panel had never worked

The card is styled `sticky top-6`, but the app root carried `overflow-x-hidden`. Per the CSS overflow spec, a non-`visible` value on one axis computes the other to `auto`, so the root resolved to `hidden auto`, became a scroll container, and the card stuck relative to *it* rather than the viewport.

Measured at the bottom of the page: `top: -3551px`. About 3,500px above the viewport.

`overflow-x: clip` contains horizontal overflow identically but does not establish a scroll container.

| | before | after |
|---|---|---|
| card `top` | −3551px | **24px** |
| visible | no | **yes** |
| page jumped | — | **no** |
| horizontal scrollbar | no | **no** |

This was already broken on the live site, where the panel simply scrolls away. Collapsing the panel turned it from cosmetic into a broken interaction: click a tile near the bottom of a 4,600px catalogue and nothing appears to happen. `scrollIntoView()` was the alternative and is worse — it yanks the reader away from the tile they just clicked.

## 3. Short groups reserved a full row of whitespace

The Z-extension sections were a three-column grid, so each row was as tall as its tallest member and Security & CFI's 3 tiles sat beside Vector Subsets' 27. They now flow as CSS multi-columns with `break-inside-avoid`.

**Trade-off, stated plainly:** this changes reading order from row-major to column-major. That is inherent to what reclaims the space, and it was reviewed visually before merging.

## 4. The panel could not be dismissed on desktop

The close button existed but was `lg:hidden`, from when the panel was permanently open and there was nothing to dismiss it to. It is now visible everywhere, with Escape as a second path, guarded on eight dialog states so it closes the topmost thing rather than clearing the selection under an open overlay.

Its `slate-*` literals only ever resolved against the dark surface it used to sit on, so it moves onto the theme tokens, taking the existing report palette rather than a new red. Light theme measures **8.01:1** against the panel surface, past both the 3:1 non-text and 4.5:1 text bars in AGENTS.md.

## Review

Two independent reviewers, neither shown the other's output. **Round 1: both requested changes, and both found the same two defects.**

- **MAJOR, accessibility.** Tailwind's `hidden` is `display: none`, which removes the panel's `aria-live="polite"` region from the accessibility tree — so the region was created and populated in the same render, and screen readers only announce changes to regions that already existed. The announcement was silently lost for exactly the users who depend on it. Fixed with an always-mounted `.sr-only` `role="status"` node; verified the DOM node persists and only its text changes.
- **MINOR.** The Escape guard omitted `workspacePanelOpen`, so Escape over an open builder panel closed it *and* cleared the selection underneath.

Neither was something I had considered, and the accessibility one I would not have caught.

**Round 2 was degraded and is not counted as a pass.** codex approved and verified that `.sr-only` is explicitly defined in `src/index.css` rather than relying on Tailwind generation, that `role="status"` already implies polite so the explicit `aria-live` is redundant but harmless, and that `builderMode` correctly stays unguarded as a persistent mode rather than an overlay. gemini failed twice with HTTP 500 and produced no output — a service-side failure. So confirmation of the round-1 fixes rests on one reviewer, not two.

## Verification

262 tests pass, `npm run build` and `npm run lint` green. All behaviour was checked in a real browser against the built output, in both themes.

Not verified: no screen reader was actually used. The live-region fix is verified structurally — node persistence and text mutation — which is the mechanism, not the lived experience.

One housekeeping note: the first commit's message describes two of the four changes rather than all four. An amend to correct it was blocked by my environment twice. This PR body is the accurate record, and it is what the squash lands.
