### PR TITLE
ci: scope GITHUB_TOKEN to read in ci.yml and dco.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
   push:
     branches: [main]
 
+# Read-only by default, so build-and-test gets a token that can do nothing but
+# fetch the code it compiles. Without this the workflow inherits whatever the
+# repository default happens to be, which is write in many configurations: a
+# build job would then hold a token able to push to main, for no reason it can
+# use. The deploy job below opts back up to contents: write, which is the one
+# job that genuinely publishes.
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -10,6 +10,13 @@ name: DCO
 on:
   pull_request:
 
+# The job walks git history and compares trailers. It never writes anything, so
+# the token it holds should not be able to. This is also why the check is a
+# plain script rather than a third-party action, per the note above -- the two
+# decisions are the same one.
+permissions:
+  contents: read
+
 jobs:
   check-sign-off:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes both open code-scanning alerts (#1 and #2), same rule: `actions/missing-workflow-permissions`, medium.

### What was wrong

`ci.yml` and `dco.yml` declared no `permissions:` block, so each inherited whatever default the repository is configured with — **write, in many configurations**. Neither needs it:

- `dco.yml` walks git history and compares trailers. It never writes.
- `build-and-test` in `ci.yml` fetches the code it compiles. It was holding a token able to push to `main` with nothing to use it for.

### The one job that does publish

`deploy` force-pushes `dist/` to `gh-pages`, and **already declared its own `contents: write`**. So setting the workflow default to `contents: read` leaves publishing untouched — it opts back up in the single job that genuinely needs it, which is what a per-job override is for.

I checked that before writing the fix: a blanket `contents: read` on `ci.yml` would have broken deploys, and the CodeQL hint (`{{contents: read}}`) does not say so.

### Result

All six workflows now state what their token may do:

| workflow | default |
|---|---|
| ci.yml | `contents: read` (deploy overrides to write) |
| dco.yml | `contents: read` |
| changelog.yml | `contents: read` |
| check-opcodes-drift.yml | `contents: read`, `issues: write` |
| sync-udb-extensions.yml | `contents: write`, `pull-requests: write` |
| audit-deps.yml | `contents: write`, `pull-requests: write` |

### Verification

`npm run lint` and `npm test` (266) green — though neither exercises workflow YAML, so the real check is this PR's own run: `build-and-test`, `DCO` and `changelog` all execute under the new scoping here. **Deploy does not run on a pull request**, so the first push to `main` after merge is what confirms publishing still works. Worth watching that run rather than assuming.