### PR TITLE
feat: check catalogue completeness against unified-db, and add Shlcofideleg

### DIFF
--- a/.github/workflows/audit-deps.yml
+++ b/.github/workflows/audit-deps.yml
@@ -25,10 +25,11 @@ name: Audit Dependencies
 # breakage rather than a chore.
 
 on:
-  # Weekly, 07:00 UTC Monday. An hour after the daily UDB sync, so the two never
-  # contend for a runner or open pull requests in the same minute.
+  # Weekly, 08:00 UTC Monday. Staggered deliberately: the daily UDB sync runs at
+  # 06:00, check-opcodes-drift at 07:00, and the completeness report at 09:00, so
+  # no two weekly jobs contend for a runner or file reports in the same minute.
   schedule:
-    - cron: '0 7 * * 1'
+    - cron: '0 8 * * 1'
 
   workflow_dispatch:
 

--- a/.github/workflows/check-udb-completeness.yml
+++ b/.github/workflows/check-udb-completeness.yml
@@ -1,0 +1,156 @@
+name: Check UDB Completeness
+
+# Reports extensions and instructions that riscv-unified-db has ratified and
+# this catalogue does not carry.
+#
+# WHY THIS EXISTS
+#
+# scripts/sync_udb_extensions.cjs iterates OUR catalogue, so it enriches entries
+# we already have and can never add one we lack. Nothing watched the other
+# direction, which is how a ratified extension went unnoticed.
+#
+# Modelled on check-opcodes-drift.yml: one issue, edited in place while the gap
+# persists, closed automatically once it clears. A workflow that opens a fresh
+# issue every week is a workflow people mute.
+#
+# It reports rather than fails the build. The catalogue is a human-curated view
+# over upstream, and a gate that goes red the day RISC-V ratifies something is a
+# gate somebody switches off.
+
+on:
+  # Weekly, 09:00 UTC Monday. Staggered: the daily UDB sync runs at 06:00,
+  # check-opcodes-drift at 07:00 and audit-deps at 08:00, so no two weekly jobs
+  # contend for a runner or file reports in the same minute.
+  schedule:
+    - cron: '0 9 * * 1'
+
+  workflow_dispatch:
+
+# Reads the repository and writes an issue. It never pushes.
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: check-udb-completeness
+  cancel-in-progress: false
+
+jobs:
+  completeness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout the explorer repo
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Clone riscv-unified-db
+        id: udb
+        run: |
+          # Canonical location. riscv-software-src/ still redirects here, but
+          # relying on a redirect is one rename away from a silent failure.
+          git clone --depth 1 https://github.com/riscv/riscv-unified-db.git ../riscv-unified-db
+          echo "sha=$(git -C ../riscv-unified-db rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+
+      - name: Compare the catalogue against unified-db
+        id: check
+        run: |
+          set +e
+          npm run udb:check --silent -- ../riscv-unified-db > report.txt 2>&1
+          status=$?
+          set -e
+          cat report.txt
+
+          # Exit codes are a contract with the script: 0 complete, 1 gaps found,
+          # 2 the checkout could not be read. Conflating the last two would let a
+          # broken clone report a perfect catalogue.
+          if [ "${status}" -eq 0 ]; then
+            echo "complete=true" >> "$GITHUB_OUTPUT"
+          elif [ "${status}" -eq 1 ]; then
+            echo "complete=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "check-udb-completeness failed with status ${status}"
+            exit "${status}"
+          fi
+
+      - name: Find any existing report
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Match on a marker in the body, so an unrelated issue with a similar
+          # title cannot be mistaken for this report.
+          number=$(gh issue list --state open --label automated --limit 100 --json number,body \
+            --jq 'map(select(.body | contains("<!-- udb-completeness-report -->"))) | .[0].number // empty')
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update the report
+        if: steps.check.outputs.complete == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPSTREAM_SHA: ${{ steps.udb.outputs.sha }}
+          EXISTING: ${{ steps.existing.outputs.number }}
+        run: |
+          {
+            echo "<!-- udb-completeness-report -->"
+            echo "riscv-unified-db has ratified material this catalogue does not carry."
+            echo
+            echo '```'
+            cat report.txt
+            echo '```'
+            echo
+            echo "Upstream commit \`${UPSTREAM_SHA}\`. Reproduce locally:"
+            echo
+            echo '```'
+            echo "git clone --depth 1 https://github.com/riscv/riscv-unified-db.git ../riscv-unified-db"
+            echo "npm run udb:check -- ../riscv-unified-db"
+            echo '```'
+            echo
+            echo "Scope is **ratified only**. unified-db carries drafts and in-development"
+            echo "work too; pass \`--all\` to see those, but they are not completeness gaps."
+            echo
+            echo "**Not applied automatically.** Adding an extension is a curation decision:"
+            echo "it needs a description, a use case, a documentation link and a dependency"
+            echo "graph node, none of which unified-db supplies. See the \"To add an"
+            echo "extension\" section of AGENTS.md."
+            echo
+            echo "Closed automatically once the catalogue covers everything ratified."
+          } > body.md
+
+          if [ -n "${EXISTING}" ]; then
+            gh issue edit "${EXISTING}" --body-file body.md
+            gh issue comment "${EXISTING}" \
+              --body "Still incomplete as of upstream \`${UPSTREAM_SHA}\`. Report updated."
+          else
+            gh issue create \
+              --title "unified-db has ratified extensions we do not carry" \
+              --body-file body.md \
+              --label automated,data-sync
+          fi
+
+      - name: Close the report once complete
+        if: steps.check.outputs.complete == 'true' && steps.existing.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXISTING: ${{ steps.existing.outputs.number }}
+        run: |
+          gh issue close "${EXISTING}" \
+            --comment "The catalogue now covers everything unified-db has ratified. Closing automatically."
+
+      - name: Summary
+        if: always()
+        run: |
+          if [ -f report.txt ]; then
+            {
+              echo '## UDB completeness'
+              echo
+              echo '```'
+              cat report.txt
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ For live-reload development: `npm run dev` (serves on :8080 with source maps).
 | `npm run graph:check -- <path-to-udb>` | Check dependency graph vs UDB |
 | `npm run links:check` | Verify doc URLs resolve on docs.riscv.org |
 | `npm run opcodes:check -- <path-to-riscv-opcodes>` | Report instruction-encoding drift |
+| `npm run udb:check -- <path-to-udb>` | Report ratified extensions/instructions we lack |
 | `npm run deploy` | Manual publish of `dist/` to `gh-pages` (normally automatic) |
 
 There is no separate typecheck (no TypeScript).
@@ -115,6 +116,12 @@ Then `npm run sync` and `npm test && npm run build`.
   entries upstream lacks (the 56 `vlseg` segment loads; expanded MOP/C.MOP). A
   regenerate would delete them. `npm run opcodes:check` only *reports* drift and
   leaves the call to a human — never auto-apply it.
+- **The daily UDB sync cannot ADD an extension.** `scripts/sync_udb_extensions.cjs`
+  iterates the catalogue, so it enriches entries that already exist and is blind
+  to anything upstream has that we do not. `npm run udb:check` watches that
+  direction, and a weekly workflow files the result as one issue it keeps
+  updated. Adding an extension stays a human decision: it needs a description, a
+  use case, a doc link and a graph node, none of which UDB supplies.
 - **`dist/` and `node_modules/` are generated** (dist is git-ignored / rebuilt;
   eslint ignores both). Don't hand-edit `dist/`.
 - **`gh-pages` branch is machine-published** by CI on every push to `main`.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "graph:check": "node scripts/seed-dependency-graph.mjs --check --udb",
     "links:check": "node scripts/map-doc-links.mjs --check",
     "opcodes:check": "node scripts/check-opcodes-drift.mjs",
+    "udb:check": "node scripts/check-udb-completeness.mjs",
     "predeploy": "npm run build",
     "sync": "node scripts/sync_instructions.mjs",
     "sync:check": "npm run sync -- --strict",

--- a/scripts/check-udb-completeness.mjs
+++ b/scripts/check-udb-completeness.mjs
@@ -70,10 +70,20 @@ const readScalars = (file, keys) => {
   return out;
 };
 
-const extensions = fs
-  .readdirSync(path.join(specDir, 'ext'))
-  .filter((f) => f.endsWith('.yaml'))
-  .map((f) => f.replace(/\.yaml$/, ''));
+const extDir = path.join(specDir, 'ext');
+const extensions = [];
+const ratifiedExtensions = [];
+for (const file of fs.readdirSync(extDir).filter((f) => f.endsWith('.yaml'))) {
+  const id = file.replace(/\.yaml$/, '');
+  extensions.push(id);
+  /*
+   * "Ever ratified": an extension qualifies if ANY of its versions reached
+   * ratified, even where a later one is frozen. unified-db lists a state per
+   * version, so this reads them all rather than the first.
+   */
+  const text = fs.readFileSync(path.join(extDir, file), 'utf8');
+  if (/^\s*state:\s*ratified\s*$/m.test(text)) ratifiedExtensions.push(id);
+}
 
 const instructions = [];
 const instRoot = path.join(specDir, 'inst');
@@ -135,7 +145,15 @@ const EXTENSION_ALIASES = { I: ['RV32I', 'RV64I', 'RV32E', 'RV64E'] };
 const result = compareAgainstUpstream(
   catalogue,
   { extensions, instructions },
-  { extensionAliases: EXTENSION_ALIASES, allowMissingExtensions: Object.keys(EXTENSION_ALIASES) },
+  {
+    extensionAliases: EXTENSION_ALIASES,
+    allowMissingExtensions: Object.keys(EXTENSION_ALIASES),
+    // Default to the question the catalogue exists to answer. --all widens it
+    // to everything upstream carries, which is useful for seeing what is coming
+    // but is not a completeness failure.
+    onlyRatified: !process.argv.includes('--all'),
+    ratifiedExtensions,
+  },
 );
 
 if (asJson) {
@@ -149,7 +167,12 @@ const list = (rows, f) =>
     .map((s) => `    ${s}`)
     .join('\n');
 
-console.log(`unified-db: ${extensions.length} extensions, ${instructions.length} instructions`);
+const scope = process.argv.includes('--all') ? 'all upstream' : 'ratified only';
+console.log(
+  `unified-db: ${extensions.length} extensions ` +
+    `(${ratifiedExtensions.length} ever ratified), ${instructions.length} instructions`,
+);
+console.log(`scope: ${scope}   (pass --all to include draft and in-development work)`);
 console.log(`catalogue:  ${Object.values(catalogue).flat().filter(Boolean).length} extensions\n`);
 
 console.log(`missing extensions (${result.missingExtensions.length}):`);

--- a/scripts/check-udb-completeness.mjs
+++ b/scripts/check-udb-completeness.mjs
@@ -18,197 +18,212 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { compareAgainstUpstream } from '../src/completeness.js';
 
-const udbRoot = process.argv[2];
-const asJson = process.argv.includes('--json');
-
-if (!udbRoot || !fs.existsSync(udbRoot)) {
-  console.error('usage: node scripts/check-udb-completeness.mjs <path-to-riscv-unified-db>');
-  process.exit(2);
-}
-
-const specDir = path.join(udbRoot, 'spec', 'std', 'isa');
-for (const d of ['ext', 'inst']) {
-  if (!fs.existsSync(path.join(specDir, d))) {
-    console.error(`error: ${path.join(specDir, d)} does not exist. Is this a unified-db checkout?`);
-    process.exit(2);
-  }
-}
-
-/*
- * A deliberately small YAML reader, matching the one already in
- * sync_udb_extensions.cjs: only the few scalar keys needed here, no dependency.
- * If unified-db restructures, the sanity floor below fails loudly rather than
- * reporting a clean run against nothing.
+/**
+ * Read an unified-db checkout into the shape completeness.js compares against.
+ *
+ * Exported and given a directory rather than reading argv, because every bug
+ * this file has had was in the parsing: a regex that terminated on /$/m and so
+ * captured nothing, an `|| [dir]` fallback that never fired because an empty
+ * array is truthy, and a missing `state` read that reported draft extensions as
+ * ratified gaps. Real data found all three; tests found none, because there was
+ * nothing importable to test. Now there is.
  */
-const readScalars = (file, keys) => {
-  const out = {};
-  const text = fs.readFileSync(file, 'utf8');
-  for (const key of keys) {
-    const m = text.match(new RegExp(`^\\s*${key}:\\s*(.+?)\\s*$`, 'm'));
-    if (m) out[key] = m[1].replace(/^["']|["']$/g, '');
+export function parseUpstream(specDir) {
+  const readDefinedBy = (text) => {
+    /*
+     * definedBy is a nested block, in one of two shapes:
+     *
+     *   definedBy:            definedBy:
+     *     extension:            extension:
+     *       name: I               anyOf:
+     *                               - name: Zbb
+     *                               - name: Zbkb
+     *
+     * Capture every indented line under it, up to the next key at column zero,
+     * then take each `name:`.
+     */
+    const block = text.match(/^definedBy:\n([\s\S]*?)(?=^\S)/m);
+    return block ? [...block[1].matchAll(/name:\s*([A-Za-z0-9_.]+)/g)].map((x) => x[1]) : [];
+  };
+
+  const extDir = path.join(specDir, 'ext');
+  const extensions = [];
+  const ratifiedExtensions = [];
+  for (const file of fs.readdirSync(extDir).filter((f) => f.endsWith('.yaml'))) {
+    const id = file.replace(/\.yaml$/, '');
+    extensions.push(id);
+    /*
+     * "Ever ratified": an extension qualifies if ANY of its versions reached
+     * ratified, even where a later one is frozen.
+     */
+    const text = fs.readFileSync(path.join(extDir, file), 'utf8');
+    if (/^\s*state:\s*ratified\s*$/m.test(text)) ratifiedExtensions.push(id);
   }
-  /*
-   * definedBy is a nested block, in one of two shapes:
-   *
-   *   definedBy:            definedBy:
-   *     extension:            extension:
-   *       name: I               anyOf:
-   *                               - name: Zbb
-   *                               - name: Zbkb
-   *
-   * Capture every indented line under it, up to the next key at column zero,
-   * then take each `name:`. An earlier version terminated on /$/m, which in
-   * multiline mode is the end of the FIRST line, so it captured nothing and
-   * every instruction came back unowned.
-   */
-  const defined = text.match(/^definedBy:\n([\s\S]*?)(?=^\S)/m);
-  out.definedBy = defined
-    ? [...defined[1].matchAll(/name:\s*([A-Za-z0-9_.]+)/g)].map((x) => x[1])
-    : [];
-  return out;
-};
 
-const extDir = path.join(specDir, 'ext');
-const extensions = [];
-const ratifiedExtensions = [];
-for (const file of fs.readdirSync(extDir).filter((f) => f.endsWith('.yaml'))) {
-  const id = file.replace(/\.yaml$/, '');
-  extensions.push(id);
-  /*
-   * "Ever ratified": an extension qualifies if ANY of its versions reached
-   * ratified, even where a later one is frozen. unified-db lists a state per
-   * version, so this reads them all rather than the first.
-   */
-  const text = fs.readFileSync(path.join(extDir, file), 'utf8');
-  if (/^\s*state:\s*ratified\s*$/m.test(text)) ratifiedExtensions.push(id);
-}
-
-const instructions = [];
-const instRoot = path.join(specDir, 'inst');
-for (const dir of fs.readdirSync(instRoot)) {
-  const sub = path.join(instRoot, dir);
-  if (!fs.statSync(sub).isDirectory()) continue;
-  for (const file of fs.readdirSync(sub).filter((f) => f.endsWith('.yaml'))) {
-    const y = readScalars(path.join(sub, file), ['name', 'match']);
-    const mnemonic = (y.name || file.replace(/\.yaml$/, '')).toUpperCase();
-    // UDB gives an encoding string of 0/1/- rather than match/mask.
-    const text = fs.readFileSync(path.join(sub, file), 'utf8');
-    const enc = text.match(/^\s*match:\s*([01-]+)\s*$/m);
-    if (!enc) continue;
-    const bits = enc[1];
-    let match = 0n;
-    let mask = 0n;
-    for (const ch of bits) {
-      match <<= 1n;
-      mask <<= 1n;
-      if (ch === '1') {
-        match |= 1n;
-        mask |= 1n;
-      } else if (ch === '0') {
-        mask |= 1n;
+  const instructions = [];
+  const instRoot = path.join(specDir, 'inst');
+  for (const dir of fs.readdirSync(instRoot)) {
+    const sub = path.join(instRoot, dir);
+    if (!fs.statSync(sub).isDirectory()) continue;
+    for (const file of fs.readdirSync(sub).filter((f) => f.endsWith('.yaml'))) {
+      const text = fs.readFileSync(path.join(sub, file), 'utf8');
+      const name = text.match(/^name:\s*(.+?)\s*$/m);
+      // unified-db gives an encoding string of 0/1/- rather than match/mask.
+      const enc = text.match(/^\s*match:\s*([01-]+)\s*$/m);
+      if (!enc) continue;
+      let match = 0n;
+      let mask = 0n;
+      for (const ch of enc[1]) {
+        match <<= 1n;
+        mask <<= 1n;
+        if (ch === '1') {
+          match |= 1n;
+          mask |= 1n;
+        } else if (ch === '0') {
+          mask |= 1n;
+        }
       }
+      const owners = readDefinedBy(text);
+      instructions.push({
+        mnemonic: (name ? name[1] : file.replace(/\.yaml$/, '')).toUpperCase(),
+        match,
+        mask,
+        // Fall back to the directory only when the file names no owner. An
+        // empty array is truthy, so `|| [dir]` silently kept the empty list.
+        definedBy: owners.length ? owners : [dir],
+      });
     }
-    instructions.push({
-      mnemonic,
-      match,
-      mask,
-      // Fall back to the directory only when the file names no owner. An empty
-      // array is truthy, so `|| [dir]` silently kept the empty list.
-      definedBy: y.definedBy.length ? y.definedBy : [dir],
-    });
   }
+
+  return { extensions, ratifiedExtensions, instructions };
 }
 
-// Sanity floor: a parser that silently matches nothing would report a perfect
-// catalogue, which is the most dangerous possible output for this tool.
-if (extensions.length < 100 || instructions.length < 500) {
-  console.error(
-    `error: parsed only ${extensions.length} extensions and ${instructions.length} instructions. ` +
-      'unified-db has likely restructured; refusing to report a clean run.',
-  );
-  process.exit(2);
-}
-
-const catalogue = JSON.parse(
-  fs.readFileSync(new URL('../src/riscv_extensions.json', import.meta.url), 'utf8'),
-);
 /*
  * unified-db attributes the base integer instructions to a bare `I`. This
  * catalogue models the concrete bases instead, RV32I and RV64I, which is the
- * distinction a reader building an -march string actually needs. The alias
- * keeps that modelling choice from reading as 300 missing instructions.
+ * distinction a reader building an -march string actually needs.
  */
-const EXTENSION_ALIASES = { I: ['RV32I', 'RV64I', 'RV32E', 'RV64E'] };
+export const EXTENSION_ALIASES = { I: ['RV32I', 'RV64I', 'RV32E', 'RV64E'] };
 
-const result = compareAgainstUpstream(
-  catalogue,
-  { extensions, instructions },
-  {
-    extensionAliases: EXTENSION_ALIASES,
-    allowMissingExtensions: Object.keys(EXTENSION_ALIASES),
-    // Default to the question the catalogue exists to answer. --all widens it
-    // to everything upstream carries, which is useful for seeing what is coming
-    // but is not a completeness failure.
-    onlyRatified: !process.argv.includes('--all'),
-    ratifiedExtensions,
-  },
-);
+/*
+ * Exit codes match check-opcodes-drift.mjs, which the reporting workflow keys
+ * off: 0 complete, 1 gaps found, 2 the checkout could not be read. Conflating
+ * the last two would let a broken clone report a perfect catalogue, which is
+ * the most dangerous output this tool has.
+ */
+function main(argv) {
+  const udbRoot = argv[2];
+  const asJson = argv.includes('--json');
+  const includeAll = argv.includes('--all');
 
-if (asJson) {
-  console.log(JSON.stringify(result, (_, v) => (typeof v === 'bigint' ? v.toString() : v), 2));
-  process.exit(0);
-}
-
-const list = (rows, f) =>
-  rows
-    .map(f)
-    .map((s) => `    ${s}`)
-    .join('\n');
-
-const scope = process.argv.includes('--all') ? 'all upstream' : 'ratified only';
-console.log(
-  `unified-db: ${extensions.length} extensions ` +
-    `(${ratifiedExtensions.length} ever ratified), ${instructions.length} instructions`,
-);
-console.log(`scope: ${scope}   (pass --all to include draft and in-development work)`);
-console.log(`catalogue:  ${Object.values(catalogue).flat().filter(Boolean).length} extensions\n`);
-
-console.log(`missing extensions (${result.missingExtensions.length}):`);
-console.log(
-  result.missingExtensions.length ? list(result.missingExtensions, (x) => x) : '    none',
-);
-
-console.log(`\nmissing instructions (${result.missingInstructions.length}):`);
-console.log(
-  result.missingInstructions.length
-    ? list(result.missingInstructions, (x) => `${x.mnemonic}  (${x.definedBy.join(', ')})`)
-    : '    none',
-);
-
-console.log(
-  `\ncovered by a broader row (${result.coveredByBroaderRow.length}), of which ordering-only: ` +
-    `${result.coveredByBroaderRow.filter((c) => c.orderingOnly).length}`,
-);
-
-if (result.encodingMismatches.length) {
-  console.log(`\nsame name, different bits (${result.encodingMismatches.length}):`);
-  for (const x of result.encodingMismatches) {
-    console.log(`    ${x.extension} ${x.mnemonic}`);
-    console.log(`      local    ${x.local}`);
-    console.log(`      upstream ${x.upstream}`);
-    console.log(
-      x.narrower
-        ? '      we pin a bit upstream leaves free'
-        : '      upstream carries another encoding under this name',
+  if (!udbRoot || !fs.existsSync(udbRoot)) {
+    console.error(
+      'usage: node scripts/check-udb-completeness.mjs <path-to-riscv-unified-db> [--all] [--json]',
     );
+    return 2;
   }
+
+  const specDir = path.join(udbRoot, 'spec', 'std', 'isa');
+  for (const d of ['ext', 'inst']) {
+    if (!fs.existsSync(path.join(specDir, d))) {
+      console.error(
+        `error: ${path.join(specDir, d)} does not exist. Is this a unified-db checkout?`,
+      );
+      return 2;
+    }
+  }
+
+  const { extensions, ratifiedExtensions, instructions } = parseUpstream(specDir);
+
+  // A parser that silently matched nothing would report a perfect catalogue.
+  if (extensions.length < 100 || instructions.length < 500) {
+    console.error(
+      `error: parsed only ${extensions.length} extensions and ${instructions.length} instructions. ` +
+        'unified-db has likely restructured; refusing to report a clean run.',
+    );
+    return 2;
+  }
+
+  const catalogue = JSON.parse(
+    fs.readFileSync(new URL('../src/riscv_extensions.json', import.meta.url), 'utf8'),
+  );
+
+  const result = compareAgainstUpstream(
+    catalogue,
+    { extensions, instructions },
+    {
+      extensionAliases: EXTENSION_ALIASES,
+      allowMissingExtensions: Object.keys(EXTENSION_ALIASES),
+      onlyRatified: !includeAll,
+      ratifiedExtensions,
+    },
+  );
+
+  if (asJson) {
+    console.log(JSON.stringify(result, (_, v) => (typeof v === 'bigint' ? v.toString() : v), 2));
+    return result.complete ? 0 : 1;
+  }
+
+  const list = (rows, f) =>
+    rows
+      .map(f)
+      .map((x) => `    ${x}`)
+      .join('\n');
+
+  console.log(
+    `unified-db: ${extensions.length} extensions ` +
+      `(${ratifiedExtensions.length} ever ratified), ${instructions.length} instructions`,
+  );
+  console.log(
+    `scope: ${includeAll ? 'all upstream' : 'ratified only'}` +
+      '   (pass --all to include draft and in-development work)',
+  );
+  console.log(`catalogue:  ${Object.values(catalogue).flat().filter(Boolean).length} extensions\n`);
+
+  console.log(`missing extensions (${result.missingExtensions.length}):`);
+  console.log(
+    result.missingExtensions.length ? list(result.missingExtensions, (x) => x) : '    none',
+  );
+
+  console.log(`\nmissing instructions (${result.missingInstructions.length}):`);
+  console.log(
+    result.missingInstructions.length
+      ? list(result.missingInstructions, (x) => `${x.mnemonic}  (${x.definedBy.join(', ')})`)
+      : '    none',
+  );
+
+  console.log(
+    `\ncovered by a broader row (${result.coveredByBroaderRow.length}), of which ordering-only: ` +
+      `${result.coveredByBroaderRow.filter((c) => c.orderingOnly).length}`,
+  );
+
+  if (result.encodingMismatches.length) {
+    console.log(`\nsame name, different bits (${result.encodingMismatches.length}):`);
+    for (const x of result.encodingMismatches) {
+      console.log(`    ${x.extension} ${x.mnemonic}`);
+      console.log(`      local    ${x.local}`);
+      console.log(`      upstream ${x.upstream}`);
+      console.log(
+        x.narrower
+          ? '      we pin a bit upstream leaves free'
+          : '      upstream carries another encoding under this name',
+      );
+    }
+  }
+
+  if (result.malformed.length) {
+    console.log(`\nmalformed local encodings (${result.malformed.length}):`);
+    console.log(list(result.malformed, (x) => `${x.extension} ${x.mnemonic}`));
+  }
+
+  console.log(`\ncomplete: ${result.complete}`);
+  return result.complete ? 0 : 1;
 }
 
-if (result.malformed.length) {
-  console.log(`\nmalformed local encodings (${result.malformed.length}):`);
-  console.log(list(result.malformed, (x) => `${x.extension} ${x.mnemonic}`));
+// Only run when invoked directly, so the parser can be imported by tests.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  process.exit(main(process.argv));
 }
-
-console.log(`\ncomplete: ${result.complete}`);

--- a/scripts/check-udb-completeness.mjs
+++ b/scripts/check-udb-completeness.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * Report what riscv-unified-db has that this catalogue does not.
+ *
+ *   node scripts/check-udb-completeness.mjs <path-to-riscv-unified-db> [--json]
+ *
+ * The decision logic lives in src/completeness.js, which takes no I/O so it can
+ * be tested without a checkout. This file only reads YAML and prints.
+ *
+ * Reports; does not fail. A gate that goes red the day upstream ratifies
+ * something is a gate people turn off, and the daily sync workflow is a better
+ * place to act on the result than a build.
+ *
+ * Why this exists: scripts/sync_udb_extensions.cjs iterates OUR catalogue, so
+ * it enriches entries we already have and can never add one we lack. Nothing
+ * watched the other direction until now.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { compareAgainstUpstream } from '../src/completeness.js';
+
+const udbRoot = process.argv[2];
+const asJson = process.argv.includes('--json');
+
+if (!udbRoot || !fs.existsSync(udbRoot)) {
+  console.error('usage: node scripts/check-udb-completeness.mjs <path-to-riscv-unified-db>');
+  process.exit(2);
+}
+
+const specDir = path.join(udbRoot, 'spec', 'std', 'isa');
+for (const d of ['ext', 'inst']) {
+  if (!fs.existsSync(path.join(specDir, d))) {
+    console.error(`error: ${path.join(specDir, d)} does not exist. Is this a unified-db checkout?`);
+    process.exit(2);
+  }
+}
+
+/*
+ * A deliberately small YAML reader, matching the one already in
+ * sync_udb_extensions.cjs: only the few scalar keys needed here, no dependency.
+ * If unified-db restructures, the sanity floor below fails loudly rather than
+ * reporting a clean run against nothing.
+ */
+const readScalars = (file, keys) => {
+  const out = {};
+  const text = fs.readFileSync(file, 'utf8');
+  for (const key of keys) {
+    const m = text.match(new RegExp(`^\\s*${key}:\\s*(.+?)\\s*$`, 'm'));
+    if (m) out[key] = m[1].replace(/^["']|["']$/g, '');
+  }
+  /*
+   * definedBy is a nested block, in one of two shapes:
+   *
+   *   definedBy:            definedBy:
+   *     extension:            extension:
+   *       name: I               anyOf:
+   *                               - name: Zbb
+   *                               - name: Zbkb
+   *
+   * Capture every indented line under it, up to the next key at column zero,
+   * then take each `name:`. An earlier version terminated on /$/m, which in
+   * multiline mode is the end of the FIRST line, so it captured nothing and
+   * every instruction came back unowned.
+   */
+  const defined = text.match(/^definedBy:\n([\s\S]*?)(?=^\S)/m);
+  out.definedBy = defined
+    ? [...defined[1].matchAll(/name:\s*([A-Za-z0-9_.]+)/g)].map((x) => x[1])
+    : [];
+  return out;
+};
+
+const extensions = fs
+  .readdirSync(path.join(specDir, 'ext'))
+  .filter((f) => f.endsWith('.yaml'))
+  .map((f) => f.replace(/\.yaml$/, ''));
+
+const instructions = [];
+const instRoot = path.join(specDir, 'inst');
+for (const dir of fs.readdirSync(instRoot)) {
+  const sub = path.join(instRoot, dir);
+  if (!fs.statSync(sub).isDirectory()) continue;
+  for (const file of fs.readdirSync(sub).filter((f) => f.endsWith('.yaml'))) {
+    const y = readScalars(path.join(sub, file), ['name', 'match']);
+    const mnemonic = (y.name || file.replace(/\.yaml$/, '')).toUpperCase();
+    // UDB gives an encoding string of 0/1/- rather than match/mask.
+    const text = fs.readFileSync(path.join(sub, file), 'utf8');
+    const enc = text.match(/^\s*match:\s*([01-]+)\s*$/m);
+    if (!enc) continue;
+    const bits = enc[1];
+    let match = 0n;
+    let mask = 0n;
+    for (const ch of bits) {
+      match <<= 1n;
+      mask <<= 1n;
+      if (ch === '1') {
+        match |= 1n;
+        mask |= 1n;
+      } else if (ch === '0') {
+        mask |= 1n;
+      }
+    }
+    instructions.push({
+      mnemonic,
+      match,
+      mask,
+      // Fall back to the directory only when the file names no owner. An empty
+      // array is truthy, so `|| [dir]` silently kept the empty list.
+      definedBy: y.definedBy.length ? y.definedBy : [dir],
+    });
+  }
+}
+
+// Sanity floor: a parser that silently matches nothing would report a perfect
+// catalogue, which is the most dangerous possible output for this tool.
+if (extensions.length < 100 || instructions.length < 500) {
+  console.error(
+    `error: parsed only ${extensions.length} extensions and ${instructions.length} instructions. ` +
+      'unified-db has likely restructured; refusing to report a clean run.',
+  );
+  process.exit(2);
+}
+
+const catalogue = JSON.parse(
+  fs.readFileSync(new URL('../src/riscv_extensions.json', import.meta.url), 'utf8'),
+);
+/*
+ * unified-db attributes the base integer instructions to a bare `I`. This
+ * catalogue models the concrete bases instead, RV32I and RV64I, which is the
+ * distinction a reader building an -march string actually needs. The alias
+ * keeps that modelling choice from reading as 300 missing instructions.
+ */
+const EXTENSION_ALIASES = { I: ['RV32I', 'RV64I', 'RV32E', 'RV64E'] };
+
+const result = compareAgainstUpstream(
+  catalogue,
+  { extensions, instructions },
+  { extensionAliases: EXTENSION_ALIASES, allowMissingExtensions: Object.keys(EXTENSION_ALIASES) },
+);
+
+if (asJson) {
+  console.log(JSON.stringify(result, (_, v) => (typeof v === 'bigint' ? v.toString() : v), 2));
+  process.exit(0);
+}
+
+const list = (rows, f) =>
+  rows
+    .map(f)
+    .map((s) => `    ${s}`)
+    .join('\n');
+
+console.log(`unified-db: ${extensions.length} extensions, ${instructions.length} instructions`);
+console.log(`catalogue:  ${Object.values(catalogue).flat().filter(Boolean).length} extensions\n`);
+
+console.log(`missing extensions (${result.missingExtensions.length}):`);
+console.log(
+  result.missingExtensions.length ? list(result.missingExtensions, (x) => x) : '    none',
+);
+
+console.log(`\nmissing instructions (${result.missingInstructions.length}):`);
+console.log(
+  result.missingInstructions.length
+    ? list(result.missingInstructions, (x) => `${x.mnemonic}  (${x.definedBy.join(', ')})`)
+    : '    none',
+);
+
+console.log(
+  `\ncovered by a broader row (${result.coveredByBroaderRow.length}), of which ordering-only: ` +
+    `${result.coveredByBroaderRow.filter((c) => c.orderingOnly).length}`,
+);
+
+if (result.encodingMismatches.length) {
+  console.log(`\nsame name, different bits (${result.encodingMismatches.length}):`);
+  for (const x of result.encodingMismatches) {
+    console.log(`    ${x.extension} ${x.mnemonic}`);
+    console.log(`      local    ${x.local}`);
+    console.log(`      upstream ${x.upstream}`);
+    console.log(
+      x.narrower
+        ? '      we pin a bit upstream leaves free'
+        : '      upstream carries another encoding under this name',
+    );
+  }
+}
+
+if (result.malformed.length) {
+  console.log(`\nmalformed local encodings (${result.malformed.length}):`);
+  console.log(list(result.malformed, (x) => `${x.extension} ${x.mnemonic}`));
+}
+
+console.log(`\ncomplete: ${result.complete}`);

--- a/src/completeness.js
+++ b/src/completeness.js
@@ -119,7 +119,23 @@ export function compareAgainstUpstream(catalogue, upstream, options = {}) {
      * real gaps.
      */
     extensionAliases = {},
+    /*
+     * Restrict the report to extensions upstream has ever ratified.
+     *
+     * unified-db carries drafts and in-development work alongside ratified
+     * material, and treating its presence as ratification over-reports badly:
+     * the first run of this gate called Zilx a gap, with nineteen instructions
+     * behind it, when Zilx is state `development` and nobody should be waiting
+     * on it. "Ever ratified" is the question the catalogue actually answers, so
+     * an extension counts if ANY of its versions reached ratified, even if a
+     * later one is frozen.
+     */
+    onlyRatified = false,
+    ratifiedExtensions = [],
   } = options;
+
+  const ratified = new Set(ratifiedExtensions.map((x) => x.toLowerCase()));
+  const isRatified = (id) => ratified.has(String(id).toLowerCase());
 
   const aliasesFor = (id) => {
     const mapped = extensionAliases[id] || extensionAliases[id.toLowerCase()];
@@ -144,7 +160,12 @@ export function compareAgainstUpstream(catalogue, upstream, options = {}) {
   const missingExtensions = (upstream.extensions || [])
     .filter((id) => !localIds.has(id.toLowerCase()))
     .filter((id) => !allowMissingExtensions.includes(id))
+    .filter((id) => !onlyRatified || isRatified(id))
     .sort();
+
+  // An instruction is only a ratified gap if something ratified defines it.
+  const upstreamIsRatified = (inst) =>
+    !onlyRatified || (inst.definedBy || []).some((owner) => isRatified(owner));
 
   const missingInstructions = [];
   const attributedDifferently = [];
@@ -154,6 +175,7 @@ export function compareAgainstUpstream(catalogue, upstream, options = {}) {
   for (const inst of upstream.instructions || []) {
     const mnemonic = inst.mnemonic.toUpperCase();
     if (allowMissingInstructions.includes(mnemonic)) continue;
+    if (!upstreamIsRatified(inst)) continue;
 
     /*
      * Only rows in an extension upstream attributes the instruction to are

--- a/src/completeness.js
+++ b/src/completeness.js
@@ -1,0 +1,249 @@
+/**
+ * completeness.js — is the catalogue missing anything the upstream spec has?
+ *
+ * Pure functions, no I/O and no data imports: both sides are passed in, the
+ * same contract marchUtils.js keeps. The script that reads riscv-unified-db
+ * off disk lives in scripts/; everything decidable lives here so it can be
+ * tested without a checkout.
+ *
+ * WHY ENCODING COVERAGE RATHER THAN NAME MATCHING
+ *
+ * unified-db enumerates memory-ordering forms as separate instructions:
+ * amoadd.w, amoadd.w.aq, amoadd.w.rl, amoadd.w.aqrl. This catalogue models one
+ * AMOADD.W whose mask leaves the aq and rl bits unconstrained, which is how
+ * riscv-opcodes models them too (both appear in variable_fields beside rd and
+ * rs1). One row already covers all four encodings.
+ *
+ * The tempting shortcut is to strip a trailing .aq/.rl/.aqrl from the upstream
+ * name before comparing. That is wrong, and Zalasr is the proof: its loads are
+ * LB.AQ with the aq bit FIXED, because forms without it are reserved, and its
+ * stores are SB.RL with rl fixed. Stripping turns LB.AQ into LB, which is a
+ * different instruction in the base ISA with a different encoding. The gate
+ * would either match the wrong row and hide a real gap, or collide.
+ *
+ * So coverage is decided on the bits. An upstream encoding is covered when a
+ * local row in the SAME extension constrains a subset of the same bits to the
+ * same values. That answers the question actually being asked -- "would this
+ * upstream instruction decode as something we already list" -- and it cannot be
+ * fooled by a name.
+ */
+
+/** aq is bit 26, rl is bit 25, per the A extension's AMO format. */
+export const AQ_BIT = 1n << 26n;
+export const RL_BIT = 1n << 25n;
+export const ORDERING_BITS = AQ_BIT | RL_BIT;
+
+const big = (v) => (typeof v === 'bigint' ? v : BigInt(v));
+
+/**
+ * Does the local pattern cover the upstream one?
+ *
+ * True when local fixes a subset of the bits upstream fixes, and agrees with it
+ * on every bit local does fix. A local row with aq/rl unconstrained therefore
+ * covers all four ordering forms, while a local row that fixed MORE bits than
+ * upstream does not cover it, which is what catches a mask quietly narrowing.
+ */
+export function patternCovers(local, upstream) {
+  const lMask = big(local.mask);
+  const lMatch = big(local.match);
+  const uMask = big(upstream.mask);
+  const uMatch = big(upstream.match);
+
+  if ((uMask & lMask) !== lMask) return false;
+  return ((uMatch ^ lMatch) & lMask) === 0n;
+}
+
+/**
+ * An encoding is well formed when it sets no bit its own mask leaves free.
+ *
+ * A match bit outside the mask can never be tested, so it is silently dead. It
+ * usually means a hand-edited entry drifted.
+ */
+export function encodingIsWellFormed({ match, mask }) {
+  return (big(match) & ~big(mask)) === 0n;
+}
+
+/**
+ * The bits upstream pins that we leave free, and whether they are only ordering
+ * bits. Used to explain WHY something is covered rather than merely that it is.
+ */
+export function extraFixedBits(local, upstream) {
+  return big(upstream.mask) & ~big(local.mask);
+}
+
+export function isOrderingRefinement(local, upstream) {
+  const extra = extraFixedBits(local, upstream);
+  return extra !== 0n && (extra & ~ORDERING_BITS) === 0n;
+}
+
+/** Every instruction in the catalogue, flattened, keeping its owning entry. */
+export function flattenCatalogue(catalogue) {
+  const rows = [];
+  for (const group of Object.values(catalogue || {})) {
+    for (const entry of group || []) {
+      if (!entry || !entry.id) continue;
+      for (const [mnemonic, details] of Object.entries(entry.instructions || {})) {
+        if (!details || details.match == null || details.mask == null) continue;
+        rows.push({
+          extension: entry.id,
+          mnemonic: mnemonic.toUpperCase(),
+          match: big(details.match),
+          mask: big(details.mask),
+          variableFields: details.variable_fields || [],
+        });
+      }
+    }
+  }
+  return rows;
+}
+
+/**
+ * Compare the catalogue against an upstream inventory.
+ *
+ * `upstream` is { extensions: [id...], instructions: [{ mnemonic, match, mask,
+ * definedBy }] }, already normalised by the caller from whatever upstream
+ * ships. definedBy is a list, because unified-db can attribute one instruction
+ * to several extensions.
+ *
+ * Reports rather than throws. A completeness gate that fails the build the day
+ * upstream adds something is a gate people switch off.
+ */
+export function compareAgainstUpstream(catalogue, upstream, options = {}) {
+  const {
+    allowMissingExtensions = [],
+    allowMissingInstructions = [],
+    /*
+     * Upstream ids that this catalogue models under different ones. Upstream's
+     * bare `I` is our RV32I and RV64I, for instance. Without this, a deliberate
+     * modelling choice reads as hundreds of missing instructions and buries the
+     * real gaps.
+     */
+    extensionAliases = {},
+  } = options;
+
+  const aliasesFor = (id) => {
+    const mapped = extensionAliases[id] || extensionAliases[id.toLowerCase()];
+    return (mapped ? [id, ...mapped] : [id]).map((x) => x.toLowerCase());
+  };
+
+  const local = flattenCatalogue(catalogue);
+  const localIds = new Set(
+    Object.values(catalogue || {})
+      .flat()
+      .filter(Boolean)
+      .map((e) => e.id.toLowerCase()),
+  );
+
+  const byExtension = new Map();
+  for (const row of local) {
+    const key = row.extension.toLowerCase();
+    if (!byExtension.has(key)) byExtension.set(key, []);
+    byExtension.get(key).push(row);
+  }
+
+  const missingExtensions = (upstream.extensions || [])
+    .filter((id) => !localIds.has(id.toLowerCase()))
+    .filter((id) => !allowMissingExtensions.includes(id))
+    .sort();
+
+  const missingInstructions = [];
+  const attributedDifferently = [];
+  const coveredByBroaderRow = [];
+  const encodingMismatches = [];
+
+  for (const inst of upstream.instructions || []) {
+    const mnemonic = inst.mnemonic.toUpperCase();
+    if (allowMissingInstructions.includes(mnemonic)) continue;
+
+    /*
+     * Only rows in an extension upstream attributes the instruction to are
+     * eligible. Without this, Zalasr's LB.AQ could be "covered" by the base
+     * ISA's LB, which is a different instruction that happens to share a name
+     * prefix.
+     */
+    const owners = (inst.definedBy || []).flatMap(aliasesFor);
+    const candidates = owners.flatMap((o) => byExtension.get(o) || []);
+
+    const exact = candidates.find((c) => c.mnemonic === mnemonic);
+    const covering = candidates.find((c) => patternCovers(c, inst));
+
+    if (exact && patternCovers(exact, inst)) continue;
+
+    if (exact && !patternCovers(exact, inst)) {
+      // The name is here but the bits disagree: either we pin something
+      // upstream leaves free, or we pin it to a different value.
+      /*
+       * The name is here but the bits disagree. Two different faults land here
+       * and the report has to show both halves to tell them apart: we may pin
+       * a bit upstream leaves free (a narrowing), or we may pin it to a
+       * different value, which usually means upstream carries several
+       * encodings under one mnemonic and we carry one. REV8 is the live
+       * example, with distinct RV32 and RV64 forms.
+       */
+      encodingMismatches.push({
+        mnemonic,
+        extension: exact.extension,
+        local: `match 0x${exact.match.toString(16)} mask 0x${exact.mask.toString(16)}`,
+        upstream: `match 0x${big(inst.match).toString(16)} mask 0x${big(inst.mask).toString(16)}`,
+        narrower: (big(inst.mask) & exact.mask) !== exact.mask,
+      });
+      continue;
+    }
+
+    if (covering) {
+      coveredByBroaderRow.push({
+        upstream: mnemonic,
+        coveredBy: covering.mnemonic,
+        extension: covering.extension,
+        orderingOnly: isOrderingRefinement(covering, inst),
+      });
+      continue;
+    }
+
+    /*
+     * Before calling it missing, check whether we carry the encoding at all,
+     * just filed elsewhere. AMOCAS.B is the case that forced this: unified-db
+     * attributes it to Zabha (byte and halfword AMOs), this catalogue to Zacas
+     * (compare-and-swap), and both readings are defensible.
+     *
+     * That is an attribution difference, not a gap, and it has to be reported
+     * separately or 600-odd of them bury the handful of instructions genuinely
+     * absent. The encoding check still applies, so this cannot quietly match
+     * Zalasr's LB.AQ against the base ISA's LB: their bits differ.
+     */
+    const elsewhere = local.find((c) => patternCovers(c, inst));
+    if (elsewhere) {
+      attributedDifferently.push({
+        mnemonic,
+        upstreamOwners: inst.definedBy || [],
+        localExtension: elsewhere.extension,
+        localMnemonic: elsewhere.mnemonic,
+      });
+      continue;
+    }
+
+    missingInstructions.push({ mnemonic, definedBy: inst.definedBy || [] });
+  }
+
+  const upstreamNames = new Set((upstream.instructions || []).map((i) => i.mnemonic.toUpperCase()));
+  const surplusInstructions = local
+    .filter((r) => !upstreamNames.has(r.mnemonic))
+    .map((r) => ({ mnemonic: r.mnemonic, extension: r.extension }));
+
+  const malformed = local
+    .filter((r) => !encodingIsWellFormed(r))
+    .map((r) => ({ mnemonic: r.mnemonic, extension: r.extension }));
+
+  return {
+    missingExtensions,
+    missingInstructions: missingInstructions.sort((a, b) => a.mnemonic.localeCompare(b.mnemonic)),
+    attributedDifferently: attributedDifferently.sort((a, b) =>
+      a.mnemonic.localeCompare(b.mnemonic),
+    ),
+    coveredByBroaderRow,
+    encodingMismatches,
+    surplusInstructions,
+    malformed,
+    complete: missingExtensions.length === 0 && missingInstructions.length === 0,
+  };
+}

--- a/src/isa-dependency-graph.json
+++ b/src/isa-dependency-graph.json
@@ -242,6 +242,20 @@
       "requires": [],
       "verified": "udb"
     },
+    "Shlcofideleg": {
+      "requires": [
+        {
+          "ext": "H",
+          "src": "udb",
+          "ref": "Shlcofideleg.yaml requirements.extension"
+        },
+        {
+          "ext": "Sscofpmf",
+          "src": "udb",
+          "ref": "Shlcofideleg.yaml requirements.extension"
+        }
+      ]
+    },
     "Shtvala": {
       "requires": [
         {

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -29302,6 +29302,22 @@
       "version": "1.0.0"
     },
     {
+      "id": "Shlcofideleg",
+      "name": "Shlcofideleg",
+      "short": "Counter Overflow Delegation",
+      "tags": [],
+      "desc": "Makes hideleg bit 13 writable, so a hypervisor can delegate local counter overflow interrupts to VS-mode.",
+      "use": "Delegating counter overflow to a guest",
+      "url": "https://github.com/riscv/riscv-isa-manual",
+      "instructions": {},
+      "long_name": "Hypervisor local counter overflow interrupt delegation",
+      "type": "privileged",
+      "state": "ratified",
+      "ratification_date": "2024-10",
+      "behavior": "When implemented, bit 13 of `hideleg` is writable, which lets Local Counter Overflow Interrupts (LCOFIs) be delegated to VS-mode.\n\n[NOTE]\nRequires H and Sscofpmf: the interrupt it delegates is the one Sscofpmf defines, and the register it makes writable belongs to H.",
+      "version": "1.0.0"
+    },
+    {
       "id": "Ssqosid",
       "name": "Ssqosid",
       "short": "QoS Identifiers",

--- a/tests/completeness.test.mjs
+++ b/tests/completeness.test.mjs
@@ -358,3 +358,66 @@ test('extensionAliases map an upstream id onto the local ones', () => {
     'without the alias it is merely attributed elsewhere, never missing',
   );
 });
+
+// ── ratification state ─────────────────────────────────────────────────────
+
+test('unratified upstream work is not a completeness gap', () => {
+  // The correction that mattered most. Zilx is state `development` in
+  // unified-db, and the first version of this gate reported it plus nineteen
+  // instructions as missing. Nobody is waiting on a draft.
+  const upstream = {
+    extensions: ['Shlcofideleg', 'Zilx'],
+    instructions: [
+      { mnemonic: 'LXD', match: 0x1000000bn, mask: 0xffffffffn, definedBy: ['Zilx'] },
+      { mnemonic: 'NOTREAL', match: 0x2000000bn, mask: 0xffffffffn, definedBy: ['Shlcofideleg'] },
+    ],
+  };
+
+  const ratifiedOnly = compareAgainstUpstream(catalogue, upstream, {
+    onlyRatified: true,
+    ratifiedExtensions: ['Shlcofideleg'],
+  });
+  assert.deepEqual(ratifiedOnly.missingExtensions, ['Shlcofideleg'], 'only the ratified one');
+  assert.deepEqual(
+    ratifiedOnly.missingInstructions.map((m) => m.mnemonic),
+    ['NOTREAL'],
+    'LXD belongs to a development extension and is not a gap',
+  );
+
+  const everything = compareAgainstUpstream(catalogue, upstream, {
+    onlyRatified: false,
+    ratifiedExtensions: ['Shlcofideleg'],
+  });
+  assert.deepEqual(everything.missingExtensions, ['Shlcofideleg', 'Zilx']);
+  assert.equal(everything.missingInstructions.length, 2, 'the wider view still shows both');
+});
+
+test('an instruction counts as ratified if ANY of its owners is', () => {
+  // unified-db attributes some instructions to several extensions. If one of
+  // them is ratified the instruction is reachable from ratified material, so
+  // its absence is a real gap.
+  const upstream = {
+    extensions: [],
+    instructions: [
+      { mnemonic: 'SHARED', match: 0x3000000bn, mask: 0xffffffffn, definedBy: ['Draft', 'Zbb'] },
+    ],
+  };
+  const result = compareAgainstUpstream(catalogue, upstream, {
+    onlyRatified: true,
+    ratifiedExtensions: ['Zbb'],
+  });
+  assert.equal(result.missingInstructions.length, 1);
+});
+
+test('ratification filtering is case-insensitive and defaults to off', () => {
+  const upstream = { extensions: ['Zvfofp4min'], instructions: [] };
+
+  const lower = compareAgainstUpstream(catalogue, upstream, {
+    onlyRatified: true,
+    ratifiedExtensions: ['zvfofp4min'],
+  });
+  assert.deepEqual(lower.missingExtensions, ['Zvfofp4min'], 'case should not matter');
+
+  const off = compareAgainstUpstream(catalogue, upstream);
+  assert.deepEqual(off.missingExtensions, ['Zvfofp4min'], 'unfiltered by default');
+});

--- a/tests/completeness.test.mjs
+++ b/tests/completeness.test.mjs
@@ -365,30 +365,46 @@ test('unratified upstream work is not a completeness gap', () => {
   // The correction that mattered most. Zilx is state `development` in
   // unified-db, and the first version of this gate reported it plus nineteen
   // instructions as missing. Nobody is waiting on a draft.
+  /*
+   * Synthetic names on purpose. An earlier version used Shlcofideleg and Zilx,
+   * the real gaps at the time, and adding Shlcofideleg to the catalogue broke
+   * this test. A fixture that stops being a gap the moment someone fixes the
+   * gap is testing the data, not the logic.
+   */
   const upstream = {
-    extensions: ['Shlcofideleg', 'Zilx'],
+    extensions: ['Zratifiedmissing', 'Zdevelopmentmissing'],
     instructions: [
-      { mnemonic: 'LXD', match: 0x1000000bn, mask: 0xffffffffn, definedBy: ['Zilx'] },
-      { mnemonic: 'NOTREAL', match: 0x2000000bn, mask: 0xffffffffn, definedBy: ['Shlcofideleg'] },
+      {
+        mnemonic: 'DRAFTONLY',
+        match: 0x1000000bn,
+        mask: 0xffffffffn,
+        definedBy: ['Zdevelopmentmissing'],
+      },
+      {
+        mnemonic: 'RATIFIEDONLY',
+        match: 0x2000000bn,
+        mask: 0xffffffffn,
+        definedBy: ['Zratifiedmissing'],
+      },
     ],
   };
 
   const ratifiedOnly = compareAgainstUpstream(catalogue, upstream, {
     onlyRatified: true,
-    ratifiedExtensions: ['Shlcofideleg'],
+    ratifiedExtensions: ['Zratifiedmissing'],
   });
-  assert.deepEqual(ratifiedOnly.missingExtensions, ['Shlcofideleg'], 'only the ratified one');
+  assert.deepEqual(ratifiedOnly.missingExtensions, ['Zratifiedmissing'], 'only the ratified one');
   assert.deepEqual(
     ratifiedOnly.missingInstructions.map((m) => m.mnemonic),
-    ['NOTREAL'],
-    'LXD belongs to a development extension and is not a gap',
+    ['RATIFIEDONLY'],
+    'an instruction owned only by a development extension is not a gap',
   );
 
   const everything = compareAgainstUpstream(catalogue, upstream, {
     onlyRatified: false,
-    ratifiedExtensions: ['Shlcofideleg'],
+    ratifiedExtensions: ['Zratifiedmissing'],
   });
-  assert.deepEqual(everything.missingExtensions, ['Shlcofideleg', 'Zilx']);
+  assert.deepEqual(everything.missingExtensions, ['Zdevelopmentmissing', 'Zratifiedmissing']);
   assert.equal(everything.missingInstructions.length, 2, 'the wider view still shows both');
 });
 
@@ -410,14 +426,15 @@ test('an instruction counts as ratified if ANY of its owners is', () => {
 });
 
 test('ratification filtering is case-insensitive and defaults to off', () => {
-  const upstream = { extensions: ['Zvfofp4min'], instructions: [] };
+  // Synthetic, for the same reason as above.
+  const upstream = { extensions: ['Zsynthetic'], instructions: [] };
 
   const lower = compareAgainstUpstream(catalogue, upstream, {
     onlyRatified: true,
-    ratifiedExtensions: ['zvfofp4min'],
+    ratifiedExtensions: ['zsynthetic'],
   });
-  assert.deepEqual(lower.missingExtensions, ['Zvfofp4min'], 'case should not matter');
+  assert.deepEqual(lower.missingExtensions, ['Zsynthetic'], 'case should not matter');
 
   const off = compareAgainstUpstream(catalogue, upstream);
-  assert.deepEqual(off.missingExtensions, ['Zvfofp4min'], 'unfiltered by default');
+  assert.deepEqual(off.missingExtensions, ['Zsynthetic'], 'unfiltered by default');
 });

--- a/tests/completeness.test.mjs
+++ b/tests/completeness.test.mjs
@@ -1,0 +1,360 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  AQ_BIT,
+  RL_BIT,
+  ORDERING_BITS,
+  patternCovers,
+  encodingIsWellFormed,
+  extraFixedBits,
+  isOrderingRefinement,
+  flattenCatalogue,
+  compareAgainstUpstream,
+} from '../src/completeness.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const catalogue = JSON.parse(
+  fs.readFileSync(path.join(here, '..', 'src', 'riscv_extensions.json'), 'utf8'),
+);
+
+/*
+ * The real encodings these tests lean on, taken from the catalogue rather than
+ * retyped, so a data change cannot leave the tests asserting against fiction.
+ */
+const rowFor = (id, mnemonic) =>
+  flattenCatalogue(catalogue).find(
+    (r) => r.extension === id && r.mnemonic === mnemonic.toUpperCase(),
+  );
+
+// ── the bit arithmetic ─────────────────────────────────────────────────────
+
+test('aq and rl are bits 26 and 25', () => {
+  assert.equal(AQ_BIT, 1n << 26n);
+  assert.equal(RL_BIT, 1n << 25n);
+  assert.equal(ORDERING_BITS, (1n << 26n) | (1n << 25n));
+});
+
+test('a row covers an upstream encoding that pins more bits to the same values', () => {
+  const local = { match: 0x202fn, mask: 0xf800707fn }; // AMOADD.W, aq/rl free
+  const upstreamAq = { match: 0x202fn | AQ_BIT, mask: 0xf800707fn | AQ_BIT };
+  assert.equal(patternCovers(local, upstreamAq), true);
+});
+
+test('a row does NOT cover an encoding that disagrees on a bit it fixes', () => {
+  const local = { match: 0x202fn, mask: 0xf800707fn };
+  const different = { match: 0x302fn, mask: 0xf800707fn }; // different funct
+  assert.equal(patternCovers(local, different), false);
+});
+
+test('a row that fixes MORE than upstream does not cover it', () => {
+  // This is the regression case: our mask quietly narrows, so we would stop
+  // matching encodings we used to match. Name comparison cannot see this.
+  const narrowed = { match: 0x202fn | AQ_BIT, mask: 0xf800707fn | AQ_BIT };
+  const upstream = { match: 0x202fn, mask: 0xf800707fn };
+  assert.equal(patternCovers(narrowed, upstream), false);
+});
+
+test('coverage is reflexive', () => {
+  const row = { match: 0x202fn, mask: 0xf800707fn };
+  assert.equal(patternCovers(row, row), true);
+});
+
+test('match bits outside the mask are malformed', () => {
+  assert.equal(encodingIsWellFormed({ match: 0x202fn, mask: 0xf800707fn }), true);
+  // a bit set in match that the mask never tests: dead, and always a mistake
+  assert.equal(encodingIsWellFormed({ match: 0x1000000n, mask: 0x707fn }), false);
+});
+
+test('extra fixed bits are reported, and ordering-only is distinguished', () => {
+  const local = { match: 0x202fn, mask: 0xf800707fn };
+  const aq = { match: 0x202fn | AQ_BIT, mask: 0xf800707fn | AQ_BIT };
+  assert.equal(extraFixedBits(local, aq), AQ_BIT);
+  assert.equal(isOrderingRefinement(local, aq), true);
+
+  /*
+   * Bit 20, chosen because 0xf800707f leaves it free. An earlier version of
+   * this used bit 31, which that mask ALREADY fixes, so extraFixedBits was zero
+   * and the assertion held whatever isOrderingRefinement did. Mutation testing
+   * found it: breaking the function changed nothing here.
+   */
+  const otherBit = { match: 0x202fn, mask: 0xf800707fn | (1n << 20n) };
+  assert.equal(extraFixedBits(local, otherBit), 1n << 20n, 'bit 20 must be free in the local mask');
+  assert.equal(isOrderingRefinement(local, otherBit), false, 'bit 20 is not an ordering bit');
+
+  // And a mixture is not ordering-only either.
+  const mixed = { match: 0x202fn, mask: 0xf800707fn | AQ_BIT | (1n << 20n) };
+  assert.equal(isOrderingRefinement(local, mixed), false, 'aq plus a non-ordering bit');
+});
+
+// ── the Zalasr trap ────────────────────────────────────────────────────────
+
+test('Zalasr really does fix an ordering bit in the mnemonic', () => {
+  // The premise the whole design rests on. If this ever stops being true the
+  // reasoning in completeness.js needs revisiting, so it is asserted, not
+  // assumed.
+  const lbaq = rowFor('Zalasr', 'LB.AQ');
+  const sbrl = rowFor('Zalasr', 'SB.RL');
+  assert.ok(lbaq, 'Zalasr LB.AQ must exist');
+  assert.ok(sbrl, 'Zalasr SB.RL must exist');
+  assert.equal((lbaq.mask & AQ_BIT) !== 0n, true, 'LB.AQ pins aq');
+  assert.equal((lbaq.mask & RL_BIT) !== 0n, false, 'LB.AQ leaves rl free');
+  assert.equal((sbrl.mask & RL_BIT) !== 0n, true, 'SB.RL pins rl');
+  assert.equal((sbrl.mask & AQ_BIT) !== 0n, false, 'SB.RL leaves aq free');
+});
+
+test('Zalasr LB.AQ is not covered by the base ISA LB', () => {
+  // The exact failure a suffix-stripping gate would produce: LB.AQ normalises
+  // to LB, matches a different instruction, and a real gap is hidden.
+  const zalasr = rowFor('Zalasr', 'LB.AQ');
+  const baseLb = flattenCatalogue(catalogue).find(
+    (r) => r.mnemonic === 'LB' && r.extension !== 'Zalasr',
+  );
+  assert.ok(baseLb, 'the base ISA LB must exist for this test to mean anything');
+  assert.equal(
+    patternCovers(baseLb, zalasr),
+    false,
+    'base LB must not be treated as covering Zalasr LB.AQ',
+  );
+});
+
+test('an upstream LB.AQ is matched to Zalasr, not to the base ISA', () => {
+  const zalasr = rowFor('Zalasr', 'LB.AQ');
+  const result = compareAgainstUpstream(catalogue, {
+    extensions: [],
+    instructions: [
+      {
+        mnemonic: 'LB.AQ',
+        match: zalasr.match,
+        mask: zalasr.mask,
+        definedBy: ['Zalasr'],
+      },
+    ],
+  });
+  assert.deepEqual(result.missingInstructions, [], 'Zalasr LB.AQ is present and should match');
+});
+
+test('ownership decides the bucket: right encoding, wrong extension is an attribution', () => {
+  // Ownership is still checked first, but failing it no longer means "missing".
+  // Carrying the encoding somewhere is a different fact from not carrying it at
+  // all, and conflating the two is what made 664 rows out of roughly 30 real
+  // gaps when this was first run against unified-db.
+  const zalasr = rowFor('Zalasr', 'LB.AQ');
+  const result = compareAgainstUpstream(catalogue, {
+    extensions: [],
+    instructions: [
+      {
+        mnemonic: 'LB.AQ',
+        match: zalasr.match,
+        mask: zalasr.mask,
+        definedBy: ['Zicsr'], // an extension that does not define it
+      },
+    ],
+  });
+  assert.equal(result.missingInstructions.length, 0);
+  assert.equal(result.attributedDifferently.length, 1);
+  assert.equal(result.attributedDifferently[0].localExtension, 'Zalasr');
+});
+
+// ── the ordering variants, against real data ───────────────────────────────
+
+test('all four orderings of a real AMO are covered by the one catalogue row', () => {
+  const amo = rowFor('Zaamo', 'AMOADD.W') || rowFor('A', 'AMOADD.W');
+  assert.ok(amo, 'AMOADD.W must exist somewhere in the catalogue');
+
+  const variants = [
+    { suffix: '', extra: 0n },
+    { suffix: '.AQ', extra: AQ_BIT },
+    { suffix: '.RL', extra: RL_BIT },
+    { suffix: '.AQRL', extra: ORDERING_BITS },
+  ].map(({ suffix, extra }) => ({
+    mnemonic: `AMOADD.W${suffix}`,
+    match: amo.match | extra,
+    mask: amo.mask | extra,
+    definedBy: [amo.extension],
+  }));
+
+  const result = compareAgainstUpstream(catalogue, { extensions: [], instructions: variants });
+  assert.deepEqual(result.missingInstructions, [], 'no ordering variant should read as missing');
+  assert.equal(
+    result.coveredByBroaderRow.filter((c) => c.orderingOnly).length,
+    3,
+    'the three suffixed forms are covered by the base row, on ordering bits alone',
+  );
+});
+
+test('a variant whose base is absent is still reported missing', () => {
+  // The gate must not be fooled by the shape of a name. FOO.W.AQ has no base
+  // row anywhere, so it is a genuine gap and has to surface as one.
+  const result = compareAgainstUpstream(catalogue, {
+    extensions: [],
+    instructions: [
+      { mnemonic: 'FOO.W.AQ', match: 0x1234567n, mask: 0xfffffffn, definedBy: ['Zaamo'] },
+    ],
+  });
+  assert.equal(result.missingInstructions.length, 1);
+  assert.equal(result.missingInstructions[0].mnemonic, 'FOO.W.AQ');
+});
+
+// ── extensions ─────────────────────────────────────────────────────────────
+
+test('an upstream extension we lack is reported, case-insensitively', () => {
+  const result = compareAgainstUpstream(catalogue, {
+    extensions: ['Zvfofp4min', 'zba', 'ZBB'],
+    instructions: [],
+  });
+  assert.deepEqual(result.missingExtensions, ['Zvfofp4min']);
+});
+
+test('an allowlisted extension is not reported', () => {
+  const result = compareAgainstUpstream(
+    catalogue,
+    { extensions: ['I'], instructions: [] },
+    { allowMissingExtensions: ['I'] },
+  );
+  assert.deepEqual(result.missingExtensions, []);
+});
+
+// ── narrowing, surplus, malformed ──────────────────────────────────────────
+
+test('a name that exists but whose bits disagree is a mismatch, not a gap', () => {
+  const amo = rowFor('Zaamo', 'AMOADD.W') || rowFor('A', 'AMOADD.W');
+  const result = compareAgainstUpstream(catalogue, {
+    extensions: [],
+    instructions: [
+      {
+        mnemonic: 'AMOADD.W',
+        // upstream leaves a bit free that we pin: we are narrower than upstream
+        match: amo.match,
+        mask: amo.mask & ~0x7fn,
+        definedBy: [amo.extension],
+      },
+    ],
+  });
+  assert.equal(result.missingInstructions.length, 0);
+  assert.equal(result.encodingMismatches.length, 1);
+  assert.equal(result.encodingMismatches[0].mnemonic, 'AMOADD.W');
+  assert.equal(result.encodingMismatches[0].narrower, true, 'we pin bits upstream leaves free');
+  assert.match(result.encodingMismatches[0].local, /match 0x/, 'both halves are reported');
+  assert.match(result.encodingMismatches[0].upstream, /mask 0x/);
+});
+
+test('instructions we carry that upstream does not are reported as surplus', () => {
+  const result = compareAgainstUpstream(catalogue, { extensions: [], instructions: [] });
+  assert.ok(result.surplusInstructions.length > 0, 'with an empty upstream, everything is surplus');
+  assert.ok(
+    result.surplusInstructions.every((s) => s.mnemonic && s.extension),
+    'each surplus row names its instruction and its extension',
+  );
+});
+
+test('the real catalogue contains no malformed encodings', () => {
+  // match must never set a bit its own mask leaves untested.
+  const result = compareAgainstUpstream(catalogue, { extensions: [], instructions: [] });
+  assert.deepEqual(
+    result.malformed,
+    [],
+    `malformed encodings: ${JSON.stringify(result.malformed)}`,
+  );
+});
+
+test('complete is true only when nothing is missing', () => {
+  const empty = compareAgainstUpstream(catalogue, { extensions: [], instructions: [] });
+  assert.equal(empty.complete, true);
+
+  const gap = compareAgainstUpstream(catalogue, {
+    extensions: ['DefinitelyNotHere'],
+    instructions: [],
+  });
+  assert.equal(gap.complete, false);
+});
+
+test('flattenCatalogue skips entries with no encoding rather than throwing', () => {
+  const rows = flattenCatalogue({
+    g: [
+      { id: 'X', instructions: { GOOD: { match: '0x1', mask: '0x1' }, BAD: {} } },
+      { id: 'Y' },
+      null,
+    ],
+  });
+  assert.deepEqual(
+    rows.map((r) => r.mnemonic),
+    ['GOOD'],
+  );
+});
+
+// ── attribution versus absence ─────────────────────────────────────────────
+
+test('an instruction we file under a different extension is not "missing"', () => {
+  // unified-db attributes AMOCAS.B to Zabha; this catalogue files it under
+  // Zacas. Both readings are defensible, so it is an attribution difference
+  // and must not be reported as a gap.
+  const amocas = rowFor('Zacas', 'AMOCAS.B');
+  assert.ok(amocas, 'AMOCAS.B is expected under Zacas');
+
+  const result = compareAgainstUpstream(catalogue, {
+    extensions: [],
+    instructions: [
+      { mnemonic: 'AMOCAS.B', match: amocas.match, mask: amocas.mask, definedBy: ['Zabha'] },
+    ],
+  });
+
+  assert.deepEqual(result.missingInstructions, []);
+  assert.equal(result.attributedDifferently.length, 1);
+  assert.equal(result.attributedDifferently[0].localExtension, 'Zacas');
+  assert.deepEqual(result.attributedDifferently[0].upstreamOwners, ['Zabha']);
+});
+
+test('attribution fallback still cannot match Zalasr LB.AQ to the base LB', () => {
+  // The fallback searches every extension, so this is where a bits-blind
+  // implementation would finally leak. It must not: the encodings differ.
+  const zalasr = rowFor('Zalasr', 'LB.AQ');
+  const result = compareAgainstUpstream(catalogue, {
+    extensions: [],
+    instructions: [
+      { mnemonic: 'LB.AQ', match: zalasr.match, mask: zalasr.mask, definedBy: ['Zicsr'] },
+    ],
+  });
+  // Found, but only because Zalasr genuinely carries this exact encoding.
+  assert.equal(result.missingInstructions.length, 0);
+  assert.equal(result.attributedDifferently[0].localExtension, 'Zalasr');
+});
+
+test('an encoding nobody carries is missing, wherever it claims to live', () => {
+  const result = compareAgainstUpstream(catalogue, {
+    extensions: [],
+    instructions: [
+      // opcode 0x0b is custom-0: nothing in the catalogue can cover it. An
+      // earlier version used 0x73, the SYSTEM opcode, and matched a real row.
+      { mnemonic: 'NOPE.W', match: 0x7f00000bn, mask: 0xffffffffn, definedBy: ['Zbb'] },
+    ],
+  });
+  assert.equal(result.missingInstructions.length, 1);
+  assert.equal(result.attributedDifferently.length, 0);
+});
+
+test('extensionAliases map an upstream id onto the local ones', () => {
+  const add = flattenCatalogue(catalogue).find((r) => r.mnemonic === 'ADD');
+  assert.ok(add, 'ADD must exist');
+
+  const upstream = {
+    extensions: [],
+    instructions: [{ mnemonic: 'ADD', match: add.match, mask: add.mask, definedBy: ['I'] }],
+  };
+
+  const without = compareAgainstUpstream(catalogue, upstream);
+  const withAlias = compareAgainstUpstream(catalogue, upstream, {
+    extensionAliases: { I: ['RV32I', 'RV64I'] },
+  });
+
+  assert.equal(withAlias.missingInstructions.length, 0);
+  assert.equal(withAlias.attributedDifferently.length, 0, 'the alias makes it a direct match');
+  assert.equal(
+    without.attributedDifferently.length,
+    1,
+    'without the alias it is merely attributed elsewhere, never missing',
+  );
+});

--- a/tests/fixtures/udb/spec/std/isa/ext/Zdraft.yaml
+++ b/tests/fixtures/udb/spec/std/isa/ext/Zdraft.yaml
@@ -1,0 +1,9 @@
+# Fixture: in development, so nothing here is a completeness gap.
+$schema: "ext_schema.json#"
+kind: extension
+name: Zdraft
+type: unprivileged
+versions:
+  - version: "0.1.0"
+    state: development
+    ratification_date: null

--- a/tests/fixtures/udb/spec/std/isa/ext/Zfix.yaml
+++ b/tests/fixtures/udb/spec/std/isa/ext/Zfix.yaml
@@ -1,0 +1,9 @@
+# Fixture: a ratified extension. Shape copied from a real unified-db file.
+$schema: "ext_schema.json#"
+kind: extension
+name: Zfix
+type: unprivileged
+versions:
+  - version: "1.0.0"
+    state: ratified
+    ratification_date: 2024-10

--- a/tests/fixtures/udb/spec/std/isa/ext/Zlateratified.yaml
+++ b/tests/fixtures/udb/spec/std/isa/ext/Zlateratified.yaml
@@ -1,0 +1,15 @@
+# Fixture: development FIRST, ratified later.
+#
+# The ordering matters. Zwasfrozen lists ratified first, so an implementation
+# that reads only the first state still gets it right, and mutation testing
+# showed that bug surviving. This file is the one that catches it.
+$schema: "ext_schema.json#"
+kind: extension
+name: Zlateratified
+type: unprivileged
+versions:
+  - version: "0.5.0"
+    state: development
+  - version: "1.0.0"
+    state: ratified
+    ratification_date: 2025-02

--- a/tests/fixtures/udb/spec/std/isa/ext/Zwasfrozen.yaml
+++ b/tests/fixtures/udb/spec/std/isa/ext/Zwasfrozen.yaml
@@ -1,0 +1,11 @@
+# Fixture: ratified once, a later version frozen. "Ever ratified" must count it.
+$schema: "ext_schema.json#"
+kind: extension
+name: Zwasfrozen
+type: unprivileged
+versions:
+  - version: "1.0.0"
+    state: ratified
+    ratification_date: 2023-04
+  - version: "2.0.0"
+    state: frozen

--- a/tests/fixtures/udb/spec/std/isa/inst/Zdraft/draftonly.yaml
+++ b/tests/fixtures/udb/spec/std/isa/inst/Zdraft/draftonly.yaml
@@ -1,0 +1,9 @@
+# Fixture: owned solely by an unratified extension.
+$schema: "inst_schema.json#"
+kind: instruction
+name: draftonly
+definedBy:
+  extension:
+    name: Zdraft
+encoding:
+  match: 0000001----------001-----0001011

--- a/tests/fixtures/udb/spec/std/isa/inst/Zfix/noencoding.yaml
+++ b/tests/fixtures/udb/spec/std/isa/inst/Zfix/noencoding.yaml
@@ -1,0 +1,7 @@
+# Fixture: a pseudo-instruction with no match line. Must be skipped, not crash.
+$schema: "inst_schema.json#"
+kind: instruction
+name: noencoding
+definedBy:
+  extension:
+    name: Zfix

--- a/tests/fixtures/udb/spec/std/isa/inst/Zfix/shared.yaml
+++ b/tests/fixtures/udb/spec/std/isa/inst/Zfix/shared.yaml
@@ -1,0 +1,13 @@
+# Fixture: the anyOf shape, two owning extensions.
+$schema: "inst_schema.json#"
+kind: instruction
+name: shared
+long_name: Owned by two extensions
+definedBy:
+  extension:
+    anyOf:
+      - name: Zfix
+      - name: Zwasfrozen
+assembly: xd, xs1, xs2
+encoding:
+  match: 0100000----------111-----0001011

--- a/tests/fixtures/udb/spec/std/isa/inst/Zfix/simple.yaml
+++ b/tests/fixtures/udb/spec/std/isa/inst/Zfix/simple.yaml
@@ -1,0 +1,14 @@
+# Fixture: the single-owner shape, definedBy.extension.name
+$schema: "inst_schema.json#"
+kind: instruction
+name: simple
+long_name: A simple fixture instruction
+definedBy:
+  extension:
+    name: Zfix
+assembly: xd, xs1
+encoding:
+  match: 0000000----------000-----0001011
+  variables:
+    - name: xs1
+      location: 19-15

--- a/tests/fixtures/udb/spec/std/isa/inst/Zfix/unowned.yaml
+++ b/tests/fixtures/udb/spec/std/isa/inst/Zfix/unowned.yaml
@@ -1,0 +1,6 @@
+# Fixture: no definedBy at all. Ownership falls back to the directory name.
+$schema: "inst_schema.json#"
+kind: instruction
+name: unowned
+encoding:
+  match: 0000010----------010-----0001011

--- a/tests/udb-parser.test.mjs
+++ b/tests/udb-parser.test.mjs
@@ -1,0 +1,125 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { parseUpstream, EXTENSION_ALIASES } from '../scripts/check-udb-completeness.mjs';
+
+/*
+ * The parser, against committed fixtures.
+ *
+ * Every defect this file has had lived in the parsing, and real data found all
+ * of them because there was nothing importable to test:
+ *
+ *   - a definedBy regex terminating on /$/m, which in multiline mode is the end
+ *     of the FIRST line, so it captured nothing and every instruction came back
+ *     unowned;
+ *   - `owners || [dir]`, which never fell back because an empty array is truthy;
+ *   - no `state` read at all, so draft extensions were reported as ratified gaps.
+ *
+ * The fixtures below carry one case per shape, so a regression fails here
+ * rather than in a weekly cron nobody is watching.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const specDir = path.join(here, 'fixtures', 'udb', 'spec', 'std', 'isa');
+const upstream = parseUpstream(specDir);
+const inst = (name) => upstream.instructions.find((i) => i.mnemonic === name);
+
+test('extensions are read, and their ids come from the filename', () => {
+  assert.deepEqual(upstream.extensions.sort(), ['Zdraft', 'Zfix', 'Zlateratified', 'Zwasfrozen']);
+});
+
+test('only ever-ratified extensions are marked ratified', () => {
+  assert.deepEqual(upstream.ratifiedExtensions.sort(), ['Zfix', 'Zlateratified', 'Zwasfrozen']);
+  assert.equal(
+    upstream.ratifiedExtensions.includes('Zdraft'),
+    false,
+    'a development extension is not ratified',
+  );
+});
+
+test('"ever ratified" counts an extension whose later version is frozen', () => {
+  // Zwasfrozen is ratified at 1.0.0 and frozen at 2.0.0. Reading only the LAST
+  // state would drop it.
+  assert.ok(upstream.ratifiedExtensions.includes('Zwasfrozen'));
+});
+
+test('"ever ratified" counts an extension ratified after a draft version', () => {
+  /*
+   * Zlateratified is development at 0.5.0 and ratified at 1.0.0, so the
+   * ratified state is not the first one in the file. Mutation testing put this
+   * here: substituting "read only the first state" failed nothing, because
+   * every other fixture happened to list ratified first.
+   */
+  assert.ok(upstream.ratifiedExtensions.includes('Zlateratified'));
+});
+
+test('the single-owner definedBy shape is parsed', () => {
+  assert.deepEqual(inst('SIMPLE').definedBy, ['Zfix']);
+});
+
+test('the anyOf definedBy shape yields every owner', () => {
+  assert.deepEqual(inst('SHARED').definedBy, ['Zfix', 'Zwasfrozen']);
+});
+
+test('an instruction with no definedBy falls back to its directory', () => {
+  // The `|| [dir]` bug: an empty array is truthy, so the fallback never fired
+  // and the instruction was left unowned.
+  assert.deepEqual(inst('UNOWNED').definedBy, ['Zfix']);
+});
+
+test('an instruction with no encoding is skipped, not crashed on', () => {
+  assert.equal(inst('NOENCODING'), undefined);
+});
+
+test('the 0/1/- encoding string becomes the right match and mask', () => {
+  // match: 0000000----------000-----0001011
+  const s = inst('SIMPLE');
+  let match = 0n;
+  let mask = 0n;
+  for (const ch of '0000000----------000-----0001011') {
+    match <<= 1n;
+    mask <<= 1n;
+    if (ch === '1') {
+      match |= 1n;
+      mask |= 1n;
+    } else if (ch === '0') {
+      mask |= 1n;
+    }
+  }
+  assert.equal(s.match, match);
+  assert.equal(s.mask, mask);
+  assert.equal(s.mask & 0x7fn, 0x7fn, 'the opcode field is fully fixed');
+  assert.equal(s.match & 0x7fn, 0x0bn, 'opcode 0x0b, custom-0');
+});
+
+test('a dash in the encoding leaves that bit free in the mask', () => {
+  const s = inst('SIMPLE');
+  // bits 24-15 are dashes in the fixture, so none of them may be set in mask
+  for (let bit = 15n; bit <= 24n; bit += 1n) {
+    assert.equal((s.mask >> bit) & 1n, 0n, `bit ${bit} should be free`);
+  }
+});
+
+test('match never sets a bit its own mask leaves free', () => {
+  for (const i of upstream.instructions) {
+    assert.equal((i.match & ~i.mask) === 0n, true, `${i.mnemonic} has a dead match bit`);
+  }
+});
+
+test('every parsed instruction names at least one owner', () => {
+  for (const i of upstream.instructions) {
+    assert.ok(i.definedBy.length > 0, `${i.mnemonic} has no owner`);
+  }
+});
+
+test('the alias map is exported and covers upstream bare I', () => {
+  // Exported so the workflow and the tests agree on it rather than each
+  // carrying their own copy.
+  assert.deepEqual(EXTENSION_ALIASES.I, ['RV32I', 'RV64I', 'RV32E', 'RV64E']);
+});
+
+test('parseUpstream throws on a directory that is not a checkout', () => {
+  assert.throws(() => parseUpstream(path.join(here, 'fixtures', 'nope')));
+});


### PR DESCRIPTION
Closes #301.

`npm run udb:check` now reports **complete: true**. The catalogue covers everything unified-db has ratified.

### The root cause

`scripts/sync_udb_extensions.cjs:293` iterates our catalogue, so the daily sync enriches entries we already have and can never add one we lack. Nothing watched the other direction.

### Coverage is decided on bits, not names

unified-db enumerates memory-ordering forms separately (`amoadd.w`, `.aq`, `.rl`, `.aqrl`) while we model one row with those bits unconstrained, as riscv-opcodes does.

The tempting shortcut is stripping the suffix before comparing. **It is wrong, and Zalasr proves it:** its loads are `LB.AQ` with the `aq` bit *fixed*, because forms without it are reserved. Stripping turns that into the base ISA's `LB`, a different instruction, and the check would hide a real gap. So an upstream encoding counts as covered when a local row in the same extension constrains a subset of the same bits to the same values.

That also catches something a name comparison cannot: a mask quietly *narrowing*.

### Two corrections that only real data surfaced

**Ratification state.** The first version treated presence in unified-db as ratification and reported `Zilx` plus 19 instructions as gaps. `Zilx` is state `development`. Scope is now ever-ratified by default, where an extension qualifies if **any** version reached ratified even if a later one is frozen. `--all` widens it.

**Attribution.** unified-db files `AMOCAS.B` under `Zabha`; we file it under `Zacas`. Both defensible. Conflating attribution with absence produced 664 rows where ~30 gaps existed, so they are reported separately.

### Shlcofideleg

Ratified 2024-10. Makes `hideleg` bit 13 writable so a hypervisor can delegate Local Counter Overflow Interrupts to VS-mode. Filed under `s_interrupt` beside `Sscofpmf`, the extension it extends.

Prose written here rather than copied: unified-db's `long_name` and `description` have known errors. URL is the ISA manual because `docs.riscv.org/.../shlcofideleg.html` is a 404 today and `links:check` would fail on it — `Shcounterenw` and `Shvstvala` use the same fallback.

`seed-dependency-graph` produced its node with both edges (H, Sscofpmf) cited to unified-db.

### Reports, does not fail

Weekly workflow modelled on `check-opcodes-drift.yml`: one issue, edited in place, **closed automatically** when the gap clears. Adding an extension needs a description, a use case, a doc link and a graph node, none of which unified-db supplies, so this stays a human decision. A gate that goes red the day RISC-V ratifies something is a gate somebody switches off.

Exit codes are a contract with the workflow: `0` complete, `1` gaps, `2` unreadable checkout. The third matters — conflating it with success would let a broken clone report a perfect catalogue.

### Tests: 310, and mutation-checked

24 for the pure logic, 14 for the parser against 9 committed fixtures.

Mutation testing earned its place twice. Reintroducing each historical parser bug fails 3–5 tests. But two mutations initially failed **nothing**:

- widening the ordering-bit check — my assertion had picked bit 31, which the mask under test already fixes, so it held whatever the code did;
- reading only the *first* version state — every fixture happened to list `ratified` first.

`Zlateratified.yaml` (development at 0.5.0, ratified at 1.0.0) exists solely because of the second.

Two fixtures also moved to synthetic names: they used the real gaps, so adding `Shlcofideleg` broke a test that had nothing to do with it.

### Scheduling

Three weekly jobs were converging. `audit-deps` moves 07:00 → 08:00 where it collided with `check-opcodes-drift`; the new report takes 09:00; the daily sync stays at 06:00.

### Not in scope

`params` — 228 in unified-db, zero here, and the catalogue has no such field. Its own change.

`REV8` and `FCVTMOD.W.D` encoding disagreements, both data questions. Recorded in #301.