### PR TITLE
ci: weekly dependency-audit PRs, and derive catalogue counts in copy

### DIFF
--- a/.github/workflows/audit-deps.yml
+++ b/.github/workflows/audit-deps.yml
@@ -1,0 +1,151 @@
+name: Audit Dependencies
+
+# Opens a pull request when `npm audit fix` can resolve advisories inside the
+# ranges package.json already allows.
+#
+# WHY NOT DEPENDABOT
+#
+# The obvious answer is .github/dependabot.yml, and it does not work here.
+# dco.yml requires every non-merge commit to carry a Signed-off-by trailer that
+# matches its author, and Dependabot does not sign off. Its pull requests would
+# arrive permanently blocked — the same backlog this is meant to prevent, only
+# with red checks on it. Exempting a bot from the DCO gate is a policy decision
+# about what a sign-off certifies, not a plumbing detail, so it is not taken
+# here by default.
+#
+# This uses the pattern sync-udb-extensions.yml already proved instead: the same
+# action, signing off as the same bot, producing pull requests that pass the
+# gate unmodified.
+#
+# SCOPE
+#
+# `npm audit fix` without --force, so only semver-compatible upgrades are taken
+# and package.json is never rewritten. A fix needing a major bump is reported in
+# the pull request body for a human to weigh, because that is a judgement about
+# breakage rather than a chore.
+
+on:
+  # Weekly, 07:00 UTC Monday. An hour after the daily UDB sync, so the two never
+  # contend for a runner or open pull requests in the same minute.
+  schedule:
+    - cron: '0 7 * * 1'
+
+  workflow_dispatch:
+
+# Note: the "Create Pull Request" step requires the repo/org setting
+# "Allow GitHub Actions to create and approve pull requests" to be enabled.
+permissions:
+  contents: write
+  pull-requests: write
+
+# Queue rather than cancel, so a manual dispatch cannot abort a run that is
+# mid-commit on the shared branch.
+concurrency:
+  group: audit-deps
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Record the advisories before
+        id: before
+        run: |
+          set -uo pipefail
+          npm audit --json > /tmp/audit-before.json 2>/dev/null || true
+          count=$(node -e 'try{const a=require("/tmp/audit-before.json");console.log(a.metadata.vulnerabilities.total)}catch{console.log(0)}')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "advisories before: $count"
+
+      - name: Apply the fixes that fit inside package.json's ranges
+        run: npm audit fix || true
+
+      # A lockfile that installs is not one that builds. The suite does not
+      # render the UI, so a broken minifier or transform would pass it; the
+      # build is what exercises the toolchain these packages belong to.
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Report what is left
+        id: after
+        run: |
+          set -uo pipefail
+          npm audit --json > /tmp/audit-after.json 2>/dev/null || true
+          count=$(node -e 'try{const a=require("/tmp/audit-after.json");console.log(a.metadata.vulnerabilities.total)}catch{console.log(0)}')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+          # Anything still listed needs a major bump, which this workflow will
+          # not take on its own. Surfaced rather than failed: a red cron every
+          # Monday for something nobody intends to auto-fix trains people to
+          # ignore the cron.
+          node -e '
+            let a; try { a = require("/tmp/audit-after.json"); } catch { process.exit(0); }
+            const vias = Object.values(a.vulnerabilities || {});
+            if (!vias.length) { console.log("nothing left"); process.exit(0); }
+            const rows = vias.map(
+              (v) =>
+                "- " + v.name + " (" + v.severity + ") - needs " +
+                (v.fixAvailable && v.fixAvailable.isSemVerMajor ? "a major bump" : "manual review"),
+            );
+            console.log(rows.join("\n"));
+          '
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet package-lock.json package.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Nothing to fix inside the allowed ranges."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --stat package-lock.json package.json
+          fi
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        with:
+          commit-message: 'chore(deps): apply npm audit fixes'
+          # Same reasoning as sync-udb-extensions.yml: the DCO gate matches the
+          # trailer against the commit AUTHOR, while this action's `signoff`
+          # writes it from the committer. Pinning both to the bot is what makes
+          # the sign-off valid.
+          author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          signoff: true
+          branch: chore/audit-deps
+          delete-branch: true
+          title: 'chore(deps): apply npm audit fixes'
+          body: |
+            Automated `npm audit fix`. Advisories went from
+            **${{ steps.before.outputs.count }}** to **${{ steps.after.outputs.count }}**.
+
+            Only semver-compatible upgrades were taken (`npm audit fix` without
+            `--force`), so `package.json` should be unchanged and this a
+            lockfile-only diff. If `package.json` does appear in the diff,
+            something took a wider bump than intended — read it before merging.
+
+            `npm run build` and `npm test` both passed on the result. Worth
+            knowing what that does and does not prove: the suite does not render
+            the UI, so a change altering bundling or minification can pass it and
+            still break the page. When the diff touches webpack, babel, terser or
+            postcss, load the built page once before merging.
+
+            Anything still outstanding needs a major version bump, which this
+            workflow deliberately will not take on its own.

--- a/src/ExtensionEvolution.jsx
+++ b/src/ExtensionEvolution.jsx
@@ -285,11 +285,11 @@ export default function ExtensionEvolution({ catalog, onSelect }) {
         </div>
 
         {/*
-         * Off the axis on purpose. These 56 are real catalogued extensions and
-         * belong in the picture -- leaving them out showed 163 of 219 and passed
-         * a subset off as the whole -- but the catalogue records no date for
-         * them, and placing them anywhere on the timeline would invent one. So
-         * they sit below it, behind a rule, labelled for what they are.
+         * Off the axis on purpose. These are real catalogued extensions and belong
+         * in the picture -- leaving them out charted a subset while presenting it
+         * as the whole -- but the catalogue records no date for them, and placing
+         * them anywhere on the timeline would invent one. So they sit below it,
+         * behind a rule, labelled for what they are.
          */}
         <div className="riscv-evo__nodate">
           <span className="riscv-evo__nodatelabel">

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -2155,7 +2155,7 @@ const RISCVExplorer = () => {
                     onClick={() => setEvolutionOpen(true)}
                     className="riscv-btn tooltip-wide tooltip-bottom-right ml-3 inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-[11px] font-bold whitespace-nowrap"
                     aria-haspopup="dialog"
-                    data-tooltip="Watch the ISA grow: a cumulative timeline of all 219 catalogued extensions, banded by family. Click any dot to open that extension."
+                    data-tooltip={`Watch the ISA grow: a cumulative timeline of all ${allExtensionsFlat.length} catalogued extensions, banded by family. Click any dot to open that extension.`}
                   >
                     {/* An axis under a filled, rising mass -- which is what the
                         panel actually draws. It was lucide's Activity, a
@@ -4371,7 +4371,7 @@ const RISCVExplorer = () => {
                     How the ISA was built
                   </h3>
                   <p className="text-[12px] mt-1" style={{ color: 'var(--riscv-text-3)' }}>
-                    How fast the ISA grew, and when each of the 219 catalogued extensions arrived.
+                    {`How fast the ISA grew, and when each of the ${allExtensionsFlat.length} catalogued extensions arrived.`}
                   </p>
                 </div>
                 <button

--- a/tests/copy-counts.test.mjs
+++ b/tests/copy-counts.test.mjs
@@ -1,0 +1,65 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+
+/*
+ * Copy that states a catalogue figure must derive it, never spell it out.
+ *
+ * The Evolution dialog said "219 catalogued extensions" in two places while the
+ * UDB sync ran daily against upstream. The first day that sync adds an entry,
+ * both sentences become quietly wrong -- the page keeps rendering, nothing
+ * fails, and the number is simply a lie. It is the same failure as the tooltip
+ * that described a waffle chart for eight redesigns after the waffle was
+ * deleted: prose has no test, so it rots in place while the code around it
+ * moves.
+ *
+ * This is the cheapest possible guard. It does not check that the prose is
+ * true; it checks that the prose cannot state a catalogue count without asking
+ * the catalogue.
+ */
+
+const SOURCES = readdirSync('src')
+  .filter((f) => f.endsWith('.jsx'))
+  .map((f) => ({ file: `src/${f}`, text: readFileSync(`src/${f}`, 'utf8') }));
+
+test('no copy hardcodes a count of catalogued extensions', () => {
+  const offenders = [];
+
+  for (const { file, text } of SOURCES) {
+    for (const [i, line] of text.split('\n').entries()) {
+      // Only prose that actually claims a catalogue figure. A bare number
+      // elsewhere is almost always geometry, and flagging those would make the
+      // guard noise that someone deletes.
+      // Comments are out of remit. This guards what a reader is shown, and a
+      // guard that also polices prose in comments becomes noise someone deletes
+      // -- taking the useful half with it.
+      const code = line.replace(/^\s*(\/\/|\*|\/\*).*$/, '');
+      if (!/catalogued extension/i.test(code)) continue;
+      const digits = line.match(/\b\d{2,}\b/g);
+      if (digits) {
+        offenders.push(`${file}:${i + 1} states ${digits.join(', ')} — derive it instead`);
+      }
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `Copy naming a catalogue size must read it from the catalogue, ` +
+      `e.g. \${allExtensionsFlat.length}:\n  ${offenders.join('\n  ')}`,
+  );
+});
+
+test('the Evolution copy is derived, not literal', () => {
+  const view = readFileSync('src/risc_v_visualizer.jsx', 'utf8');
+  const claims = view.split('\n').filter((l) => /catalogued extension/i.test(l));
+
+  assert.ok(claims.length >= 2, 'expected the tooltip and the dialog subtitle');
+  for (const line of claims) {
+    assert.match(
+      line,
+      /allExtensionsFlat\.length/,
+      `this copy names a catalogue size without deriving it: ${line.trim()}`,
+    );
+  }
+});


### PR DESCRIPTION
The two follow-ups from #296, fixed together.

## 1. Advisories had nothing raising PRs

25 alerts accumulated before anyone looked, because alerts alone open nothing.

**The obvious fix is `.github/dependabot.yml`, and it does not work here.** `dco.yml` requires every non-merge commit to carry a `Signed-off-by` trailer matching its author, and **Dependabot does not sign off**. Its PRs would arrive permanently blocked — the same backlog, now with red checks on it. Exempting a bot from the DCO gate is a decision about what a sign-off certifies, not plumbing, so it isn't taken as a side effect of a chore.

`.github/workflows/audit-deps.yml` reuses the pattern `sync-udb-extensions.yml` already proved: same action, same bot identity pinned to **both** `author` and `committer` (the trailer is matched against the author, while `signoff` writes it from the committer — they differ by default), `signoff: true`. The resulting PRs pass the gate unmodified.

Scope is deliberately narrow. `npm audit fix` **without** `--force`, so only semver-compatible upgrades are taken and `package.json` is never rewritten. Anything needing a major bump is reported in the PR body rather than applied — or failed on. A red cron every Monday for something nobody intends to auto-fix only teaches people to ignore the cron.

It builds and tests before opening anything, and the body states what that does *not* prove: the suite never renders the UI, so a change to bundling or minification can pass it and still break the page — exactly the risk in #296's minifier swap.

Runs 07:00 UTC Monday, an hour after the daily UDB sync, so the two never contend for a runner.

## 2. Copy hardcoded a catalogue count

The Evolution tooltip and dialog subtitle both said **"219 catalogued extensions"** while the sync runs daily against UDB. The first day it adds an entry, both sentences go quietly wrong — the page still renders, nothing fails, the number is just a lie.

This is the failure that let a tooltip describe a waffle chart for eight redesigns after the waffle was deleted. **Prose has no test, so it rots in place while the code around it moves.**

Both now read `allExtensionsFlat.length`, the same source the header count uses, so the three cannot disagree. Verified in a browser: header, tooltip and subtitle all report 219 from one source.

### The guard

`tests/copy-counts.test.mjs` does not check that the prose is *true*. It checks that prose naming a catalogue figure cannot state it without asking the catalogue — which is testable, where truth is not.

Proven to bite: reintroducing the literal fails with `src/risc_v_visualizer.jsx:4374 states 219 — derive it instead`; removing it passes.

Comments are deliberately out of its remit — a guard that also polices comment prose becomes noise someone deletes, taking the useful half with it. Writing it did surface one comment that pinned a count, reworded here on its own merits.

## Verification

`npm run lint`, `npm run build`, `npm test` — **266 passing** (264 + the two new guards). Workflow checked for structural validity and tab characters, with all three action SHAs identical to the proven workflow's.

## Not done, still your call

The audit workflow needs **"Allow GitHub Actions to create and approve pull requests"** enabled at repo or org level — the same setting `sync-udb-extensions.yml` already depends on, so it is presumably on, but the first Monday run will say so either way.