### PR TITLE
feat: add an Evolution panel showing how the ISA grew (#290)

### DIFF
--- a/src/ExtensionEvolution.jsx
+++ b/src/ExtensionEvolution.jsx
@@ -1,0 +1,338 @@
+import React from 'react';
+import { buildBands, buildEvolution, buildScatter, monotoneSample } from './evolutionModel.js';
+
+/**
+ * ExtensionEvolution — how RISC-V grew, and when each extension arrived.
+ *
+ * Two charts over one calendar axis. The curve answers "how fast did this grow";
+ * the scatter puts every dated extension on the month it was ratified, so the
+ * reader sees the events themselves rather than a summary of them.
+ *
+ * Neither chart has a denominator. The waffle these replaced drew each family as
+ * a row of filled squares, which reads as "42 of 42" when the catalogue has no
+ * maximum; the lifecycle bars that followed implied continuous work across every
+ * year a bar spanned, which is equally untrue. A dot is an event.
+ *
+ * Inline SVG and absolutely-positioned spans rather than a charting library: two
+ * charts of this size do not justify a dependency, and the published page's CSP
+ * admits scripts from a short allowlist only.
+ */
+
+const PAD = { top: 14, right: 10, bottom: 20, left: 38 };
+const CURVE_H = 240;
+
+export default function ExtensionEvolution({ catalog, onSelect }) {
+  const model = React.useMemo(() => buildEvolution(catalog), [catalog]);
+  const scatter = React.useMemo(() => buildScatter(catalog), [catalog]);
+  const bands = React.useMemo(() => buildBands(scatter), [scatter]);
+  const { series, minYear, maxYear } = model;
+
+  const reduceMotion = React.useMemo(
+    () =>
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    [],
+  );
+
+  /*
+   * A continuous playhead rather than a yearly tick. The drawing edge sweeps the
+   * axis and each dot appears as the edge reaches its own month, so the curve is
+   * drawn and populated in one motion instead of arriving in eight jumps.
+   */
+  const [playing, setPlaying] = React.useState(!reduceMotion);
+  const [lit, setLit] = React.useState(null);
+
+  /*
+   * Measured in real pixels rather than a stretched viewBox. Scaling a viewBox
+   * with preserveAspectRatio="none" smears everything that is not a horizontal
+   * line -- axis labels become squiggles, point markers become ellipses -- and
+   * it turns fixed padding into a percentage of the width.
+   */
+  const boxRef = React.useRef(null);
+  const [boxW, setBoxW] = React.useState(0);
+
+  /*
+   * Measured synchronously before paint, then kept current by an observer. The
+   * observer alone was not enough: its first callback can land after the frame
+   * that matters, and the chart then renders its whole geometry against a guessed
+   * width -- the SVG letterboxes and every mark shifts. Measuring in a layout
+   * effect means the first painted frame is already correct.
+   */
+  React.useLayoutEffect(() => {
+    const node = boxRef.current;
+    if (!node) return undefined;
+    const read = () => {
+      const next = node.getBoundingClientRect().width;
+      if (next > 0) setBoxW((prev) => (Math.abs(prev - next) > 0.5 ? next : prev));
+    };
+    read();
+    if (typeof ResizeObserver === 'undefined') return undefined;
+    const ro = new ResizeObserver(read);
+    ro.observe(node);
+    return () => ro.disconnect();
+    /*
+     * Mount only. Without the dependency array this re-ran on every render,
+     * tearing down and rebuilding the observer each time; the measured width
+     * churned by fractions of a pixel, which restarted the animation effect
+     * before it could advance a frame. The playhead sat at the start line.
+     */
+  }, []);
+
+  if (minYear === null) return null;
+
+  /*
+   * One calendar domain -- January of the first year to January after the last --
+   * so a given month is the same horizontal position in both charts. A year's
+   * cumulative total is plotted at the END of that year, which is when it was
+   * actually true, and the line starts from zero at the domain's origin.
+   */
+  const X0 = minYear;
+  const X1 = maxYear + 1;
+  const at = (t) => (t - X0) / (X1 - X0);
+
+  // The layout effect measures before paint, so this fallback only ever applies
+  // in a non-DOM render; the first painted frame already has the real width.
+  const W = boxW || 680;
+  const top = Math.max(...series.map((s) => s.cumulative));
+  const px = (t) => PAD.left + at(t) * (W - PAD.left - PAD.right);
+  const py = (v) => PAD.top + (1 - v / top) * (CURVE_H - PAD.top - PAD.bottom);
+
+  /*
+   * Every edge sampled off one monotone spline, so the bands and the outline
+   * bend identically and the outline still bounds the mass exactly.
+   */
+  const SAMPLES = 240;
+  const sampleXs = Array.from(
+    { length: SAMPLES },
+    (_, i) => px(X0) + (i / (SAMPLES - 1)) * (px(X1) - px(X0)),
+  );
+  const edgeXs = bands.dates.map((d) => px(d)).concat([px(X1)]);
+  const smoothEdge = (values) =>
+    monotoneSample(
+      edgeXs,
+      values.map((v) => py(v)).concat([py(values[values.length - 1])]),
+      sampleXs,
+    );
+
+  /*
+   * The guide is the top of the stack, sampled off the very same spline as the
+   * band edges. Built independently it would drift from the mass it is meant to
+   * bound -- the failure this chart already had once, when the line stepped
+   * yearly over bands that stepped monthly.
+   */
+  const topEdge = smoothEdge(bands.total);
+  const line = `M ${sampleXs.map((x, i) => `${x.toFixed(2)} ${topEdge[i].toFixed(2)}`).join(' L ')}`;
+
+  /*
+   * Each family is one band, stacked in the order the families first
+   * appear. The band's height at any moment is that family's cumulative count,
+   * so the top of the stack is the total and the bands are contiguous blocks of
+   * one colour instead of eighteen hues interleaved a pixel apart.
+   *
+   * Stepped, never smoothed: the total genuinely holds flat between ratification
+   * months, and a curve through those points would draw growth that did not
+   * happen.
+   */
+  const bandPath = (band) => {
+    const lo = smoothEdge(band.base);
+    const hi = smoothEdge(band.base.map((v, i) => v + band.cum[i]));
+    const bottom = sampleXs.map((x, i) => `${x.toFixed(2)} ${lo[i].toFixed(2)}`);
+    const top = sampleXs.map((x, i) => `${x.toFixed(2)} ${hi[i].toFixed(2)}`).reverse();
+    return `M ${bottom.join(' L ')} L ${top.join(' L ')} Z`;
+  };
+
+  const monthLabel = (t) => {
+    const year = Math.floor(t + 1e-6);
+    const month = Math.round((t - year) * 12) + 1;
+    return `${year}-${String(month).padStart(2, '0')}`;
+  };
+
+  return (
+    <section className="riscv-evo" onMouseLeave={() => setLit(null)}>
+      <figure className="riscv-evo__fig" ref={boxRef}>
+        <figcaption>
+          Extensions ratified, cumulative
+          <span className="riscv-evo__hint">
+            every dot is one extension, at its own place in the running total
+          </span>
+          <output className="riscv-evo__read">{`${scatter.events.length} of ${scatter.total}`}</output>
+          <button
+            type="button"
+            className="riscv-evo__play"
+            onClick={() => {
+              // Stopping shows the finished picture rather than whichever year the
+              // loop happened to be passing -- that is the frame worth reading.
+              setPlaying((p) => !p);
+            }}
+            aria-label={playing ? 'Stop and show every year' : 'Replay the timeline from the start'}
+          >
+            {playing ? '❙❙ Show all' : '▶ Replay'}
+          </button>
+        </figcaption>
+
+        {/* The dots are positioned as percentages of this box, so it must wrap the
+            SVG alone. Anchoring them to the <figure> included the caption and
+            pushed every dot upward by its height. */}
+        {/*
+         * The sweep is a CSS animation on this wrapper, inherited by the mass,
+         * the guide and the dot layer alike, so they reveal in lockstep.
+         *
+         * It was a requestAnimationFrame loop writing attributes directly. That
+         * cannot be made reliable here: React owns these elements, and every
+         * reconcile reset the values the frame had just written -- so the
+         * playhead kept snapping back to the start line.
+         */}
+        <div className={'riscv-evo__plot' + (playing ? ' is-sweeping' : '')}>
+          <svg
+            viewBox={`0 0 ${W} ${CURVE_H}`}
+            className="riscv-evo__curve"
+            role="img"
+            aria-label={`Cumulative ratified extensions, rising from ${series[0].cumulative} at the end of ${minYear} to ${top}. The steepest year is ${model.peak.year}, which added ${model.peak.added}.`}
+          >
+            {[0, Math.round(top / 2), top].map((v) => (
+              <g key={v}>
+                <line
+                  className="riscv-evo__grid"
+                  x1={PAD.left}
+                  x2={W - PAD.right}
+                  y1={py(v)}
+                  y2={py(v)}
+                />
+                <text className="riscv-evo__ylabel" x={PAD.left - 8} y={py(v) + 4}>
+                  {v}
+                </text>
+              </g>
+            ))}
+
+            <g className="riscv-evo__mass">
+              {bands.bands.map((band) => (
+                <path
+                  key={band.key}
+                  className={lit && lit !== band.key ? 'is-dim' : undefined}
+                  d={bandPath(band)}
+                  fill={`var(--evo-c${band.colour})`}
+                >
+                  <title>{`${band.label}: ${band.cum[band.cum.length - 1]} ratified`}</title>
+                </path>
+              ))}
+            </g>
+
+            <path className="riscv-evo__line" d={line} clipPath="url(#riscv-evo-reveal)" />
+          </svg>
+
+          {/* Overlaid on the same box and the same scales, so a dot's height is
+            read off the very axis the line is drawn against. */}
+          <div className="riscv-evo__field">
+            {scatter.events.map((e) => (
+              <button
+                type="button"
+                key={e.id}
+                // Always rendered; the sweeping clip on this layer decides
+                // what is visible, so no per-dot state changes during the run.
+                className={'riscv-evo__pt' + (lit && lit !== e.group ? ' is-dim' : '')}
+                style={{
+                  /*
+                   * Percentages of the viewBox, not raw units. The SVG scales its
+                   * viewBox to whatever box it is given -- 240 units into 230px
+                   * here -- so pixel coordinates drift out of register with the
+                   * line and dots near the top escaped the plot entirely. A
+                   * percentage rides the same scaling the line does.
+                   */
+                  left: `${(((px(e.at) + e.dx) / W) * 100).toFixed(3)}%`,
+                  top: `${((py(e.stackY) / CURVE_H) * 100).toFixed(3)}%`,
+                  '--c': `var(--evo-c${e.colour})`,
+                }}
+                title={`${e.id}${e.short ? ` — ${e.short}` : ''}\n${e.family}\nratified ${monthLabel(e.at)}\n#${e.rank} of ${scatter.peakRank} ratified`}
+                onMouseEnter={() => setLit(e.group)}
+                onFocus={() => setLit(e.group)}
+                onClick={() => onSelect && onSelect(e.id)}
+              >
+                <span className="sr-only">{`${e.id}, ${e.family}, ratified ${monthLabel(e.at)}`}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="riscv-evo__axis" aria-hidden="true">
+          {series.map((s) => (
+            <span
+              key={s.year}
+              className="riscv-evo__year"
+              // Centred in its own year rather than on the boundary, so a label
+              // reads as "this band of dots" instead of as a tick.
+              style={{ '--x': at(s.year + 0.5) }}
+            >
+              {`'${String(s.year).slice(2)}`}
+            </span>
+          ))}
+        </div>
+
+        {/*
+         * Off the axis on purpose. These 56 are real catalogued extensions and
+         * belong in the picture -- leaving them out showed 163 of 219 and passed
+         * a subset off as the whole -- but the catalogue records no date for
+         * them, and placing them anywhere on the timeline would invent one. So
+         * they sit below it, behind a rule, labelled for what they are.
+         */}
+        <div className="riscv-evo__nodate">
+          <span className="riscv-evo__nodatelabel">
+            No ratification date recorded <b>{scatter.undated.length}</b>
+            <span className="riscv-evo__hint">— real extensions, not placeable in time</span>
+          </span>
+          <span className="riscv-evo__nodatefield">
+            {scatter.undated.map((e) => (
+              <button
+                type="button"
+                key={e.id}
+                className={
+                  'riscv-evo__pt is-in is-loose' + (lit && lit !== e.group ? ' is-dim' : '')
+                }
+                style={{ '--c': `var(--evo-c${e.colour})` }}
+                title={`${e.id}${e.short ? ` — ${e.short}` : ''}\n${e.family}\nno ratification date recorded`}
+                onMouseEnter={() => setLit(e.group)}
+                onFocus={() => setLit(e.group)}
+                onClick={() => onSelect && onSelect(e.id)}
+              >
+                <span className="sr-only">{`${e.id}, ${e.family}, no ratification date`}</span>
+              </button>
+            ))}
+          </span>
+        </div>
+
+        <ul className="riscv-evo__key">
+          {scatter.legend.map((g) => (
+            <li key={g.key}>
+              <button
+                type="button"
+                className={'riscv-evo__keybtn' + (lit && lit !== g.key ? ' is-dim' : '')}
+                style={{ '--c': `var(--evo-c${g.colour})` }}
+                onMouseEnter={() => setLit(g.key)}
+                onFocus={() => setLit(g.key)}
+                onClick={() => setLit((k) => (k === g.key ? null : g.key))}
+                aria-pressed={lit === g.key}
+              >
+                <i />
+                {g.label}
+                <b>{g.count}</b>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </figure>
+
+      <p className="riscv-evo__foot">
+        {/*
+         * The only caveat that cannot be drawn: a partial year charted as a full
+         * one overstates the slowdown.
+         *
+         * What the undated entries are is said once, on the band itself, where
+         * the reader is looking at them. Repeating it here and in the dialog
+         * subtitle stated one fact three times.
+         */}
+        {maxYear} is still running, so its figure is partial. The curve counts dated extensions
+        only.
+      </p>
+    </section>
+  );
+}

--- a/src/evolutionModel.js
+++ b/src/evolutionModel.js
@@ -1,0 +1,395 @@
+/**
+ * evolutionModel.js — the catalogue arranged as a history.
+ *
+ * Pure functions, no React and no JSON import: the catalogue is passed in, the
+ * same contract marchUtils.js keeps.
+ *
+ * This replaced a waffle model. A waffle is a part-of-whole chart and this data
+ * has no whole: a family drawn as 42 filled squares reads as "42 of 42", but
+ * the catalogue grows and there is no denominator. Equal squares also weighed
+ * `V` (627 instructions) the same as an umbrella tag defining none. What the
+ * reader actually wants is how fast RISC-V grew and which parts have stopped
+ * moving, and neither is a composition question.
+ */
+
+/** The 18 catalogue groups, in tile order, with their headings. */
+export const CATALOGUE_GROUPS = [
+  { key: 'base', label: 'Base ISA' },
+  { key: 'standard', label: 'Single-Letter Extensions' },
+  { key: 'z_bit', label: 'Bit Manipulation (Zb*)' },
+  { key: 'z_atomics', label: 'Atomics (Za/Zic*)' },
+  { key: 'z_compress', label: 'Compressed (Zc*)' },
+  { key: 'z_float', label: 'Float & Numerics (Zf*)' },
+  { key: 'z_load_store', label: 'Load / Store' },
+  { key: 'z_integer', label: 'Integer' },
+  { key: 'z_vector', label: 'Vector Subsets (Zv/Zve)' },
+  { key: 'z_security', label: 'Security & CFI' },
+  { key: 'z_crypto', label: 'Cryptography (Zk*)' },
+  { key: 'z_vector_crypto', label: 'Vector Cryptography (Zvk*)' },
+  { key: 'z_system', label: 'System' },
+  { key: 'z_caches', label: 'Caches' },
+  { key: 's_mem', label: 'Memory & Addressing' },
+  { key: 's_interrupt', label: 'Interrupts (Sm/Ss)' },
+  { key: 's_counters', label: 'Counters & Profiling' },
+  { key: 's_trap', label: 'Traps' },
+];
+
+/**
+ * The ratification date as a fractional year, or null when none is recorded.
+ *
+ * The catalogue stores "YYYY-MM", so snapping to the year discards precision the
+ * data actually has -- and that precision is the story: 2021 was not a steady
+ * year, it was four extensions in June and twenty in November.
+ */
+export function monthOf(ext) {
+  const m = String(ext?.ratification_date ?? '').match(/^(\d{4})-(\d{2})/);
+  if (!m) return null;
+  return Number(m[1]) + (Number(m[2]) - 1) / 12;
+}
+
+/** The year an extension was ratified, or null when the catalogue records none. */
+export function yearOf(ext) {
+  const m = String(ext?.ratification_date ?? '').match(/^(\d{4})/);
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * The catalogue arranged as a history rather than as a composition.
+ *
+ * WHY THIS REPLACED THE WAFFLE
+ *
+ * A waffle is a part-of-whole chart, and this data has no whole. A family drawn
+ * as 42 filled squares reads as "42 of 42, complete", but the catalogue grows:
+ * there is no denominator, and implying one is the single most misleading thing
+ * the old view did. Equal squares also weighed `V` (627 instructions) the same
+ * as an umbrella tag defining none.
+ *
+ * A cumulative curve has no ceiling to misread, and a lifecycle bar is a span
+ * rather than a fraction. Between them they answer the two questions actually
+ * being asked: how fast did RISC-V grow, and which parts of it have settled.
+ *
+ * The undated entries stay off both charts. 56 of 219 carry no ratification
+ * date, and placing them anywhere on a time axis would invent one.
+ */
+export function buildEvolution(catalog, today = new Date()) {
+  const rows = [];
+  for (const group of CATALOGUE_GROUPS) {
+    for (const ext of catalog?.[group.key] || []) {
+      rows.push({
+        id: ext.id,
+        group: group.key,
+        label: group.label,
+        year: yearOf(ext),
+        instructions: Object.keys(ext.instructions || {}).length,
+      });
+    }
+  }
+
+  const dated = rows.filter((r) => r.year !== null);
+  const years = dated.map((r) => r.year);
+  const minYear = years.length ? Math.min(...years) : null;
+  const maxYear = years.length ? Math.max(...years) : null;
+
+  const series = [];
+  let cumulative = 0;
+  let cumulativeInstructions = 0;
+  for (let y = minYear; y <= maxYear; y += 1) {
+    const inYear = dated.filter((r) => r.year === y);
+    const instructions = inYear.reduce((n, r) => n + r.instructions, 0);
+    cumulative += inYear.length;
+    cumulativeInstructions += instructions;
+    series.push({
+      year: y,
+      added: inYear.length,
+      instructions,
+      cumulative,
+      cumulativeInstructions,
+      /*
+       * The current year has not finished, so its bar is not comparable with a
+       * full one. Marked rather than hidden: dropping it would understate the
+       * total, and drawing it unmarked would overstate the slowdown.
+       */
+      partial: y === today.getFullYear(),
+    });
+  }
+
+  const families = CATALOGUE_GROUPS.map((group) => {
+    const members = dated.filter((r) => r.group === group.key);
+    if (members.length === 0) return null;
+    const span = members.map((r) => r.year);
+    /*
+     * One entry per year the family actually shipped in, rather than a first-to-last
+     * span. A span implies continuous work across every year it covers, and that is
+     * not what happened: Memory & Addressing reads as six years of steady output but
+     * is really four bursts separated by two silent years. Discrete points can show
+     * a gap; a bar cannot.
+     */
+    const byYear = new Map();
+    for (const r of members) byYear.set(r.year, (byYear.get(r.year) || 0) + 1);
+    const points = [...byYear.entries()]
+      .map(([year, count]) => ({ year, count }))
+      .sort((a, b) => a.year - b.year);
+    return {
+      key: group.key,
+      label: group.label,
+      first: Math.min(...span),
+      last: Math.max(...span),
+      count: members.length,
+      instructions: members.reduce((n, r) => n + r.instructions, 0),
+      points,
+      // The busiest single year this family had, which sets the largest dot.
+      busiest: Math.max(...points.map((p) => p.count)),
+    };
+  })
+    .filter(Boolean)
+    .sort((a, b) => a.first - b.first || a.last - b.last || b.count - a.count);
+
+  const undated = rows.filter((r) => r.year === null);
+
+  return {
+    series,
+    families,
+    minYear,
+    maxYear,
+    total: rows.length,
+    dated: dated.length,
+    undated: undated.length,
+    undatedInstructions: undated.reduce((n, r) => n + r.instructions, 0),
+    peak: series.reduce((a, b) => (b.added > a.added ? b : a), series[0] || null),
+    // One scale across every row. Sizing each family against its own maximum
+    // would make a family that shipped 2 in a year look like one that shipped 14.
+    busiestCell: families.reduce((n, f) => Math.max(n, f.busiest), 1),
+  };
+}
+
+/**
+ * Every dated extension as its own dot, placed at the month it was ratified.
+ *
+ * The per-family chart this replaced drew one mark per family-year, which still
+ * aggregated: a family that shipped ten in a year was one dot. Here each of the
+ * 163 dated extensions is its own dot, so the shape of the field is the real
+ * distribution rather than a summary of it.
+ *
+ * Dots that share a month stack upward into a column. Within a column they are
+ * ordered by family, so members of one family sit adjacent and a column reads as
+ * coloured bands -- comparing bands is possible, picking one dot out of eighteen
+ * hues is not.
+ */
+export function buildScatter(catalog) {
+  const events = [];
+  const undated = [];
+  for (const [index, group] of CATALOGUE_GROUPS.entries()) {
+    for (const ext of catalog?.[group.key] || []) {
+      const at = monthOf(ext);
+      if (at === null) {
+        /*
+         * Kept, not dropped. These are real catalogued extensions; excluding them
+         * made the chart show 163 of 219 and quietly present a subset as the whole.
+         * They cannot go on a time axis -- there is no date to place them at -- so
+         * they are drawn in their own band, off the axis and labelled as such.
+         */
+        undated.push({
+          id: ext.id,
+          short: ext.short && ext.short !== ext.id ? ext.short : '',
+          group: group.key,
+          family: group.label,
+          colour: index,
+          at: null,
+          year: null,
+          instructions: Object.keys(ext.instructions || {}).length,
+        });
+        continue;
+      }
+      events.push({
+        id: ext.id,
+        short: ext.short && ext.short !== ext.id ? ext.short : '',
+        group: group.key,
+        family: group.label,
+        colour: index,
+        at,
+        year: yearOf(ext),
+        instructions: Object.keys(ext.instructions || {}).length,
+      });
+    }
+  }
+
+  const columns = new Map();
+  for (const e of events) {
+    if (!columns.has(e.at)) columns.set(e.at, []);
+    columns.get(e.at).push(e);
+  }
+
+  /*
+   * Every dot gets its exact position in the running total: the nth extension
+   * ratified sits at height n. So the field rises to the right and the dots ARE
+   * the cumulative growth -- the line through them is a guide, not a separate
+   * chart. Before this the y axis carried nothing, dots sat at a fixed middle,
+   * and the picture said "how many that month" rather than "how many so far".
+   *
+   * Only the horizontal offset is invented. Dots sharing a date would otherwise
+   * be one vertical stroke, so they fan out sideways using a golden-angle cosine
+   * (deterministic -- the picture is identical on every render, unlike jitter).
+   * Vertical position is never nudged, because it is real.
+   */
+  const GOLDEN = Math.PI * (3 - Math.sqrt(5));
+  let rank = 0;
+  let widest = 0;
+  for (const date of [...columns.keys()].sort((x, y) => x - y)) {
+    const column = columns.get(date);
+    column.sort((x, y) => x.colour - y.colour || x.id.localeCompare(y.id));
+    column.forEach((e, i) => {
+      rank += 1;
+      e.rank = rank;
+      e.dx = Math.cos(i * GOLDEN) * (3.5 + Math.sqrt(i) * 2.4);
+      widest = Math.max(widest, Math.abs(e.dx));
+    });
+  }
+
+  const at = events.map((e) => e.at);
+  const all = [...events, ...undated];
+  return {
+    events: events.sort((a, b) => a.rank - b.rank),
+    // Grouped by family so the band reads as coloured runs, like the columns do.
+    undated: undated.sort((a, b) => a.colour - b.colour || a.id.localeCompare(b.id)),
+    total: all.length,
+    // The running total at the end, which is also the y axis maximum, and the
+    // widest horizontal fan, so the chart can inset its edges to contain it.
+    peakRank: rank,
+    widest,
+    months: columns.size,
+    from: Math.min(...at),
+    to: Math.max(...at),
+    // Counts every member, dated or not, so the legend totals the whole catalogue
+    // rather than the part that happens to be placeable in time.
+    legend: CATALOGUE_GROUPS.map((g, i) => ({
+      key: g.key,
+      label: g.label,
+      colour: i,
+      count: all.filter((e) => e.group === g.key).length,
+    })).filter((g) => g.count > 0),
+  };
+}
+
+/**
+ * The cumulative mass, stacked by family instead of by date.
+ *
+ * The version this replaced drew one 1.24px stripe per extension in ratification
+ * order, so eighteen hues interleaved a pixel apart. Two independent reviewers
+ * named the same three causes: the stripes are sub-pixel on ordinary displays,
+ * equal-luminance hues vibrate against one another at that scale, and the
+ * overlap used to close the gaps anti-aliased neighbouring colours together.
+ *
+ * Grouping by family fuses those stripes into contiguous bands. The arithmetic
+ * is the real constraint: 163 separately legible marks stacked with a 1px gap
+ * needs about 490px of height and the whole panel has 400px, so the cumulative
+ * mass cannot be built from one mark per extension. It is built from 18 bands,
+ * and the individual extensions stay visible as arrival dots on top of them.
+ *
+ * Bands are ordered by when each family first appears, so the stack builds from
+ * a stable base rather than reshuffling as it grows.
+ */
+export function buildBands(scatter) {
+  const dates = [...new Set(scatter.events.map((e) => e.at))].sort((a, b) => a - b);
+
+  const firstSeen = new Map();
+  for (const e of scatter.events) {
+    if (!firstSeen.has(e.group)) firstSeen.set(e.group, e.at);
+  }
+  const order = [...firstSeen.entries()].sort((a, b) => a[1] - b[1]).map(([key]) => key);
+
+  const running = dates.map(() => 0);
+  const bands = order.map((key) => {
+    const members = scatter.events
+      .filter((e) => e.group === key)
+      .sort((a, b) => a.at - b.at || a.id.localeCompare(b.id));
+    const cum = dates.map((d) => members.filter((e) => e.at <= d).length);
+    const base = running.slice();
+    cum.forEach((v, i) => {
+      running[i] += v;
+    });
+
+    /*
+     * Each member's dot sits inside its own band, at the height it took the band
+     * to. Its position is therefore still the running total -- just the family's
+     * contribution to it, rather than a global rank.
+     */
+    let within = 0;
+    for (const e of members) {
+      within += 1;
+      const i = dates.indexOf(e.at);
+      e.stackY = base[i] + within;
+    }
+
+    return { key, label: members[0].family, colour: members[0].colour, base, cum };
+  });
+
+  return { dates, bands, total: running };
+}
+
+/**
+ * Monotone cubic interpolation (Fritsch-Carlson), sampled to a polyline.
+ *
+ * The stepped path this softens was honest but hard to look at. An ordinary
+ * spline is not a safe substitute for cumulative data: a Catmull-Rom or plain
+ * bezier overshoots at every corner, so a running total would appear to dip
+ * below a value it had already reached, or rise above one it had not. Nothing in
+ * the ISA ever un-ratifies, and the chart must not draw that.
+ *
+ * Fritsch-Carlson limits the tangents so the interpolant is monotone wherever
+ * the data is. Cumulative counts only ever rise, so the softened edge only ever
+ * rises too. What it does give up is the flat-then-jump shape of a real
+ * ratification: the curve now accrues gradually between months it actually
+ * jumped on. The dots stay at their true months, and carry that truth.
+ */
+export function monotoneSample(xs, ys, at) {
+  const n = xs.length;
+  if (n === 0) return [];
+  if (n === 1) return at.map(() => ys[0]);
+
+  const slope = [];
+  for (let i = 0; i < n - 1; i += 1) {
+    const dx = xs[i + 1] - xs[i];
+    slope.push(dx === 0 ? 0 : (ys[i + 1] - ys[i]) / dx);
+  }
+
+  const m = new Array(n);
+  m[0] = slope[0];
+  m[n - 1] = slope[n - 2];
+  for (let i = 1; i < n - 1; i += 1) m[i] = (slope[i - 1] + slope[i]) / 2;
+
+  for (let i = 0; i < n - 1; i += 1) {
+    if (slope[i] === 0) {
+      m[i] = 0;
+      m[i + 1] = 0;
+      continue;
+    }
+    const a = m[i] / slope[i];
+    const b = m[i + 1] / slope[i];
+    const s = a * a + b * b;
+    // The circle of radius 3 is the monotonicity region; outside it the
+    // interpolant would overshoot, so pull the tangents back onto the boundary.
+    if (s > 9) {
+      const tau = 3 / Math.sqrt(s);
+      m[i] = tau * a * slope[i];
+      m[i + 1] = tau * b * slope[i];
+    }
+  }
+
+  let seg = 0;
+  return at.map((x) => {
+    if (x <= xs[0]) return ys[0];
+    if (x >= xs[n - 1]) return ys[n - 1];
+    while (seg < n - 2 && xs[seg + 1] < x) seg += 1;
+    const h = xs[seg + 1] - xs[seg];
+    if (h === 0) return ys[seg];
+    const t = (x - xs[seg]) / h;
+    const t2 = t * t;
+    const t3 = t2 * t;
+    return (
+      (2 * t3 - 3 * t2 + 1) * ys[seg] +
+      (t3 - 2 * t2 + t) * h * m[seg] +
+      (-2 * t3 + 3 * t2) * ys[seg + 1] +
+      (t3 - t2) * h * m[seg + 1]
+    );
+  });
+}

--- a/src/index.css
+++ b/src/index.css
@@ -322,7 +322,9 @@ pre,
 
 /* A bit position the compared instructions disagree on. Refined border and glow so bit digits inside stay completely legible. */
 .riscv-bit-diff {
-  box-shadow: inset 0 0 0 1.5px var(--riscv-gold), 0 0 5px rgba(245, 197, 66, 0.4);
+  box-shadow:
+    inset 0 0 0 1.5px var(--riscv-gold),
+    0 0 5px rgba(245, 197, 66, 0.4);
   position: relative;
   font-weight: 700;
   color: var(--riscv-text) !important;
@@ -633,6 +635,10 @@ pre,
 }
 
 /* Cards need a real edge on light; on dark the glow did that work. */
+:root[data-theme='light'] .riscv-evo {
+  --evo-accent: #003262;
+}
+
 :root[data-theme='light'] .riscv-card,
 :root[data-theme='light'] .riscv-card-2 {
   box-shadow:
@@ -1342,7 +1348,9 @@ pre,
 }
 .compare-attr.compare-diff {
   background: var(--riscv-panel) !important;
-  box-shadow: inset 3px 0 0 var(--riscv-violet), 2px 0 10px rgba(0, 0, 0, 0.08);
+  box-shadow:
+    inset 3px 0 0 var(--riscv-violet),
+    2px 0 10px rgba(0, 0, 0, 0.08);
   color: var(--riscv-violet);
   font-weight: 700;
 }
@@ -1611,7 +1619,9 @@ pre,
   max-width: min(96vw, 1060px);
   background: var(--riscv-panel);
   border: 1px solid var(--riscv-tint-4);
-  box-shadow: 0 20px 48px -10px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.08);
+  box-shadow:
+    0 20px 48px -10px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(255, 255, 255, 0.08);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
   border-radius: 18px;
@@ -1620,13 +1630,17 @@ pre,
   align-items: center;
   gap: 12px;
   animation: dockSlideUp 0.25s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+  transition:
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
 }
 
 :root[data-theme='light'] .riscv-compare-dock {
   background: rgba(255, 255, 255, 0.94);
   border-color: rgba(0, 0, 0, 0.12);
-  box-shadow: 0 20px 48px -10px rgba(0, 0, 0, 0.18), 0 0 0 1px rgba(0, 0, 0, 0.05);
+  box-shadow:
+    0 20px 48px -10px rgba(0, 0, 0, 0.18),
+    0 0 0 1px rgba(0, 0, 0, 0.05);
 }
 
 .riscv-dock-tab-group {
@@ -1727,7 +1741,9 @@ pre,
   background: var(--riscv-surface-2);
   border: 1px solid var(--riscv-border-2);
   cursor: pointer;
-  transition: background-color 0.2s ease, border-color 0.2s ease;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
   flex-shrink: 0;
 }
 
@@ -1743,7 +1759,9 @@ pre,
   border-radius: 999px;
   background: var(--riscv-text-3);
   transform: translateX(2px);
-  transition: transform 0.2s ease, background-color 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    background-color 0.2s ease;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
@@ -1796,11 +1814,17 @@ pre,
  * --------------------------------------------------------------------------- */
 
 @keyframes ai-pulse {
-  0%, 100% {
-    box-shadow: 0 0 0 0 rgba(139, 124, 248, 0), 0 4px 16px rgba(0, 0, 0, 0.4);
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 0 rgba(139, 124, 248, 0),
+      0 4px 16px rgba(0, 0, 0, 0.4);
   }
   50% {
-    box-shadow: 0 0 0 4px rgba(139, 124, 248, 0.2), 0 0 16px rgba(139, 124, 248, 0.25), 0 6px 20px rgba(0, 0, 0, 0.5);
+    box-shadow:
+      0 0 0 4px rgba(139, 124, 248, 0.2),
+      0 0 16px rgba(139, 124, 248, 0.25),
+      0 6px 20px rgba(0, 0, 0, 0.5);
   }
 }
 
@@ -1858,10 +1882,16 @@ pre,
   border-radius: 15px;
   border: 1px solid rgba(139, 124, 248, 0.4);
   background: #1e1b3a;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4), 0 1px 3px rgba(0, 0, 0, 0.3);
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.4),
+    0 1px 3px rgba(0, 0, 0, 0.3);
   cursor: pointer;
   animation: ai-pulse 3s ease-in-out infinite;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, transform 0.16s ease;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background 0.2s ease,
+    transform 0.16s ease;
   overflow: hidden;
   user-select: none;
 }
@@ -1869,7 +1899,9 @@ pre,
 .ask-ai-btn:hover {
   border-color: rgba(245, 197, 66, 0.85);
   background: #28244c;
-  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.5), 0 0 16px rgba(245, 197, 66, 0.3);
+  box-shadow:
+    0 6px 22px rgba(0, 0, 0, 0.5),
+    0 0 16px rgba(245, 197, 66, 0.3);
   transform: scale(1.06);
   animation: none;
 }
@@ -1915,13 +1947,27 @@ pre,
    compound selector so it beats the .ask-ai-btn pulse on specificity rather
    than relying on source order. */
 @keyframes ask-ai-buzz {
-  0%   { transform: translateX(0) rotate(0deg) scale(1); }
-  12%  { transform: translateX(-3px) rotate(-4deg) scale(1.06); }
-  28%  { transform: translateX(3px) rotate(4deg) scale(1.06); }
-  44%  { transform: translateX(-2px) rotate(-2.5deg) scale(1.04); }
-  60%  { transform: translateX(2px) rotate(2.5deg) scale(1.03); }
-  78%  { transform: translateX(-1px) rotate(-1deg) scale(1.01); }
-  100% { transform: translateX(0) rotate(0deg) scale(1); }
+  0% {
+    transform: translateX(0) rotate(0deg) scale(1);
+  }
+  12% {
+    transform: translateX(-3px) rotate(-4deg) scale(1.06);
+  }
+  28% {
+    transform: translateX(3px) rotate(4deg) scale(1.06);
+  }
+  44% {
+    transform: translateX(-2px) rotate(-2.5deg) scale(1.04);
+  }
+  60% {
+    transform: translateX(2px) rotate(2.5deg) scale(1.03);
+  }
+  78% {
+    transform: translateX(-1px) rotate(-1deg) scale(1.01);
+  }
+  100% {
+    transform: translateX(0) rotate(0deg) scale(1);
+  }
 }
 
 .ask-ai-btn.ask-ai-btn--buzz {
@@ -1940,7 +1986,10 @@ pre,
   border-radius: 15px;
   border: 1.5px dashed rgba(139, 124, 248, 0.35);
   background: rgba(139, 124, 248, 0.06);
-  transition: border-color 0.15s ease, background 0.15s ease, transform 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease,
+    transform 0.15s ease;
 }
 
 .ask-ai-snap-hint--active {
@@ -1979,4 +2028,360 @@ pre,
 .riscv-panel-dismiss:focus-visible {
   outline: 2px solid var(--riscv-report-fg);
   outline-offset: 2px;
+}
+
+/* ── evolution: growth curve + family lifecycles ───────────────────────── */
+
+.riscv-evo {
+  /*
+   * Berkeley's two brand colours, one per ground. Neither works on both: gold is
+   * 1.78:1 on white and blue is 1.32:1 on the dark surface, so a single accent
+   * would fail one theme outright. Paired to their own grounds they measure
+   * 9.57:1 and 12.86:1. Dark is the default theme here, so gold lives on :root.
+   */
+  --evo-accent: #fdb515;
+  --inset: 18px;
+  /*
+   * Eighteen hues solved to the SAME relative luminance (~0.205), which is the
+   * only band that clears 3:1 against both the white and the near-black ground.
+   * A conventional palette needs a light and a dark variant; equal-luminance
+   * needs one, and every hue measures ~4.1:1 in both themes.
+   *
+   * Eighteen colours is past what anyone reliably tells apart from memory, so
+   * the legend is interactive: hovering a family dims the rest. The colours
+   * group a column into bands; the legend is what identifies them.
+   */
+  --evo-c0: #e04444;
+  --evo-c1: #189040;
+  --evo-c2: #b14fe2;
+  --evo-c3: #828215;
+  --evo-c4: #1e85b8;
+  --evo-c5: #e03e73;
+  --evo-c6: #189118;
+  --evo-c7: #8f63e6;
+  --evo-c8: #a3751a;
+  --evo-c9: #178a8b;
+  --evo-c10: #de32a4;
+  --evo-c11: #3f8e17;
+  --evo-c12: #6f6fe7;
+  --evo-c13: #cd5b21;
+  --evo-c14: #178e66;
+  --evo-c15: #d623d6;
+  --evo-c16: #628916;
+  --evo-c17: #4679e1;
+  font-size: 12px;
+  color: var(--riscv-text-2);
+}
+
+/* Sits at the end of the first caption row rather than in a header of its own:
+   one line of chrome instead of two. */
+.riscv-evo__play {
+  margin-left: auto;
+  border: 1px solid var(--riscv-border);
+  background: var(--riscv-surface-2);
+  color: var(--riscv-text-2);
+  border-radius: 999px;
+  padding: 3px 12px;
+  font-size: 11px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.riscv-evo__play:hover {
+  color: var(--riscv-text);
+  border-color: var(--riscv-border-2);
+}
+
+.riscv-evo__fig {
+  margin: 14px 0 0;
+}
+
+.riscv-evo__fig figcaption {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--riscv-text-3);
+  margin-bottom: 6px;
+}
+
+.riscv-evo__read {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+  text-transform: none;
+  font-weight: 700;
+  color: var(--riscv-text);
+}
+
+.riscv-evo__hint {
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--riscv-text-3);
+}
+
+/* The viewBox is regenerated from the measured width, so one SVG unit is one
+   CSS pixel and nothing needs to compensate for a non-uniform scale. */
+.riscv-evo__plot {
+  position: relative;
+}
+
+/*
+ * One animation, inherited by every layer inside the plot, so the mass, the
+ * guide and the dots are revealed by the same moving edge: a dot becomes
+ * visible exactly as the curve reaches its month.
+ */
+@keyframes riscv-evo-sweep {
+  from {
+    clip-path: inset(0 100% 0 0);
+  }
+  to {
+    clip-path: inset(0 0 0 0);
+  }
+}
+
+.riscv-evo__plot.is-sweeping .riscv-evo__mass,
+.riscv-evo__plot.is-sweeping .riscv-evo__line,
+.riscv-evo__plot.is-sweeping .riscv-evo__field {
+  animation: riscv-evo-sweep 7s linear infinite;
+}
+
+/* Stopped means finished, not frozen mid-sweep. */
+.riscv-evo__plot:not(.is-sweeping) .riscv-evo__mass,
+.riscv-evo__plot:not(.is-sweeping) .riscv-evo__line,
+.riscv-evo__plot:not(.is-sweeping) .riscv-evo__field {
+  clip-path: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .riscv-evo__plot.is-sweeping .riscv-evo__mass,
+  .riscv-evo__plot.is-sweeping .riscv-evo__line,
+  .riscv-evo__plot.is-sweeping .riscv-evo__field {
+    animation: none;
+    clip-path: none;
+  }
+}
+
+.riscv-evo__curve {
+  display: block;
+  width: 100%;
+  height: 240px;
+  overflow: visible;
+}
+
+.riscv-evo__grid {
+  stroke: var(--riscv-border);
+  stroke-width: 1;
+}
+
+.riscv-evo__ylabel {
+  fill: var(--riscv-text-3);
+  font-size: 10px;
+  text-anchor: end;
+  font-variant-numeric: tabular-nums;
+}
+
+/* The mass carries the data; the line rides over it as a guide. */
+/* The stacked bands carry the data; the line rides over them as a guide.
+   A hairline separator keeps adjacent bands from fusing where two families
+   happen to sit next to each other in similar tones. */
+.riscv-evo__mass path {
+  stroke: var(--riscv-surface);
+  stroke-width: 0.5;
+  transition: opacity 0.16s ease;
+}
+
+.riscv-evo__mass path.is-dim {
+  opacity: 0.12;
+}
+
+/* vector-effect keeps the stroke one pixel wide however far the viewBox is
+   stretched horizontally; without it a non-uniform scale smears the line. */
+.riscv-evo__line {
+  fill: none;
+  stroke: var(--evo-accent);
+  stroke-width: 1.5;
+  stroke-linejoin: round;
+  stroke-linecap: round;
+}
+
+.riscv-evo__dot {
+  fill: var(--evo-accent);
+}
+
+/* The steepest year earns a marker. It is the one number in the chart worth
+   carrying away, so it is drawn rather than left to be inferred. */
+.riscv-evo__dot.is-peak {
+  stroke: var(--riscv-surface);
+  stroke-width: 2.5;
+}
+
+/* Dots are absolutely placed on a shared calendar scale, inset by half a dot at
+   each end so nothing overflows the field. The year axis below uses the same
+   inset, so a dot sits over the year it belongs to. */
+/* Laid over the SVG rather than beside it: same box, same scales, one chart. */
+.riscv-evo__field {
+  position: absolute;
+  inset: 0;
+}
+
+.riscv-evo__pt {
+  position: absolute;
+  /* left/top come from the component, in the SVG's own pixel space. */
+  width: 8px;
+  height: 8px;
+  margin: -4px 0 0 -4px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: var(--c);
+  cursor: pointer;
+  transition: opacity 0.16s ease;
+}
+
+/* Dimmed rather than hidden: the shape of the whole field stays legible while
+   one family is picked out of it. */
+.riscv-evo__pt.is-dim {
+  opacity: 0.12;
+}
+
+.riscv-evo__pt:hover,
+.riscv-evo__pt:focus-visible {
+  outline: 2px solid var(--riscv-text);
+  outline-offset: 1px;
+  z-index: 2;
+}
+
+/* Separated by a rule and its own label, so nothing here can be read as sitting
+   at a point on the axis above. */
+.riscv-evo__nodate {
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px dashed var(--riscv-border-2);
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.riscv-evo__nodatelabel {
+  font-size: 10.5px;
+  color: var(--riscv-text-3);
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  flex: none;
+}
+
+.riscv-evo__nodatelabel b {
+  color: var(--riscv-text-2);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Flow, not absolute placement: these dots have no coordinate to be placed at,
+   and packing them in a row says so more plainly than any caption. */
+.riscv-evo__nodatefield {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  flex: 1 1 240px;
+  align-content: flex-start;
+}
+
+/* The undated band has no coordinates at all, so its dots flow instead. */
+.riscv-evo__pt.is-loose {
+  position: static;
+  top: auto;
+  left: auto;
+  margin: 0;
+  flex: none;
+}
+
+.riscv-evo__key {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px 10px;
+  margin: 10px 0 0;
+  padding: 0;
+}
+
+.riscv-evo__keybtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 0;
+  padding: 1px 0;
+  background: none;
+  font: inherit;
+  font-size: 10.5px;
+  color: var(--riscv-text-2);
+  cursor: pointer;
+  transition: opacity 0.16s ease;
+}
+
+.riscv-evo__keybtn.is-dim {
+  opacity: 0.3;
+}
+
+.riscv-evo__keybtn i {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--c);
+  flex: none;
+}
+
+.riscv-evo__keybtn b {
+  color: var(--riscv-text-3);
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+}
+
+.riscv-evo__keybtn:hover,
+.riscv-evo__keybtn:focus-visible {
+  color: var(--riscv-text);
+}
+
+/* Inherits --inset from the field above so a label sits under its own cloud. */
+.riscv-evo__axis {
+  position: relative;
+  height: 14px;
+  margin: 5px 0 0;
+}
+
+.riscv-evo__year {
+  position: absolute;
+  top: 0;
+  left: calc(var(--inset) + var(--x) * (100% - var(--inset) * 2));
+  transform: translateX(-50%);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  color: var(--riscv-text-3);
+}
+
+.riscv-evo__year.is-current {
+  color: var(--riscv-text);
+  font-weight: 700;
+}
+
+.riscv-evo__foot {
+  margin: 14px 0 0;
+  padding-top: 10px;
+  border-top: 1px solid var(--riscv-border);
+  font-size: 11.5px;
+  color: var(--riscv-text-3);
+}
+
+.riscv-evo__foot b {
+  color: var(--riscv-text-2);
+  font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .riscv-evo__pt {
+    transition: none;
+  }
 }

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -23,6 +23,7 @@ import {
   ExternalLink,
   Network,
   Activity,
+  AreaChart,
   BookOpen,
   AlertTriangle,
   CheckCircle2,
@@ -79,6 +80,7 @@ import { PROFILES } from './profiles.js';
 import PROFILE_OPTIONAL from './profile-optional.json';
 import { buildIsaConfigYaml } from './exportUtils.js';
 import AskAiLauncher from './AskAiLauncher.jsx';
+import ExtensionEvolution from './ExtensionEvolution.jsx';
 
 // Ids the catalog can actually render. The dependency graph carries a few nodes
 // the catalog does not (UDB's S requires Sm, for which we have no entry), and
@@ -575,6 +577,8 @@ const RISCVExplorer = () => {
   // cost three lines of vertical space above the fold to say something a
   // returning visitor already knows). The trigger keeps it one click away.
   const [aboutOpen, setAboutOpen] = useState(false);
+  const [evolutionOpen, setEvolutionOpen] = useState(false);
+  const evolutionTriggerRef = React.useRef(null);
   const aboutTriggerRef = React.useRef(null);
   const [encodingMapOpen, setEncodingMapOpen] = useState(false);
   const [encoderValidatorInput, setEncoderValidatorInput] = useState({
@@ -609,6 +613,24 @@ const RISCVExplorer = () => {
       aboutTriggerRef.current?.focus();
     };
   }, [aboutOpen]);
+
+  // Evolution panel: same shape as the About dialog above. It holds a slider
+  // and 219 buttons, but they are all inside the dialog, so Escape plus
+  // returning focus to the trigger is the whole contract.
+  React.useEffect(() => {
+    if (!evolutionOpen) return undefined;
+    const onKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setEvolutionOpen(false);
+      }
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, true);
+      evolutionTriggerRef.current?.focus();
+    };
+  }, [evolutionOpen]);
 
   // Expanded instruction modal: focus trap and Escape, in one listener.
   //
@@ -2123,6 +2145,25 @@ const RISCVExplorer = () => {
                       {label !== 'Volumes' && <span className="mx-1 opacity-50">&middot;</span>}
                     </span>
                   ))}
+
+                  {/* Before About, because it answers the same question one
+                      step earlier: not "what is this tool" but "what is the
+                      thing it catalogues, and how did it get here". */}
+                  <button
+                    type="button"
+                    ref={evolutionTriggerRef}
+                    onClick={() => setEvolutionOpen(true)}
+                    className="riscv-btn tooltip-wide tooltip-bottom-right ml-3 inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[11px] font-bold whitespace-nowrap"
+                    aria-haspopup="dialog"
+                    data-tooltip="Watch the ISA grow: a cumulative timeline of all 219 catalogued extensions, banded by family. Click any dot to open that extension."
+                  >
+                    {/* An axis under a filled, rising mass -- which is what the
+                        panel actually draws. It was lucide's Activity, a
+                        heart-rate trace, which said nothing about growth and was
+                        already in use elsewhere in this file. */}
+                    <AreaChart size={12} />
+                    Evolution
+                  </button>
 
                   {/* Sits between the counts and Report an issue: the three
                       things a first-time visitor wants from the header row are
@@ -4299,6 +4340,71 @@ const RISCVExplorer = () => {
         expandDeps={compareExpandDeps}
         onToggleExpandDeps={setCompareExpandDeps}
       />
+
+      {evolutionOpen && (
+        <div className="fixed inset-0 z-50">
+          <div
+            className="absolute inset-0"
+            style={{ background: 'rgba(7,7,14,0.85)', backdropFilter: 'blur(4px)' }}
+            onClick={() => setEvolutionOpen(false)}
+            role="presentation"
+          />
+
+          <div className="absolute inset-0 p-3 md:p-6 flex items-start justify-center overflow-y-auto">
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="evolution-title"
+              className="animate-scale-in w-full max-w-6xl riscv-card overflow-hidden"
+              style={{ boxShadow: '0 0 60px rgba(0,0,0,0.8), 0 0 0 1px rgba(139,124,248,0.15)' }}
+            >
+              <div
+                className="p-4 flex items-start justify-between gap-3"
+                style={{ borderBottom: '1px solid var(--riscv-border)' }}
+              >
+                <div>
+                  <h3
+                    id="evolution-title"
+                    className="text-[13px] font-semibold uppercase tracking-widest"
+                    style={{ color: 'var(--riscv-text-2)' }}
+                  >
+                    How the ISA was built
+                  </h3>
+                  <p className="text-[12px] mt-1" style={{ color: 'var(--riscv-text-3)' }}>
+                    How fast the ISA grew, and when each of the 219 catalogued extensions arrived.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setEvolutionOpen(false)}
+                  aria-label="Close the evolution panel"
+                  title="Close (Esc)"
+                  className="p-1 rounded-md transition-colors riscv-panel-dismiss"
+                >
+                  <X size={16} />
+                </button>
+              </div>
+
+              <div className="p-4">
+                <ExtensionEvolution
+                  catalog={extensions}
+                  onSelect={(id) => {
+                    const found = Object.values(extensions)
+                      .flat()
+                      .find((e) => e && e.id === id);
+                    if (found) {
+                      handleSelectExt(found);
+                      // Close on pick: the reader asked for that extension, and
+                      // the details panel is behind this dialog.
+                      setEvolutionOpen(false);
+                    }
+                  }}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       {aboutOpen && (
         <div className="fixed inset-0 z-50">


### PR DESCRIPTION
Closes #290.

A dialog beside About, holding one chart: cumulative ratifications over calendar time, stacked into 18 family bands, with every dated extension drawn as a dot at the month it arrived. A CSS sweep draws the curve and places the dots as it goes. Clicking a dot opens that extension.

### What the chart says

| | 2019 | 2020 | 2021 | 2022 | 2023 | 2024 | 2025 | 2026\* |
|---|---|---|---|---|---|---|---|---|
| ratified | 16 | 0 | 30 | 18 | **57** | 35 | 6 | 1 |
| cumulative | 16 | 16 | 46 | 64 | 121 | 156 | 162 | 163 |

2021–24 averaged 35 a year; 2025–26 averaged four. Hovering a family lights its band across the whole timeline, which is how you see that Cryptography landed 13 extensions inside 2022 and never moved again, while Traps ran 2021→2025 and is now the thickest band.

\*2026 is a partial year.

### Three things the chart must not misstate

- **56 entries carry no ratification date.** They are real extensions, not errors, so they appear in a labelled band off the axis — shown, but never given invented dates. All 219 are on screen.
- **2026 is partial**, stated in the footnote rather than drawn as a full year.
- **Curves use monotone cubic interpolation** (Fritsch–Carlson), which provably cannot overshoot or dip. An ordinary spline would draw a running total falling below a value it had already reached; nothing ever un-ratifies.

### Designs discarded on the way, and why

Each was a real modelling error, not a style preference:

- A **waffle grid** read as "42 of 42 complete" for a family. The catalogue has no maximum.
- **Family lifecycle bars** implied continuous work across silent years. Memory & Addressing looks like six years of steady output but is four bursts around a two-year gap.
- **Dots stacked from a baseline** made a histogram wearing dots, with the y axis carrying nothing.
- **One 1.24px stripe per extension**, ordered by date, interleaved 18 hues a pixel apart into noise. 163 marks stacked with a 1px gap needs ~490px; the panel has 400px. Grouping by family fixed it.

### Accessibility

- The 18 family hues are solved to **equal relative luminance (~0.205)** — the only band clearing 3:1 against both the light and the dark ground — so one palette serves both themes at ~4.1:1 each.
- 18 colours is past what anyone distinguishes from memory, so the legend is interactive: hovering a family dims the rest.
- `prefers-reduced-motion` disables the sweep in a single rule.
- Verified at 700px and at full width: no marks escaping the plot, no year-label collisions, no horizontal page scroll.

### Implementation notes

- **No new dependencies.** Inline SVG and CSS only, per the published page's CSP.
- The sweep is a **CSS animation**, not a rAF loop. Driving it from React state re-splined eighteen bands sixty times a second and froze the renderer; writing the attributes imperatively lost to React's reconciler on every reconcile.
- `evolutionModel.js` is pure — no React, no JSON import, catalogue passed in — matching the contract `marchUtils.js` keeps.

### Verification

`npm run lint`, `npm run build` and `npm test` (264 passing) all green, and the chart was checked in a real browser in both themes, since the unit tests do not render the UI.

Re-verified after rebasing onto #287's UDB data resync: 219 total, 163 dated, 56 undated, peak 57 in 2023 — unchanged.

### Follow-up worth doing separately

The Evolution button's tooltip described the waffle for eight redesigns because nothing tests copy against the component it describes. A guard in the same shape as the `DATA_PROVENANCE` test would catch that class of drift.