### PR TITLE
fix(ask-ai): ask a question the specifications can actually answer

### DIFF
--- a/src/AskAiLauncher.jsx
+++ b/src/AskAiLauncher.jsx
@@ -46,7 +46,7 @@ function nearestCorner(x, y) {
   return `${v}-${h}`;
 }
 
-const AskAiLauncher = ({ query = null }) => {
+const AskAiLauncher = ({ context = null }) => {
   const [corner, setCorner] = React.useState(() => {
     try {
       const saved = window.localStorage.getItem(LS_KEY);
@@ -79,7 +79,7 @@ const AskAiLauncher = ({ query = null }) => {
     // resetting left the chip stuck mid-buzz — holding its accent border and
     // refusing to animate again — whenever the context went away inside the
     // 700ms window.
-    if (!query) {
+    if (!context?.query) {
       setBuzzing(false);
       return undefined;
     }
@@ -100,7 +100,7 @@ const AskAiLauncher = ({ query = null }) => {
       cancelAnimationFrame(frameId);
       clearTimeout(timeoutId);
     };
-  }, [query]);
+  }, [context?.query]);
 
   const dragStartRef = React.useRef(null);
 
@@ -135,7 +135,12 @@ const AskAiLauncher = ({ query = null }) => {
     // clicked "Ask AI" with Zba open gets the answer rather than a form to
     // press enter on. Without a selection there is nothing to ask, so the
     // modal opens empty and waits.
-    const args = query ? { mode: 'ai', query, submit: true } : { mode: 'ai' };
+    // Whether to send is the caller's decision: an extension or instruction is
+    // a clean single question worth asking outright, while the builder opens a
+    // sentence for the reader to finish.
+    const args = context?.query
+      ? { mode: 'ai', query: context.query, submit: Boolean(context.submit) }
+      : { mode: 'ai' };
 
     /*
      * Plain open, no lifecycle games.
@@ -152,7 +157,7 @@ const AskAiLauncher = ({ query = null }) => {
      * setSourceGroupIDs); asking them for one is the route, not remounting.
      */
     window.Kapa.open(args);
-  }, [query]);
+  }, [context]);
 
   const onPointerDown = React.useCallback((e) => {
     if (e.pointerType === 'mouse' && e.button !== 0) return;

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -858,79 +858,63 @@ const RISCVExplorer = () => {
    * Ordered most specific first: an open instruction is narrower than the
    * extension behind it, which is narrower than the builder.
    */
-  const askAiQuery = React.useMemo(() => {
-    if (selectedExt?.id && selectedInstruction?.mnemonic) {
+  /*
+   * What the Ask AI button opens with, derived from whatever the reader has on
+   * screen. Returns the question and whether to send it, because those differ
+   * per context.
+   *
+   * Two rules, both from putting the wording to independent review:
+   *
+   * 1. Only the extension id and instruction mnemonic go in. `short` is our own
+   *    editorial label ("Address-Generation Bitmanip"), written for the tiles
+   *    and absent from the specifications kapa retrieves over, so it dilutes
+   *    the match against the one token that does appear verbatim: the id. It
+   *    also produced nonsense on the 41 entries whose short contains
+   *    parentheses, worst of all "the Shvstvala extension (Virtual Supervisor
+   *    Trap Value (vstval) provides all needed values)".
+   *
+   * 2. Single intent. Asking two things at once pulls the query vector between
+   *    them and retrieves a weaker match for both. The dependency and encoding
+   *    detail arrives anyway, because it sits in the same spec passage.
+   *
+   * "RISC-V" is named explicitly. Ids like B, V and M are ambiguous, and the
+   * model writing the answer has read every other architecture too.
+   */
+  const askAiContext = React.useMemo(() => {
+    if (workspacePanelOpen) {
       /*
-       * Gated on the extension as well as the instruction.
+       * Checked first, not last. The builder panel covers the page, so while it
+       * is open it is what the reader is looking at, whatever is still selected
+       * behind it.
        *
-       * Not on instructionExpandOpen: that flag is only true for the expanded
-       * encoding modal, so clicking ADD inside RV32I never satisfied it and the
-       * question fell through to the extension.
+       * Never auto-submitted, and never a list of ids.
        *
-       * But the instruction alone is not enough either. Closing the details
-       * panel clears selectedExt and leaves selectedInstruction set, so a
-       * reader who picked ADD, closed the panel and then opened the builder
-       * would be asked about ADD. An instruction is only meaningful inside the
-       * extension showing it, so both must be present.
+       * A full profile resolves to 78 extensions, and a wall of comma-separated
+       * acronyms matches no passage in any specification: the retriever lands
+       * on something generic like a title page. It is also a poor thing to send
+       * on someone's behalf, because a reader looking at a configuration has a
+       * specific worry in mind and it is rarely "summarise all of these".
+       *
+       * So this opens a sentence for them to finish rather than a question they
+       * did not ask.
        */
-      return `What does the ${selectedInstruction.mnemonic} instruction in ${selectedExt.id} do, and how is it encoded?`;
+      const from = seedProfile ? ` based on the ${seedProfile} profile` : '';
+      return { query: `I am configuring a RISC-V core${from}. `, submit: false };
+    }
+    if (selectedExt?.id && selectedInstruction?.mnemonic) {
+      // Both required: closing the panel clears selectedExt but leaves the
+      // instruction set, and an instruction is only meaningful inside the
+      // extension showing it.
+      return {
+        query: `How does the ${selectedInstruction.mnemonic} instruction work in the RISC-V ${selectedExt.id} extension?`,
+        submit: true,
+      };
     }
     if (selectedExt?.id) {
-      // `short` is the readable label ("Address-Generation Bitmanip"); `name`
-      // is usually just the id again, so it would read "Zba (Zba)".
-      const short =
-        selectedExt.short && selectedExt.short !== selectedExt.id ? ` (${selectedExt.short})` : '';
-      return `What does the ${selectedExt.id} extension${short} do, and what depends on it?`;
-    }
-    if (workspacePanelOpen) {
-      const picked = Array.from(workspaceIds || []);
-      return picked.length
-        ? `I am building a RISC-V ISA configuration with ${picked.join(', ')}. What should I know about combining these?`
-        : 'How do I choose a set of RISC-V extensions for a custom ISA configuration?';
+      return { query: `Explain the RISC-V ${selectedExt.id} extension.`, submit: true };
     }
     return null;
-  }, [instructionExpandOpen, selectedInstruction, selectedExt, workspacePanelOpen, workspaceIds]);
-
-  // Escape dismisses the Selected Details panel, matching the button's tooltip.
-  //
-  // Deliberately last in line: every dialog that can sit above the panel is
-  // checked first, so Escape closes the topmost thing rather than quietly
-  // clearing the selection underneath an open modal. Those dialogs each stop
-  // propagation on their own listener, but they are mounted conditionally and
-  // this one is not, so the guard is what keeps the ordering honest rather
-  // than relying on listener registration order.
-  React.useEffect(() => {
-    if (!selectedExt) return undefined;
-    const onKeyDown = (e) => {
-      if (e.key !== 'Escape') return;
-      if (
-        aboutOpen ||
-        encoderValidatorOpen ||
-        encodingMapOpen ||
-        instructionExpandOpen ||
-        compareOpen ||
-        quickExportOpen ||
-        profileMenuOpen ||
-        workspacePanelOpen
-      ) {
-        return;
-      }
-      setSelectedExt(null);
-      setSelectedInstruction(null);
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [
-    selectedExt,
-    aboutOpen,
-    encoderValidatorOpen,
-    encodingMapOpen,
-    instructionExpandOpen,
-    compareOpen,
-    quickExportOpen,
-    profileMenuOpen,
-    workspacePanelOpen,
-  ]);
+  }, [selectedInstruction, selectedExt, workspacePanelOpen, seedProfile]);
 
   const [quickExportIncludeInstr, setQuickExportIncludeInstr] = useState(true);
 
@@ -5348,7 +5332,7 @@ const RISCVExplorer = () => {
       />
 
       {/* ── Ask AI Launcher ── */}
-      <AskAiLauncher query={askAiQuery} />
+      <AskAiLauncher context={askAiContext} />
 
       {/* ── Workspace Notices Toast ── */}
       <div


### PR DESCRIPTION
Closes #284. Follow-up to #282 / #283.

## The trigger

For `Shvstvala` the button was sending:

> What does the Shvstvala extension (Virtual Supervisor Trap Value (vstval) provides all needed values) do, and what depends on it?

Not an edge case — **41 of 219** `short` values contain parentheses, and 5 are full sentences.

## What changed, and why

| Context | Question | Auto-sends |
|---|---|---|
| Extension | `Explain the RISC-V Zba extension.` | yes |
| Instruction | `How does the ADD instruction work in the RISC-V RV32I extension?` | yes |
| Builder open | `I am configuring a RISC-V core. ` | **no** |

**`short` is gone.** It's our own editorial label, written for the tiles, and it appears nowhere in the specifications kapa retrieves over. Including it dilutes the query against the one token that *does* appear verbatim — the extension id.

**Single intent.** Asking two things at once pulls the query vector between them and retrieves a weaker match for both. The dependency and encoding detail arrives anyway, since it sits in the same spec passage.

**RISC-V named explicitly.** Ids like `B`, `V` and `M` are ambiguous, and the model *writing* the answer has read every other architecture, not just this one.

**The builder no longer lists 78 ids, and no longer auto-sends.** A wall of comma-separated acronyms matches no passage in any specification, so the retriever lands on something generic. It's also a poor thing to send on someone's behalf: a reader looking at a configuration has a specific worry in mind, rarely "summarise all of these". It now opens a sentence for them to finish.

## A bug found while verifying

The builder context wasn't winning even with its panel open — a selected extension still took precedence. That panel covers the page, so while it's open it's what the reader is looking at. The builder branch is now checked first.

Found by driving the UI, not by reading the diff.

## Review

The wording was put to two independent models, neither shown the other's answer.

**Both agreed**, and firmly: drop `short`, name RISC-V explicitly, never auto-submit a list of ids. One called the id list *"catastrophic for retrieval"*; the other made the human argument that it's an unpleasant thing to send unasked.

**They split** on the instruction question — one would keep it compound (behaviour *and* encoding as a single natural lookup), the other would drop the second clause since the retrieved passage carries the encoding regardless. Single intent won, as the safer default.

## Verification

264 tests pass, `npm run build` and `npm run lint` green. All three contexts checked in a real browser by intercepting what reaches `Kapa.open`, including the `Shvstvala` worst case.
