### PR TITLE
feat(ask-ai): open the assistant with a question about what is on screen

### DIFF
--- a/src/AskAiLauncher.jsx
+++ b/src/AskAiLauncher.jsx
@@ -21,6 +21,7 @@ const LS_KEY = 'riscv-ai-corner';
  * itself, and gate rendering on it so a blocked or failed script leaves no
  * button rather than one that silently does nothing when clicked.
  */
+
 function kapaOpenReady() {
   return typeof window.Kapa?.open === 'function';
 }
@@ -45,7 +46,7 @@ function nearestCorner(x, y) {
   return `${v}-${h}`;
 }
 
-const AskAiLauncher = () => {
+const AskAiLauncher = ({ query = null }) => {
   const [corner, setCorner] = React.useState(() => {
     try {
       const saved = window.localStorage.getItem(LS_KEY);
@@ -59,6 +60,47 @@ const AskAiLauncher = () => {
   const [dragging, setDragging] = React.useState(false);
   const [dragPos, setDragPos] = React.useState(null);
   const [kapaReady, setKapaReady] = React.useState(kapaOpenReady);
+  const [buzzing, setBuzzing] = React.useState(false);
+
+  /*
+   * Buzz once when the launcher becomes contextual, so a reader who has just
+   * opened an extension notices the assistant can now answer about it.
+   *
+   * Keyed on the query rather than a boolean, so moving from Zba to Zbb buzzes
+   * again: that is a new thing to ask about. Clearing the selection does not
+   * buzz, because there is nothing to draw attention to.
+   *
+   * Cleared on a timer rather than animationend: animationend never fires under
+   * prefers-reduced-motion, where the animation is suppressed, and the class
+   * would then stay on forever holding its accent border.
+   */
+  React.useEffect(() => {
+    // Clearing the selection must also clear the class. Returning early without
+    // resetting left the chip stuck mid-buzz — holding its accent border and
+    // refusing to animate again — whenever the context went away inside the
+    // 700ms window.
+    if (!query) {
+      setBuzzing(false);
+      return undefined;
+    }
+    /*
+     * Drop the class before re-adding it. Going Zba -> Zbb while the previous
+     * buzz is still running leaves ask-ai-btn--buzz continuously applied, and a
+     * CSS animation only restarts when the class is actually removed and put
+     * back. Without the frame in between, the second selection silently does
+     * not buzz.
+     */
+    setBuzzing(false);
+    let timeoutId;
+    const frameId = requestAnimationFrame(() => {
+      setBuzzing(true);
+      timeoutId = setTimeout(() => setBuzzing(false), 700);
+    });
+    return () => {
+      cancelAnimationFrame(frameId);
+      clearTimeout(timeoutId);
+    };
+  }, [query]);
 
   const dragStartRef = React.useRef(null);
 
@@ -89,8 +131,28 @@ const AskAiLauncher = () => {
 
   const openKapa = React.useCallback(() => {
     if (!kapaOpenReady()) return;
-    window.Kapa.open({ mode: 'ai' });
-  }, []);
+    // `query` pre-fills kapa's box and `submit` sends it, so a reader who
+    // clicked "Ask AI" with Zba open gets the answer rather than a form to
+    // press enter on. Without a selection there is nothing to ask, so the
+    // modal opens empty and waits.
+    const args = query ? { mode: 'ai', query, submit: true } : { mode: 'ai' };
+
+    /*
+     * Plain open, no lifecycle games.
+     *
+     * An unmount()/render() cycle on every click was tried, to force a fresh
+     * conversation. It coincided with kapa answering "We noticed unusual
+     * activity. Please try asking your question again." — its bot protection.
+     * That is unsurprising in hindsight: tearing down and recreating the widget
+     * on every press also tears down the reCAPTCHA context it is protected by,
+     * and rapid remount-then-submit is exactly what automated abuse looks like.
+     *
+     * Fresh conversations are not worth breaking the assistant for. kapa
+     * exposes no supported reset (docs list only open/close/render/unmount and
+     * setSourceGroupIDs); asking them for one is the route, not remounting.
+     */
+    window.Kapa.open(args);
+  }, [query]);
 
   const onPointerDown = React.useCallback((e) => {
     if (e.pointerType === 'mouse' && e.button !== 0) return;
@@ -190,7 +252,9 @@ const AskAiLauncher = () => {
         }}
       >
         <button
-          className={`ask-ai-btn${dragging ? ' ask-ai-btn--dragging' : ''}`}
+          className={`ask-ai-btn${dragging ? ' ask-ai-btn--dragging' : ''}${
+            buzzing && !dragging ? ' ask-ai-btn--buzz' : ''
+          }`}
           aria-label="Ask AI Assistant"
           title="Ask AI — Click to open, drag to move"
           onClick={(e) => e.stopPropagation()}

--- a/src/index.css
+++ b/src/index.css
@@ -1844,9 +1844,17 @@ pre,
   align-items: center;
   justify-content: center;
   gap: 3px;
-  width: 66px;
-  height: 62px;
-  padding: 6px 4px 5px;
+  /* Sizes to its label. It was a fixed 66x62 box with overflow:hidden, from
+     when the label was always the two short words "Ask AI"; once it says
+     "Ask about Zvbc32e" that box clips the extension name off the bottom.
+     The minimum keeps the idle chip the size it has always been, and the
+     maximum stops a long id stretching it across the viewport. */
+  width: auto;
+  min-width: 66px;
+  max-width: 148px;
+  height: auto;
+  min-height: 62px;
+  padding: 6px 10px 5px;
   border-radius: 15px;
   border: 1px solid rgba(139, 124, 248, 0.4);
   background: #1e1b3a;
@@ -1886,10 +1894,42 @@ pre,
 .ask-ai-btn__label {
   font-size: 11.5px;
   font-weight: 700;
-  line-height: 1.1;
+  line-height: 1.15;
   color: #ffffff;
   letter-spacing: 0.02em;
   pointer-events: none;
+  text-align: center;
+  /* Extension ids are unbroken tokens with no spaces to wrap at, so a long one
+     would push past the chip's edge. Allow a break anywhere inside the word,
+     then clamp to two lines and ellipsise rather than growing without limit. */
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* A short buzz when the launcher becomes contextual.
+   Fires once per selection change, not on a loop: a chip that shakes forever
+   is noise, and this one already carries a slow idle pulse. Written as a
+   compound selector so it beats the .ask-ai-btn pulse on specificity rather
+   than relying on source order. */
+@keyframes ask-ai-buzz {
+  0%   { transform: translateX(0) rotate(0deg) scale(1); }
+  12%  { transform: translateX(-3px) rotate(-4deg) scale(1.06); }
+  28%  { transform: translateX(3px) rotate(4deg) scale(1.06); }
+  44%  { transform: translateX(-2px) rotate(-2.5deg) scale(1.04); }
+  60%  { transform: translateX(2px) rotate(2.5deg) scale(1.03); }
+  78%  { transform: translateX(-1px) rotate(-1deg) scale(1.01); }
+  100% { transform: translateX(0) rotate(0deg) scale(1); }
+}
+
+.ask-ai-btn.ask-ai-btn--buzz {
+  animation: ask-ai-buzz 0.6s cubic-bezier(0.36, 0.07, 0.19, 0.97);
+  border-color: rgba(244, 176, 27, 0.85);
+  box-shadow:
+    0 4px 20px rgba(244, 176, 27, 0.35),
+    0 1px 3px rgba(0, 0, 0, 0.3);
 }
 
 /* ── Snap-zone corner hints ─────────────────────────────────────────────── */
@@ -1912,7 +1952,8 @@ pre,
 /* The idle pulse and the settle are decorative; honour a reduced-motion request. */
 @media (prefers-reduced-motion: reduce) {
   .ask-ai-launcher,
-  .ask-ai-btn {
+  .ask-ai-btn,
+  .ask-ai-btn.ask-ai-btn--buzz {
     animation: none;
   }
 }

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -841,6 +841,56 @@ const RISCVExplorer = () => {
   }, [profileMenuOpen]);
   const [quickExportOpen, setQuickExportOpen] = useState(false);
 
+  /*
+   * The question the Ask AI button opens with, derived from whatever the reader
+   * currently has open.
+   *
+   * kapa's open() takes a `query` and pre-fills its box with it. That is a
+   * documented, supported option — worth recording, because an earlier probe
+   * concluded it was ignored. That probe ran while the widget was not yet
+   * allowlisted for this origin, so it was mounting nothing at all and no
+   * option could have had any effect. Re-tested once the widget worked: it
+   * pre-fills.
+   *
+   * Deliberately no `submit`. The question is a starting point the reader can
+   * edit, not one sent on their behalf.
+   *
+   * Ordered most specific first: an open instruction is narrower than the
+   * extension behind it, which is narrower than the builder.
+   */
+  const askAiQuery = React.useMemo(() => {
+    if (selectedExt?.id && selectedInstruction?.mnemonic) {
+      /*
+       * Gated on the extension as well as the instruction.
+       *
+       * Not on instructionExpandOpen: that flag is only true for the expanded
+       * encoding modal, so clicking ADD inside RV32I never satisfied it and the
+       * question fell through to the extension.
+       *
+       * But the instruction alone is not enough either. Closing the details
+       * panel clears selectedExt and leaves selectedInstruction set, so a
+       * reader who picked ADD, closed the panel and then opened the builder
+       * would be asked about ADD. An instruction is only meaningful inside the
+       * extension showing it, so both must be present.
+       */
+      return `What does the ${selectedInstruction.mnemonic} instruction in ${selectedExt.id} do, and how is it encoded?`;
+    }
+    if (selectedExt?.id) {
+      // `short` is the readable label ("Address-Generation Bitmanip"); `name`
+      // is usually just the id again, so it would read "Zba (Zba)".
+      const short =
+        selectedExt.short && selectedExt.short !== selectedExt.id ? ` (${selectedExt.short})` : '';
+      return `What does the ${selectedExt.id} extension${short} do, and what depends on it?`;
+    }
+    if (workspacePanelOpen) {
+      const picked = Array.from(workspaceIds || []);
+      return picked.length
+        ? `I am building a RISC-V ISA configuration with ${picked.join(', ')}. What should I know about combining these?`
+        : 'How do I choose a set of RISC-V extensions for a custom ISA configuration?';
+    }
+    return null;
+  }, [instructionExpandOpen, selectedInstruction, selectedExt, workspacePanelOpen, workspaceIds]);
+
   // Escape dismisses the Selected Details panel, matching the button's tooltip.
   //
   // Deliberately last in line: every dialog that can sit above the panel is
@@ -866,6 +916,7 @@ const RISCVExplorer = () => {
         return;
       }
       setSelectedExt(null);
+      setSelectedInstruction(null);
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
@@ -2120,7 +2171,6 @@ const RISCVExplorer = () => {
                   </a>
                 </div>
               </div>
-
 
               {/* Controls Area.
                   items-end right-aligns children, so a child wider than this
@@ -3456,9 +3506,7 @@ const RISCVExplorer = () => {
             id="detail-panel"
             role="region"
             aria-label="Selected extension details"
-            className={`lg:col-span-4 mt-6 lg:mt-0 ${
-              selectedExt ? 'panel-open' : 'hidden'
-            }`}
+            className={`lg:col-span-4 mt-6 lg:mt-0 ${selectedExt ? 'panel-open' : 'hidden'}`}
           >
             <div
               className="sticky top-6 riscv-card backdrop-blur-sm min-h-[400px] max-h-[calc(100vh-3rem)] flex flex-col overflow-hidden"
@@ -3488,7 +3536,10 @@ const RISCVExplorer = () => {
                 */}
                 <button
                   type="button"
-                  onClick={() => setSelectedExt(null)}
+                  onClick={() => {
+                    setSelectedExt(null);
+                    setSelectedInstruction(null);
+                  }}
                   aria-label="Close details panel"
                   title="Close (Esc)"
                   className="p-1 rounded-md transition-colors riscv-panel-dismiss"
@@ -4305,7 +4356,10 @@ const RISCVExplorer = () => {
                 </button>
               </div>
 
-              <div className="p-4 text-[13px] leading-relaxed" style={{ color: 'var(--riscv-text-2)' }}>
+              <div
+                className="p-4 text-[13px] leading-relaxed"
+                style={{ color: 'var(--riscv-text-2)' }}
+              >
                 <p>
                   Browse every ratified RISC-V extension, its instructions and their encodings.{' '}
                   <span style={{ color: 'var(--riscv-text-3)' }}>
@@ -5294,7 +5348,7 @@ const RISCVExplorer = () => {
       />
 
       {/* ── Ask AI Launcher ── */}
-      <AskAiLauncher />
+      <AskAiLauncher query={askAiQuery} />
 
       {/* ── Workspace Notices Toast ── */}
       <div


### PR DESCRIPTION
Closes #282.

The assistant opened blank. A reader looking at `Zba`, or at `ADD` inside `RV32I`, had to retype what they were already looking at.

## What it does

`window.Kapa.open({ mode: 'ai', query, submit: true })` — both options documented and supported, so **nothing touches the widget's DOM.**

| Context | Question sent |
|---|---|
| Instruction inside an extension | *What does the ADD instruction in RV32I do, and how is it encoded?* |
| Extension selected | *What does the Zba extension (Address-Generation Bitmanip) do, and what depends on it?* |
| Builder open | *I am building a RISC-V ISA configuration with RV64I, M, Zba. What should I know about combining these?* |
| Nothing selected | no query; opens empty |

Plus a one-shot buzz on the chip when the context changes, and the chip now sizes to its label instead of a fixed `66×62` box with `overflow: hidden` that clipped anything longer than "Ask AI" — a latent bug that predates this work.

## The bug the review caught

The instruction question is gated on **both** the extension and the instruction. Gating on the instruction alone leaked: closing the details panel clears `selectedExt` but left `selectedInstruction` set, so picking ADD, closing the panel and opening the builder still asked about ADD — the stale instruction outranking the builder. The close paths now clear the instruction as well, correcting the state rather than masking it.

Verified by driving the real UI and intercepting what reaches `Kapa.open`:

```
RV32I selected      -> "What does the RV32I extension … do, and what depends on it?"
ADD clicked         -> "What does the ADD instruction in RV32I do, and how is it encoded?"
panel closed        -> (no query)          ← was leaking the stale ADD question
```

## Deliberately not included

**Starting a fresh conversation per press.** kapa keeps the thread in the widget instance and documents no reset — the JS API is only `open`, `close`, `render`, `unmount`, `setSourceGroupIDs`, `getSourceGroupIDs`.

An `unmount()`/`render()` cycle was attempted twice and **must not be reintroduced**: once it left the widget permanently dead, and once it tripped kapa's bot protection (*"We noticed unusual activity"*) by tearing down the reCAPTCHA context it runs behind. There's a comment in the code recording this. It needs a supported API from kapa.

## Review

Two independent models, two rounds, neither shown the other's output.

**Round 1: both requested changes, and both found the stale-instruction bug independently.** I introduced it and would have shipped it.

Two findings were **rejected**: removing `submit: true` (the maintainer asked for auto-submit; the quota concern is noted and real, but it's a product decision) and treating the hardcoded "Ask AI" label as a defect (the label was explicitly requested to stay). Neither reviewer pressed either point in round 2.

**Round 2: both approved.** Both raised the same minor — a rapid context change didn't *restart* the animation, since the class never left the element. Fixed anyway, because re-buzzing per selection is the requested behaviour.

## Verification

264 tests pass, `npm run build` and `npm run lint` green. Behaviour checked in a real browser.

**Not verified by me:** the kapa modal does not render in my automation browser, so every claim about what it *displays* rests on the maintainer's observation. That gap caused two regressions during development, both caught by the maintainer rather than by me.
