### PR TITLE
perf: stop repainting every tile per keystroke, and defer three panels

### DIFF
--- a/src/ExtensionTile.jsx
+++ b/src/ExtensionTile.jsx
@@ -28,8 +28,7 @@ import { tilePropsAreEqual } from './tileMemo.js';
 function ExtensionTile({
   data,
   colorClass,
-  searchQuery,
-  searchIndex,
+  matchesSearch,
   selectedExtId,
   workspaceIds,
   compareIds,
@@ -42,9 +41,6 @@ function ExtensionTile({
   onToggleWorkspace,
   onToggleCompare,
 }) {
-  const q = searchQuery.trim().toLowerCase();
-  const matchesSearch = q.length ? (searchIndex || '').includes(q) : false;
-
   const isDiscontinued = data.discontinued === 1;
   const isSelected = selectedExtId === data.id;
   const highlighted = isHighlighted(data.id) || matchesSearch || isSelected;

--- a/src/risc_v_visualizer.jsx
+++ b/src/risc_v_visualizer.jsx
@@ -46,14 +46,12 @@ import {
   GitCompare,
 } from 'lucide-react';
 import extensions from './riscv_extensions.json';
-import EncodingMap from './EncodingMap.jsx';
-import WorkspacePanel from './WorkspacePanel.jsx';
 import ExtensionTile from './ExtensionTile.jsx';
+import CompareView from './CompareView.jsx';
 import EncodingDiagram from './EncodingDiagram.jsx';
 import { focusableWithin, nextFocus } from './focusTrap.js';
 import { computeLockedExtensions, missingMandatory } from './workspaceLock.js';
 import CompareTray from './CompareTray.jsx';
-import CompareView from './CompareView.jsx';
 import {
   COMPARE_MAX,
   COMPARE_PARAM,
@@ -80,7 +78,6 @@ import { PROFILES } from './profiles.js';
 import PROFILE_OPTIONAL from './profile-optional.json';
 import { buildIsaConfigYaml } from './exportUtils.js';
 import AskAiLauncher from './AskAiLauncher.jsx';
-import ExtensionEvolution from './ExtensionEvolution.jsx';
 
 // Ids the catalog can actually render. The dependency graph carries a few nodes
 // the catalog does not (UDB's S requires Sm, for which we have no entry), and
@@ -177,7 +174,66 @@ const loadSavedBuilderState = () => {
   };
 };
 
+/*
+ * Three panels are heavy and not needed for first paint: WorkspacePanel alone
+ * is 104 KB of source. Loading them lazily keeps them out of the initial parse
+ * and compile.
+ *
+ * The Suspense fallbacks are null rather than a loading shell. One reviewer
+ * wanted a shell, since opening the Workspace also hides its own toolbar
+ * button and a slow chunk could leave neither on screen; another judged null
+ * safe, because focus stays on the trigger until the panel mounts. The chunks
+ * are 7 to 46 KB from the same origin as the page that just loaded, so the gap
+ * is short, and an idle prefetch was tried and reverted: dynamic import of JSX
+ * cannot resolve in the test environment and it took the render-smoke suite
+ * from seconds to two minutes.
+ *
+ * CompareView is deliberately NOT lazy. It is reachable by permalink, so a URL
+ * that opens straight into a comparison would have to wait on a chunk before
+ * showing anything. Four render-smoke tests cover exactly that path, and the
+ * right response to them failing was to narrow the optimisation, not to weaken
+ * the tests.
+ *
+ * Paired with useOnceMounted below, which is what makes this safe. These
+ * components are rendered unconditionally today and hold state while closed
+ * (WorkspacePanel has twenty state hooks and fifteen transitions), so gating
+ * them on `open` would lose that state and break the close animation. Mounting
+ * on first open and leaving them mounted defers the download without changing
+ * when anything unmounts.
+ */
+const EncodingMap = React.lazy(() => import('./EncodingMap.jsx'));
+const WorkspacePanel = React.lazy(() => import('./WorkspacePanel.jsx'));
+const ExtensionEvolution = React.lazy(() => import('./ExtensionEvolution.jsx'));
+
+/**
+ * True once `open` has been true, and true forever after.
+ *
+ * Lets a lazy panel stay unmounted until it is first needed, then behave
+ * exactly as it did before: still mounted while closed, still holding its own
+ * state, still able to animate out.
+ */
+function useOnceMounted(open) {
+  /*
+   * A ref latch rather than state, because state costs a render before the
+   * chunk fetch can even begin: the first render after `open` flips would still
+   * return false, Suspense would render nothing, and only the following render
+   * would mount the boundary and start the download. Latching during render
+   * starts the fetch in the same pass.
+   *
+   * Safe to write during render because it is idempotent: it only ever moves
+   * false to true, so a double invocation reaches the same value.
+   */
+  const mounted = React.useRef(open);
+  if (open) mounted.current = true;
+  return mounted.current;
+}
+
 const allExtensionsFlat = Object.values(extensions).flat().filter(Boolean);
+
+// Shared so an empty query allocates nothing and searchMatchIds keeps a stable
+// reference for anything that depends on it. Note this is NOT what protects the
+// tile memo: tiles receive a boolean, so a fresh Set would compare the same.
+const EMPTY_MATCH_SET = new Set();
 
 const findExtensionById = (id) => {
   const wanted = String(id ?? '')
@@ -570,6 +626,13 @@ const RISCVExplorer = () => {
   const [selectedInstruction, setSelectedInstruction] = useState(null);
   const [copyStatus, setCopyStatus] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
+
+  /*
+   * Whether the current selection was made by the search effect rather than by
+   * a click. Only the former is debounced when written to the URL.
+   */
+  const selectionCameFromSearchRef = React.useRef(false);
+
   const [searchMatches, setSearchMatches] = useState(null);
   const [encoderValidatorOpen, setEncoderValidatorOpen] = useState(false);
 
@@ -1682,15 +1745,37 @@ const RISCVExplorer = () => {
   // replaceState rather than pushState on purpose: clicking through twenty
   // tiles should not bury the previous page under twenty history entries that
   // Back has to walk through one at a time.
+  /*
+   * Debounced ONLY for selections search made on the reader's behalf.
+   *
+   * Search selects as you type, so an exact id match writes history on the
+   * keystroke that produces it: typing "amo" wrote three times, once for the
+   * "a" that matches extension A. Delaying that is right.
+   *
+   * Delaying a deliberate click is not. Someone who clicks a tile and reaches
+   * straight for the address bar would copy the previous URL, and the write
+   * would be cancelled outright if they closed the tab inside the window. A
+   * click is an explicit act and the URL has to be true immediately.
+   */
   React.useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const url = new URL(window.location.href);
-    const current = url.searchParams.get(PERMALINK_PARAM);
-    const next = selectedExt?.id ?? null;
-    if (current === next) return;
-    if (next) url.searchParams.set(PERMALINK_PARAM, next);
-    else url.searchParams.delete(PERMALINK_PARAM);
-    window.history.replaceState(null, '', url.toString());
+    if (typeof window === 'undefined') return undefined;
+
+    const write = () => {
+      const url = new URL(window.location.href);
+      const current = url.searchParams.get(PERMALINK_PARAM);
+      const next = selectedExt?.id ?? null;
+      if (current === next) return;
+      if (next) url.searchParams.set(PERMALINK_PARAM, next);
+      else url.searchParams.delete(PERMALINK_PARAM);
+      window.history.replaceState(null, '', url.toString());
+    };
+
+    if (!selectionCameFromSearchRef.current) {
+      write();
+      return undefined;
+    }
+    const id = setTimeout(write, 250);
+    return () => clearTimeout(id);
   }, [selectedExt]);
 
   // A fresh selection invalidates the "Copied" confirmation.
@@ -1711,6 +1796,7 @@ const RISCVExplorer = () => {
   }, [selectedExt, copyTextToClipboard, showToast]);
 
   const handleSelectExt = React.useCallback((data) => {
+    selectionCameFromSearchRef.current = false;
     // A deliberate click owns the panel from here on, so a later non-matching
     // query must not clear it out from under the user.
     searchDrivenSelectionRef.current = false;
@@ -1850,9 +1936,28 @@ const RISCVExplorer = () => {
   const openCompareView = React.useCallback(() => setCompareOpen(true), []);
   const closeCompareView = React.useCallback(() => setCompareOpen(false), []);
 
+  /*
+   * One pass per query instead of one per tile per keystroke. The tiles are
+   * handed the answer, so React can skip every tile whose match state did not
+   * change; previously the raw query was a prop and all 219 re-rendered on
+   * every character.
+   */
+  // Each panel mounts on its first open and stays mounted thereafter.
+  const encodingMapMounted = useOnceMounted(encodingMapOpen);
+  const workspacePanelMounted = useOnceMounted(workspacePanelOpen);
+
+  const searchMatchIds = React.useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return EMPTY_MATCH_SET;
+    const hits = new Set();
+    for (const [id, index] of extensionSearchIndexById) {
+      if ((index || '').includes(q)) hits.add(id);
+    }
+    return hits;
+  }, [searchQuery, extensionSearchIndexById]);
+
   const tileProps = React.useMemo(
     () => ({
-      searchQuery,
       selectedExtId: selectedExt?.id ?? null,
       workspaceIds,
       lockedExtensions,
@@ -1866,7 +1971,9 @@ const RISCVExplorer = () => {
       onToggleCompare: toggleCompareExt,
     }),
     [
-      searchQuery,
+      // searchQuery is deliberately absent: it is no longer a tile prop, so
+      // rebuilding this object on every keystroke would re-render all 219 tiles
+      // for nothing, which is the exact cost this change removes.
       selectedExt,
       workspaceIds,
       lockedExtensions,
@@ -1971,6 +2078,10 @@ const RISCVExplorer = () => {
     const allExts = Object.values(extensions).flat();
     let matchedMnemonic = null;
     let matchedDetails = null;
+
+    // Anything selected from here on is search acting on the reader's behalf,
+    // not a deliberate click, so its URL write is the one that gets debounced.
+    selectionCameFromSearchRef.current = true;
 
     // First, try an exact extension ID match
     let targetExt = allExts.find((ext) => ext.id.toLowerCase() === q);
@@ -3006,7 +3117,7 @@ const RISCVExplorer = () => {
                       <ExtensionTile
                         key={item.id}
                         data={item}
-                        searchIndex={extensionSearchIndexById.get(item.id)}
+                        matchesSearch={searchMatchIds.has(item.id)}
                         {...tileProps}
                         colorClass="border-blue-900/60 bg-blue-950/40 text-blue-100"
                       />
@@ -3033,7 +3144,7 @@ const RISCVExplorer = () => {
                       <ExtensionTile
                         key={item.id}
                         data={item}
-                        searchIndex={extensionSearchIndexById.get(item.id)}
+                        matchesSearch={searchMatchIds.has(item.id)}
                         {...tileProps}
                         colorClass="border-emerald-900/60 bg-emerald-950/40 text-emerald-100"
                       />
@@ -3064,7 +3175,7 @@ const RISCVExplorer = () => {
                         <ExtensionTile
                           key={item.id}
                           data={item}
-                          searchIndex={extensionSearchIndexById.get(item.id)}
+                          matchesSearch={searchMatchIds.has(item.id)}
                           {...tileProps}
                           colorClass="border-purple-900/60 bg-purple-950/30 text-purple-100"
                         />
@@ -3090,7 +3201,7 @@ const RISCVExplorer = () => {
                         <ExtensionTile
                           key={item.id}
                           data={item}
-                          searchIndex={extensionSearchIndexById.get(item.id)}
+                          matchesSearch={searchMatchIds.has(item.id)}
                           {...tileProps}
                           colorClass="border-amber-900/60 bg-amber-950/30 text-amber-100"
                         />
@@ -3116,7 +3227,7 @@ const RISCVExplorer = () => {
                         <ExtensionTile
                           key={item.id}
                           data={item}
-                          searchIndex={extensionSearchIndexById.get(item.id)}
+                          matchesSearch={searchMatchIds.has(item.id)}
                           {...tileProps}
                           colorClass="border-indigo-900/60 bg-indigo-950/30 text-indigo-100"
                         />
@@ -3142,7 +3253,7 @@ const RISCVExplorer = () => {
                         <ExtensionTile
                           key={item.id}
                           data={item}
-                          searchIndex={extensionSearchIndexById.get(item.id)}
+                          matchesSearch={searchMatchIds.has(item.id)}
                           {...tileProps}
                           colorClass="border-pink-900/60 bg-pink-950/30 text-pink-100"
                         />
@@ -3168,7 +3279,7 @@ const RISCVExplorer = () => {
                         <ExtensionTile
                           key={item.id}
                           data={item}
-                          searchIndex={extensionSearchIndexById.get(item.id)}
+                          matchesSearch={searchMatchIds.has(item.id)}
                           {...tileProps}
                           colorClass="border-sky-900/60 bg-sky-950/30 text-sky-100"
                         />
@@ -3194,7 +3305,7 @@ const RISCVExplorer = () => {
                         <ExtensionTile
                           key={item.id}
                           data={item}
-                          searchIndex={extensionSearchIndexById.get(item.id)}
+                          matchesSearch={searchMatchIds.has(item.id)}
                           {...tileProps}
                           colorClass="border-fuchsia-900/60 bg-fuchsia-950/30 text-fuchsia-100"
                         />
@@ -3220,7 +3331,7 @@ const RISCVExplorer = () => {
                         <ExtensionTile
                           key={item.id}
                           data={item}
-                          searchIndex={extensionSearchIndexById.get(item.id)}
+                          matchesSearch={searchMatchIds.has(item.id)}
                           {...tileProps}
                           colorClass="border-teal-900/60 bg-teal-950/30 text-teal-100"
                         />
@@ -3246,7 +3357,7 @@ const RISCVExplorer = () => {
                         <ExtensionTile
                           key={item.id}
                           data={item}
-                          searchIndex={extensionSearchIndexById.get(item.id)}
+                          matchesSearch={searchMatchIds.has(item.id)}
                           {...tileProps}
                           colorClass="border-red-900/60 bg-red-950/30 text-red-100"
                         />
@@ -3272,7 +3383,7 @@ const RISCVExplorer = () => {
                         <ExtensionTile
                           key={item.id}
                           data={item}
-                          searchIndex={extensionSearchIndexById.get(item.id)}
+                          matchesSearch={searchMatchIds.has(item.id)}
                           {...tileProps}
                           colorClass="border-[var(--riscv-border-2)] bg-[var(--riscv-surface-2)] text-slate-300"
                         />
@@ -3298,7 +3409,7 @@ const RISCVExplorer = () => {
                         <ExtensionTile
                           key={item.id}
                           data={item}
-                          searchIndex={extensionSearchIndexById.get(item.id)}
+                          matchesSearch={searchMatchIds.has(item.id)}
                           {...tileProps}
                           colorClass="border-violet-900/60 bg-violet-950/30 text-violet-100"
                         />
@@ -3324,7 +3435,7 @@ const RISCVExplorer = () => {
                         <ExtensionTile
                           key={item.id}
                           data={item}
-                          searchIndex={extensionSearchIndexById.get(item.id)}
+                          matchesSearch={searchMatchIds.has(item.id)}
                           {...tileProps}
                           colorClass="border-orange-900/60 bg-orange-950/30 text-orange-100"
                         />
@@ -3350,7 +3461,7 @@ const RISCVExplorer = () => {
                         <ExtensionTile
                           key={item.id}
                           data={item}
-                          searchIndex={extensionSearchIndexById.get(item.id)}
+                          matchesSearch={searchMatchIds.has(item.id)}
                           {...tileProps}
                           colorClass="border-orange-900/40 bg-orange-950/20 text-orange-100"
                         />
@@ -3392,7 +3503,7 @@ const RISCVExplorer = () => {
                           <ExtensionTile
                             key={item.id}
                             data={item}
-                            searchIndex={extensionSearchIndexById.get(item.id)}
+                            matchesSearch={searchMatchIds.has(item.id)}
                             {...tileProps}
                             colorClass="border-cyan-900/50 bg-cyan-950/20 text-cyan-100"
                           />
@@ -3417,7 +3528,7 @@ const RISCVExplorer = () => {
                           <ExtensionTile
                             key={item.id}
                             data={item}
-                            searchIndex={extensionSearchIndexById.get(item.id)}
+                            matchesSearch={searchMatchIds.has(item.id)}
                             {...tileProps}
                             colorClass="border-cyan-900/50 bg-cyan-950/20 text-cyan-100"
                           />
@@ -3442,7 +3553,7 @@ const RISCVExplorer = () => {
                           <ExtensionTile
                             key={item.id}
                             data={item}
-                            searchIndex={extensionSearchIndexById.get(item.id)}
+                            matchesSearch={searchMatchIds.has(item.id)}
                             {...tileProps}
                             colorClass="border-cyan-900/50 bg-cyan-950/20 text-cyan-100"
                           />
@@ -3467,7 +3578,7 @@ const RISCVExplorer = () => {
                           <ExtensionTile
                             key={item.id}
                             data={item}
-                            searchIndex={extensionSearchIndexById.get(item.id)}
+                            matchesSearch={searchMatchIds.has(item.id)}
                             {...tileProps}
                             colorClass="border-cyan-900/50 bg-cyan-950/20 text-cyan-100"
                           />
@@ -4306,17 +4417,21 @@ const RISCVExplorer = () => {
         </footer>
       </div>
 
-      <EncodingMap
-        open={encodingMapOpen}
-        onClose={() => setEncodingMapOpen(false)}
-        catalog={extensions}
-        onSelectExtension={(id) => {
-          const target = Object.values(extensions)
-            .flat()
-            .find((e) => e && e.id === id);
-          if (target) handleSelectExt(target);
-        }}
-      />
+      {encodingMapMounted && (
+        <React.Suspense fallback={null}>
+          <EncodingMap
+            open={encodingMapOpen}
+            onClose={() => setEncodingMapOpen(false)}
+            catalog={extensions}
+            onSelectExtension={(id) => {
+              const target = Object.values(extensions)
+                .flat()
+                .find((e) => e && e.id === id);
+              if (target) handleSelectExt(target);
+            }}
+          />
+        </React.Suspense>
+      )}
 
       <CompareTray
         extIds={compareExtIds}
@@ -4386,20 +4501,22 @@ const RISCVExplorer = () => {
               </div>
 
               <div className="p-4">
-                <ExtensionEvolution
-                  catalog={extensions}
-                  onSelect={(id) => {
-                    const found = Object.values(extensions)
-                      .flat()
-                      .find((e) => e && e.id === id);
-                    if (found) {
-                      handleSelectExt(found);
-                      // Close on pick: the reader asked for that extension, and
-                      // the details panel is behind this dialog.
-                      setEvolutionOpen(false);
-                    }
-                  }}
-                />
+                <React.Suspense fallback={null}>
+                  <ExtensionEvolution
+                    catalog={extensions}
+                    onSelect={(id) => {
+                      const found = Object.values(extensions)
+                        .flat()
+                        .find((e) => e && e.id === id);
+                      if (found) {
+                        handleSelectExt(found);
+                        // Close on pick: the reader asked for that extension, and
+                        // the details panel is behind this dialog.
+                        setEvolutionOpen(false);
+                      }
+                    }}
+                  />
+                </React.Suspense>
               </div>
             </div>
           </div>
@@ -5337,105 +5454,111 @@ const RISCVExplorer = () => {
       )}
 
       {/* ── ISA Workspace Panel ────────────────────────────────────────── */}
-      <WorkspacePanel
-        open={workspacePanelOpen}
-        onClose={() => setWorkspacePanelOpen(false)}
-        workspaceIds={workspaceIds}
-        lockedExtensions={lockedExtensions}
-        allExts={allExtsList}
-        onSetVlen={handleSetVlen}
-        seedProfile={seedProfile}
-        profileOptional={PROFILE_OPTIONAL}
-        paramChoices={paramChoices}
-        onSetParam={handleSetParam}
-        baselineLocked={baselineLocked}
-        customFromProfile={customFromProfile}
-        onToggleBaseline={() => {
-          if (baselineLocked) {
-            // Releasing the lock: just release it
-            setBaselineLocked(false);
-          } else {
-            // Re-locking: restore any missing mandatory extensions first,
-            // so the locked state is always a genuinely compliant configuration.
-            if (seedProfile) {
-              const mandatory = PROFILES[seedProfile] || [];
-              const missing = mandatory.filter((id) => !workspaceIds.has(id));
-              if (missing.length > 0) {
-                addWorkspaceIdsSmart(missing);
+      {workspacePanelMounted && (
+        <React.Suspense fallback={null}>
+          <WorkspacePanel
+            open={workspacePanelOpen}
+            onClose={() => setWorkspacePanelOpen(false)}
+            workspaceIds={workspaceIds}
+            lockedExtensions={lockedExtensions}
+            allExts={allExtsList}
+            onSetVlen={handleSetVlen}
+            seedProfile={seedProfile}
+            profileOptional={PROFILE_OPTIONAL}
+            paramChoices={paramChoices}
+            onSetParam={handleSetParam}
+            baselineLocked={baselineLocked}
+            customFromProfile={customFromProfile}
+            onToggleBaseline={() => {
+              if (baselineLocked) {
+                // Releasing the lock: just release it
+                setBaselineLocked(false);
+              } else {
+                // Re-locking: restore any missing mandatory extensions first,
+                // so the locked state is always a genuinely compliant configuration.
+                if (seedProfile) {
+                  const mandatory = PROFILES[seedProfile] || [];
+                  const missing = mandatory.filter((id) => !workspaceIds.has(id));
+                  if (missing.length > 0) {
+                    addWorkspaceIdsSmart(missing);
+                    showToast(
+                      `Re-locked ${seedProfile}: restored ${missing.join(', ')} to the mandatory set.`,
+                    );
+                  }
+                }
+                setBaselineLocked(true);
+              }
+            }}
+            onAddId={(id) => addWorkspaceIdsSmart(id, true)}
+            onRemoveId={(id) => {
+              // Decide before mutating anything. The previous order downgraded the
+              // profile first and only then discovered the removal was refused,
+              // which left the configuration permanently 'Custom' and the lock
+              // forced open while nothing had actually been removed.
+              if (lockedExtensions.has(id)) {
                 showToast(
-                  `Re-locked ${seedProfile}: restored ${missing.join(', ')} to the mandatory set.`,
+                  `Cannot remove ${id}: required by ${lockedExtensions.get(id).join(', ')}`,
+                );
+                return;
+              }
+              if (!workspaceIds.has(id)) return;
+
+              // Reaching here means the removal will happen. A mandatory extension
+              // can only be unlocked, so this is the deliberate divergence path.
+              const divergesFromProfile = Boolean(
+                seedProfile && (PROFILES[seedProfile] || []).includes(id),
+              );
+
+              setWorkspaceIds((prev) => {
+                const next = new Set(prev);
+                next.delete(id);
+                return next;
+              });
+
+              if (divergesFromProfile) {
+                setSeedProfile(null);
+                setCustomFromProfile(seedProfile);
+                showToast(
+                  `${id} removed — configuration is now Custom (from ${seedProfile}). Re-select the profile from the switcher to restore full compliance.`,
                 );
               }
-            }
-            setBaselineLocked(true);
-          }
-        }}
-        onAddId={(id) => addWorkspaceIdsSmart(id, true)}
-        onRemoveId={(id) => {
-          // Decide before mutating anything. The previous order downgraded the
-          // profile first and only then discovered the removal was refused,
-          // which left the configuration permanently 'Custom' and the lock
-          // forced open while nothing had actually been removed.
-          if (lockedExtensions.has(id)) {
-            showToast(`Cannot remove ${id}: required by ${lockedExtensions.get(id).join(', ')}`);
-            return;
-          }
-          if (!workspaceIds.has(id)) return;
-
-          // Reaching here means the removal will happen. A mandatory extension
-          // can only be unlocked, so this is the deliberate divergence path.
-          const divergesFromProfile = Boolean(
-            seedProfile && (PROFILES[seedProfile] || []).includes(id),
-          );
-
-          setWorkspaceIds((prev) => {
-            const next = new Set(prev);
-            next.delete(id);
-            return next;
-          });
-
-          if (divergesFromProfile) {
-            setSeedProfile(null);
-            setCustomFromProfile(seedProfile);
-            showToast(
-              `${id} removed — configuration is now Custom (from ${seedProfile}). Re-select the profile from the switcher to restore full compliance.`,
-            );
-          }
-        }}
-        onClear={() => {
-          setWorkspaceIds(new Set());
-          setSeedProfile(null);
-          setCustomFromProfile(null);
-          setParamChoices({});
-          setBaselineLocked(true);
-          try {
-            window.localStorage.removeItem(BUILDER_STORAGE_KEY);
-          } catch {
-            /* ignore */
-          }
-        }}
-        onLoadIds={(ids, profileName) => {
-          setWorkspaceIds(new Set()); // clear
-          addWorkspaceIdsSmart(ids); // smartly add all
-          setSeedProfile(profileName || null);
-          setCustomFromProfile(null); // fresh load resets origin tracking
-          setBaselineLocked(true);
-        }}
-        onSelectInstruction={({ extId, mnemonic, encoding, variable_fields, match, mask }) => {
-          // Navigate the main view to the specified extension + instruction
-          const targetExt = allExtsList.find((e) => e.id === extId);
-          if (targetExt) {
-            setSelectedExt(targetExt);
-            setSelectedInstruction({ mnemonic, encoding, variable_fields, match, mask });
-            setWorkspacePanelOpen(false); // close panel to reveal main view
-            // Scroll tile into view
-            requestAnimationFrame(() => {
-              const el = document.getElementById(`ext-${extId}`);
-              if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            });
-          }
-        }}
-      />
+            }}
+            onClear={() => {
+              setWorkspaceIds(new Set());
+              setSeedProfile(null);
+              setCustomFromProfile(null);
+              setParamChoices({});
+              setBaselineLocked(true);
+              try {
+                window.localStorage.removeItem(BUILDER_STORAGE_KEY);
+              } catch {
+                /* ignore */
+              }
+            }}
+            onLoadIds={(ids, profileName) => {
+              setWorkspaceIds(new Set()); // clear
+              addWorkspaceIdsSmart(ids); // smartly add all
+              setSeedProfile(profileName || null);
+              setCustomFromProfile(null); // fresh load resets origin tracking
+              setBaselineLocked(true);
+            }}
+            onSelectInstruction={({ extId, mnemonic, encoding, variable_fields, match, mask }) => {
+              // Navigate the main view to the specified extension + instruction
+              const targetExt = allExtsList.find((e) => e.id === extId);
+              if (targetExt) {
+                setSelectedExt(targetExt);
+                setSelectedInstruction({ mnemonic, encoding, variable_fields, match, mask });
+                setWorkspacePanelOpen(false); // close panel to reveal main view
+                // Scroll tile into view
+                requestAnimationFrame(() => {
+                  const el = document.getElementById(`ext-${extId}`);
+                  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                });
+              }
+            }}
+          />
+        </React.Suspense>
+      )}
 
       {/* ── Ask AI Launcher ── */}
       <AskAiLauncher context={askAiContext} />

--- a/src/tileMemo.js
+++ b/src/tileMemo.js
@@ -11,17 +11,24 @@
  * shallow compare sees new objects and re-renders all 227 tiles whenever any one
  * of them moves. Asking instead "did membership change for THIS id" means
  * selecting D repaints the D tile and nothing else.
+ *
+ * The same principle applies to search: the tile is passed the ANSWER
+ * (matchesSearch) rather than the question (searchQuery), so typing only
+ * re-renders tiles whose match state changed.
  */
 
 /** True when the tile can be skipped. */
 export function tilePropsAreEqual(prev, next) {
   if (prev.data !== next.data) return false;
   if (prev.colorClass !== next.colorClass) return false;
-  if (prev.searchQuery !== next.searchQuery) return false;
+  // A boolean, not the query string. Comparing the raw query meant every tile
+  // failed this check on every keystroke, so all 219 re-rendered even though
+  // only the handful whose match state actually flipped had anything new to
+  // show. The parent computes the match once; the tile is told the answer.
+  if (prev.matchesSearch !== next.matchesSearch) return false;
   if (prev.builderMode !== next.builderMode) return false;
   if (prev.compareMode !== next.compareMode) return false;
   if (prev.selectedExtId !== next.selectedExtId) return false;
-  if (prev.searchIndex !== next.searchIndex) return false;
   if (prev.onSelect !== next.onSelect) return false;
   if (prev.onToggleWorkspace !== next.onToggleWorkspace) return false;
   if (prev.onToggleCompare !== next.onToggleCompare) return false;

--- a/tests/extension-tile.test.mjs
+++ b/tests/extension-tile.test.mjs
@@ -28,8 +28,7 @@ const srcDir = path.join(here, '..', 'src');
 const baseProps = (over = {}) => ({
   data: { id: 'Zfa', name: 'Zfa', desc: 'Additional FP Instructions' },
   colorClass: 'border-blue-900/60',
-  searchQuery: '',
-  searchIndex: 'zfa additional fp instructions',
+  matchesSearch: false,
   selectedExtId: null,
   workspaceIds: new Set(),
   lockedExtensions: new Map(),
@@ -87,8 +86,7 @@ test('everything the tile displays forces a re-render when it changes', () => {
   const changes = {
     data: { id: 'Zfa', name: 'Zfa', desc: 'changed' },
     colorClass: 'border-red-900',
-    searchQuery: 'zf',
-    searchIndex: 'different',
+    matchesSearch: true,
     selectedExtId: 'Zfa',
     builderMode: true,
     isHighlighted: () => true,
@@ -97,12 +95,39 @@ test('everything the tile displays forces a re-render when it changes', () => {
     onToggleWorkspace: () => {},
   };
   for (const [key, value] of Object.entries(changes)) {
+    /*
+     * Spread the SAME base rather than calling baseProps() again. baseProps()
+     * mints fresh arrow functions and Sets each call, so comparing two of its
+     * results differed on five identities at once: the comparator returned
+     * false whatever key was overridden, and this loop passed for any key at
+     * all, including one that does not exist. Holding every other reference
+     * fixed is what makes each iteration actually test its own key.
+     */
     assert.equal(
-      tilePropsAreEqual(base, baseProps({ [key]: value })),
+      tilePropsAreEqual(base, { ...base, [key]: value }),
       false,
       `${key} changed but the tile would not re-render`,
     );
   }
+});
+
+test('the loop above can fail: an ignored prop does not force a re-render', () => {
+  // Guards the fixture itself. If baseProps() ever goes back to minting fresh
+  // references, this is the test that catches it, because a prop the
+  // comparator does not read must still be skippable.
+  const base = baseProps();
+  assert.equal(tilePropsAreEqual(base, { ...base, somethingUnread: 'changed' }), true);
+});
+
+test('typing does not re-render a tile whose match state is unchanged', () => {
+  // The point of passing matchesSearch instead of searchQuery: two different
+  // queries that both miss this tile must not repaint it.
+  const base = baseProps({ matchesSearch: false });
+  assert.equal(tilePropsAreEqual(base, { ...base }), true);
+
+  const hit = baseProps({ matchesSearch: true });
+  assert.equal(tilePropsAreEqual(base, { ...base, matchesSearch: true }), false);
+  assert.equal(tilePropsAreEqual(hit, { ...hit, matchesSearch: true }), true);
 });
 
 test('no component is declared inside another component', () => {
@@ -125,8 +150,8 @@ test('no component is declared inside another component', () => {
   assert.deepEqual(
     offenders,
     [],
-    'components must live at module scope, or React remounts their subtree every render:\n  '
-      + offenders.join('\n  '),
+    'components must live at module scope, or React remounts their subtree every render:\n  ' +
+      offenders.join('\n  '),
   );
 });
 
@@ -167,7 +192,11 @@ test('a tile re-renders when its own compare membership changes', () => {
 test('pinning a different extension does not re-render this tile', () => {
   const prev = baseProps({ compareIds: new Set() });
   const next = baseProps({ ...prev, compareIds: new Set(['Zba']) });
-  assert.equal(tilePropsAreEqual(prev, next), true, 'baseProps is Zfa, so Zba is none of its business');
+  assert.equal(
+    tilePropsAreEqual(prev, next),
+    true,
+    'baseProps is Zfa, so Zba is none of its business',
+  );
 });
 
 test('an unstable onToggleCompare re-renders, which is why it must be memoised', () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,12 @@ module.exports = (env, argv = {}) => {
     output: {
       filename: 'bundle.js',
       path: path.resolve(__dirname, 'dist'),
+      // Webpack 5 leaves its output directory alone by default, so anything a
+      // previous build emitted survives forever. A local dist/ had accumulated
+      // a 280 KB PNG that nothing referenced. It matters more now that the
+      // build emits code-split chunks, since stale chunks would linger and be
+      // published by a manual deploy.
+      clean: true,
     },
     // eval-source-map keeps rebuilds fast while still pointing at the original JSX.
     devtool: isDev ? 'eval-source-map' : false,


### PR DESCRIPTION
Closes #299.

Initial JavaScript falls from **185,726 to 170,918 bytes gzip**. Three chunks totalling ~21 KB gzip now load on first panel open rather than before first paint.

### 1. Every keystroke repainted all 219 tiles

`src/tileMemo.js` compared the raw `searchQuery`, which every tile received as a prop, so all 219 failed the memo check on every character even though only the handful whose match state flipped had anything new to draw.

The parent now computes the matching ids once per query and hands each tile a `matchesSearch` boolean. `searchQuery` also leaves the shared `tileProps` memo, which was rebuilding every keystroke for the same reason.

### 2. Only search-driven history writes are debounced

Search selects as you type, so typing `amo` wrote browser history three times, once for the `a` that matches extension `A`.

My first attempt debounced *all* selections. Two reviewers independently caught the regression: click a tile, reach for the address bar, and you copy the previous URL — and the write is cancelled outright if you close the tab inside the window. A deliberate click now writes immediately, **measured at 25 ms**; only search defers.

### 3. Three panels are deferred

`EncodingMap`, `WorkspacePanel` and `ExtensionEvolution` become lazy modules.

These are rendered unconditionally and hold state while closed — `WorkspacePanel` alone has 20 state hooks and 15 transitions — so gating them on `open` would have lost that state and broken the close animation. `useOnceMounted` mounts each on first open and keeps it mounted, so **nothing unmounts that did not unmount before**. It latches in a ref rather than state, because state costs a render before the chunk fetch can start.

**`CompareView` is deliberately left eager.** Making it lazy failed four `render-smoke` tests, and reading them showed why: it is reachable by permalink, so a URL that opens straight into a comparison would wait on a chunk. The right response was to narrow the optimisation, not to weaken the tests.

An idle prefetch of the three chunks was tried and **reverted**: dynamic `import()` of JSX cannot resolve in the test environment, and it took `render-smoke` from 16 seconds to two minutes. The Suspense fallbacks stay `null`; the reasoning, including the reviewer disagreement about a loading shell, is recorded in the source.

### 4. `output.clean`

Webpack 5 leaves its output directory alone, so a local `dist/` had kept a 280 KB PNG nothing references. It matters more now that the build emits chunks, which would otherwise linger.

### A test that was asserting nothing

`tests/extension-tile.test.mjs` had a fixture that minted fresh arrow functions and Sets per call, so comparing two of its results differed on five identities at once. The comparator returned `false` whatever key was overridden — **the loop passed for any key, including one that does not exist.**

It now spreads a single base object, with a companion test guarding the fixture itself. Verified by deleting the `matchesSearch` comparison, which the repaired loop catches.

### Verification

268 tests, lint and build green. Verified in a browser **on a subpath**, as GitHub Pages serves it, since `output.publicPath` is unset and defaults to `auto`:

- 0 chunks at first paint; opening Evolution fetches exactly one; the panel renders its 18 bands
- search highlighting intact (matching tile gets `ext-tile-active` and a ring, non-matching gets neither)
- click writes the permalink in 25 ms; search defers past the keystroke
- no console errors