### PR TITLE
fix(march): restore DATA_PROVENANCE to an array, unbreaking the builder panel

### DIFF
--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -221,15 +221,32 @@ export const NON_MARCH_IDS = new Set([
 // ============================================================================
 // Data provenance — displayed in ISA Workspace footer
 // ============================================================================
-export const DATA_PROVENANCE = {
-  spec_reference: 'RISC-V Unprivileged ISA Specification, Chapter 27 (v20240411)',
-  compiler_docs:  'GCC 14.1 / LLVM 18.1 RISC-V Target Architecture Documentation',
-  validation:     'Automated schema-validation against riscv_extensions.json',
-  live_ci_testing:
-    'CI does compile-check the generated -march strings against clang. Rows that ' +
-    'need a newer clang than the job provides are skipped and reported, so the ' +
-    'check is a floor rather than full coverage — that is the remaining gap.',
-};
+/**
+ * Where the catalogue's facts come from, rendered as links by WorkspacePanel.
+ *
+ * This is an array of {label, source, url} rows because a consumer maps over
+ * it. It was briefly replaced by an object of prose strings, which threw
+ * "DATA_PROVENANCE.map is not a function" and unmounted the whole app the
+ * moment the builder panel opened. The prose duplicated the DATA SOURCES block
+ * at the top of this file; the rows do not, so the rows are what belongs here.
+ */
+export const DATA_PROVENANCE = [
+  {
+    label: 'Instruction Encodings',
+    source: 'riscv/riscv-opcodes',
+    url: 'https://github.com/riscv/riscv-opcodes',
+  },
+  {
+    label: 'Extension Metadata & Profiles',
+    source: 'RISC-V ISA Manual',
+    url: 'https://github.com/riscv/riscv-isa-manual',
+  },
+  {
+    label: '-march Naming Rules',
+    source: 'RISC-V ISA Spec §27 · GCC 12+ / LLVM convention',
+    url: 'https://github.com/riscv/riscv-isa-manual',
+  },
+];
 
 // ============================================================================
 // G expansion components

--- a/tests/march.test.mjs
+++ b/tests/march.test.mjs
@@ -7,7 +7,7 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import {
@@ -18,6 +18,7 @@ import {
   NON_MARCH_IDS,
   SHORTHAND_BUNDLES,
   absorbedByShorthand,
+  DATA_PROVENANCE,
 } from '../src/marchUtils.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -212,4 +213,53 @@ test('nothing is absorbed without a shorthand, and the input may be empty', () =
   assert.equal(absorbedByShorthand(['RV64I', 'Zbkb']).size, 0, 'a bare member absorbs nothing');
   assert.equal(absorbedByShorthand([]).size, 0);
   assert.equal(absorbedByShorthand(undefined).size, 0, 'must not throw on no selection');
+});
+
+test('DATA_PROVENANCE is an array of rows, because a consumer maps over it', () => {
+  // WorkspacePanel renders DATA_PROVENANCE.map(...). It was briefly replaced by
+  // an object of prose strings, which threw "DATA_PROVENANCE.map is not a
+  // function" and unmounted the entire app the moment the builder panel opened.
+  assert.ok(Array.isArray(DATA_PROVENANCE), 'a consumer calls .map on this');
+  assert.ok(DATA_PROVENANCE.length > 0);
+  for (const row of DATA_PROVENANCE) {
+    for (const key of ['label', 'source', 'url']) {
+      assert.equal(
+        typeof row[key],
+        'string',
+        `provenance row is missing ${key}: ${JSON.stringify(row)}`,
+      );
+      assert.ok(row[key].length > 0, `provenance row has an empty ${key}`);
+    }
+  }
+});
+
+/**
+ * The general form of the bug above.
+ *
+ * Neither build nor lint nor any unit test noticed that an exported constant
+ * changed shape under a consumer that maps over it, because no test opens the
+ * builder panel. Rather than add one test per constant, read the JSX for
+ * `X.map(` where X is imported from marchUtils, and require X to be an array.
+ */
+test('every marchUtils export a component maps over is actually an array', async () => {
+  const mod = await import('../src/marchUtils.js');
+  const srcDir = join(dirname(fileURLToPath(import.meta.url)), '..', 'src');
+  const jsx = readdirSync(srcDir).filter((f) => f.endsWith('.jsx'));
+  const checked = [];
+  for (const file of jsx) {
+    const text = readFileSync(join(srcDir, file), 'utf8');
+    if (!/from '\.\/marchUtils\.js'/.test(text)) continue;
+    for (const [, name] of text.matchAll(/\b([A-Z][A-Z0-9_]+)\.map\(/g)) {
+      if (!(name in mod)) continue;
+      checked.push(`${file}:${name}`);
+      assert.ok(
+        Array.isArray(mod[name]),
+        `${file} calls ${name}.map(...) but marchUtils exports it as ${typeof mod[name]}`,
+      );
+    }
+  }
+  assert.ok(
+    checked.length > 0,
+    'this guard found nothing to check — has the import shape changed?',
+  );
 });


### PR DESCRIPTION
`main` is currently broken. The ISA Configuration Builder shows a **white page**: opening the panel and loading any profile throws

```
TypeError: DATA_PROVENANCE.map is not a function
```

which unmounts the entire React tree, not just the panel.

## Cause

#277 replaced `DATA_PROVENANCE` — an array of `{label, source, url}` rows that `WorkspacePanel.jsx:2255` renders as the "Specification Data Sources" links — with an unrelated object of prose strings. That prose duplicated the `DATA SOURCES` block already at the top of `marchUtils.js`. The rows it displaced duplicated nothing.

Bisected against the built output in a browser:

| commit | PR | builder panel |
|---|---|---|
| `17dcde0` | #273 | works |
| `688ff69` | #275 | works |
| `c09e797` | **#277** | **white page** |
| `37e07d6` | #278 | broken |
| `5ea2320` | #280 | broken |

## Fix

Restore the array, with a note recording that the shape is load-bearing.

## Two guards, because nothing caught this

Build green, lint green, **262 tests passing** — while the application was unusable. No test opens the builder panel.

1. **Specific:** `DATA_PROVENANCE` must be an array of rows with non-empty `label`, `source`, `url`.
2. **General, and the one that matters:** read every `.jsx` importing from `marchUtils`, find `SOME_CONSTANT.map(`, and assert `marchUtils` exports an array under that name. Any future export that changes shape under a consumer that maps over it now fails with the file and the offending type named:

   ```
   WorkspacePanel.jsx calls DATA_PROVENANCE.map(...) but marchUtils exports it as object
   ```

Both mutation-checked by reintroducing the object form: both fail.

## Verification

264 tests pass, build and lint green. Verified in a browser on the built output: RVA23 loads with 78 extensions, 1,024 instructions, the `-march` string, the exclusion list, and the Specification Data Sources panel that this constant feeds.

## Accountability

I approved #277. I flagged its unrelated 334-line rewrite of `marchUtils.js` and specifically noted the provenance citations changing — then merged it without checking whether anything consumed the constant I had just watched change. The review caught the right file and stopped one step short.
