### PR TITLE
ci: sync UDB extensions daily instead of weekly

### DIFF
--- a/.github/workflows/sync-udb-extensions.yml
+++ b/.github/workflows/sync-udb-extensions.yml
@@ -1,9 +1,15 @@
 name: Sync UDB Extensions
 
 on:
-  # Run every Monday at 06:00 UTC
+  # Run daily at 06:00 UTC.
+  #
+  # Was weekly, which meant a UDB change could sit unreflected here for six days.
+  # Daily is safe rather than noisy: the pull request step is guarded on an
+  # actual diff, so a quiet day produces nothing at all, and create-pull-request
+  # reuses one branch, so consecutive days with drift update the same pull
+  # request instead of stacking new ones.
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 * * *'
 
   # Allow manual trigger from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Changes the `Sync UDB Extensions` schedule from `0 6 * * 1` (Mondays) to `0 6 * * *` (daily), both at 06:00 UTC.

A weekly cron meant an upstream change could sit unreflected in the catalogue for six days. The explorer's value is that it matches `riscv-unified-db`, so a week of drift is the wrong default.

**Daily is safe rather than noisy**, which I checked before changing it:

- the Create Pull Request step is guarded on `steps.changes.outputs.changed == 'true'`, computed from a real `git diff` against `riscv_extensions.json` and `isa-dependency-graph.json` — a quiet day produces nothing at all
- `peter-evans/create-pull-request` reuses a single branch, so consecutive days with drift update the same pull request instead of stacking new ones
- the existing `concurrency` group with `cancel-in-progress: false` already serialises runs

Manual `workflow_dispatch` is unchanged. YAML parses.