### PR TITLE
fix: make the Evolution sweep run on mobile browsers (#292)

### DIFF
--- a/src/ExtensionEvolution.jsx
+++ b/src/ExtensionEvolution.jsx
@@ -205,7 +205,23 @@ export default function ExtensionEvolution({ catalog, onSelect }) {
               </g>
             ))}
 
-            <g className="riscv-evo__mass">
+            <defs>
+              {/*
+               * A real clipPath applied through the SVG *attribute*. WebKit does
+               * not implement the CSS clip-path property on SVG elements, so the
+               * stylesheet sweep animated the HTML dot layer and left the mass
+               * fully drawn from the first frame -- the animation looked broken
+               * on iOS while working in Chrome.
+               *
+               * The wipe rect is animated with a transform, which SVG supports
+               * everywhere, instead of an animated clip-path.
+               */}
+              <clipPath id="riscv-evo-reveal" clipPathUnits="userSpaceOnUse">
+                <rect className="riscv-evo__wipe" x={0} y={0} width={W} height={CURVE_H} />
+              </clipPath>
+            </defs>
+
+            <g className="riscv-evo__mass" clipPath="url(#riscv-evo-reveal)">
               {bands.bands.map((band) => (
                 <path
                   key={band.key}

--- a/src/index.css
+++ b/src/index.css
@@ -2133,36 +2133,68 @@ pre,
  * guide and the dots are revealed by the same moving edge: a dot becomes
  * visible exactly as the curve reaches its month.
  */
+/*
+ * Two mechanisms for one sweep, because no single one works everywhere.
+ *
+ * The SVG mass and guide are clipped by a <clipPath> applied through the SVG
+ * attribute, and the rect inside it is wiped with a transform. WebKit does not
+ * support the CSS clip-path property on SVG elements at all, so animating that
+ * silently did nothing on iOS: the curve appeared complete from the first frame
+ * while only the dots swept.
+ *
+ * The dot layer is an HTML element, where CSS clip-path is well supported, so it
+ * keeps the inset animation. Both run on the same duration, timing function and
+ * iteration count, which is what keeps them in lockstep.
+ */
+@keyframes riscv-evo-wipe {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
 @keyframes riscv-evo-sweep {
   from {
+    -webkit-clip-path: inset(0 100% 0 0);
     clip-path: inset(0 100% 0 0);
   }
   to {
+    -webkit-clip-path: inset(0 0 0 0);
     clip-path: inset(0 0 0 0);
   }
 }
 
-.riscv-evo__plot.is-sweeping .riscv-evo__mass,
-.riscv-evo__plot.is-sweeping .riscv-evo__line,
+/* fill-box so the wipe grows from the plot's own left edge, not the viewport's. */
+.riscv-evo__wipe {
+  transform-box: fill-box;
+  transform-origin: left center;
+}
+
+.riscv-evo__plot.is-sweeping .riscv-evo__wipe {
+  animation: riscv-evo-wipe 7s linear infinite;
+}
+
 .riscv-evo__plot.is-sweeping .riscv-evo__field {
   animation: riscv-evo-sweep 7s linear infinite;
 }
 
 /* Stopped means finished, not frozen mid-sweep. */
-.riscv-evo__plot:not(.is-sweeping) .riscv-evo__mass,
-.riscv-evo__plot:not(.is-sweeping) .riscv-evo__line,
 .riscv-evo__plot:not(.is-sweeping) .riscv-evo__field {
+  -webkit-clip-path: none;
   clip-path: none;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .riscv-evo__plot.is-sweeping .riscv-evo__mass,
-  .riscv-evo__plot.is-sweeping .riscv-evo__line,
-  .riscv-evo__plot.is-sweeping .riscv-evo__field {
-    animation: none;
-    clip-path: none;
-  }
-}
+/*
+ * Deliberately no prefers-reduced-motion rule here.
+ *
+ * Reduced motion suppresses the AUTOPLAY -- the component starts paused when the
+ * setting is on, so nothing moves unless asked. Killing the animation in CSS as
+ * well meant pressing Replay did nothing at all, which reads as a broken button
+ * rather than as a respected preference. Movement the reader explicitly asks for
+ * is the one kind reduced-motion is not meant to forbid.
+ */
 
 .riscv-evo__curve {
   display: block;


### PR DESCRIPTION
Closes #292.

Two faults, either of which stops the animation on iOS.

### 1. WebKit does not implement CSS `clip-path` on SVG elements

The sweep animated `clip-path` on `.riscv-evo__mass` and `.riscv-evo__line`, both SVG. On iOS those never clipped, so the mass was drawn complete from the first frame while only the HTML dot layer swept — which reads as broken rather than absent.

The reveal now goes through an SVG `<clipPath>` applied **by attribute**, with the rect inside it wiped by a `transform`. Both are supported in every engine. The HTML dot layer keeps its `inset()` animation on identical timing, which is what keeps the two in lockstep.

This also repairs a **dangling reference**: the guide already carried `clip-path="url(#riscv-evo-reveal)"` while the `<defs>` defining that id had been removed when the sweep moved to CSS. Chrome ignores a broken clip reference; WebKit may drop the element instead, which would have hidden the guide outright.

### 2. `prefers-reduced-motion` disabled the Replay button

The media query set `animation: none` unconditionally. The component already starts paused under that setting, so the rule's only remaining effect was to make **Replay do nothing when pressed** — a broken control rather than a respected preference. iOS "Reduce Motion" is common, and this is a plausible second cause of the report.

Reduced motion should suppress autoplay, not movement the reader explicitly asks for. The rule is gone; the pause-by-default stays.

### Verification

In Chrome: both keyframes running at 7s infinite, the clip target resolves, Replay stops and restarts the sweep (`is-sweeping` toggles, animation count 1 → 0 → 1, `playState: running`), and the panel holds at 390px wide with the legend wrapping and no horizontal page overflow.

**Not verified on a real iOS device.** I do not have one here; the diagnosis rests on WebKit's documented lack of CSS `clip-path` support for SVG elements. Worth a check on a phone before closing the loop.