### PR TITLE
fix: honour unified-db `not:` constraints when reading encodings

### DIFF
--- a/scripts/check-udb-completeness.mjs
+++ b/scripts/check-udb-completeness.mjs
@@ -31,6 +31,88 @@ import { compareAgainstUpstream } from '../src/completeness.js';
  * ratified gaps. Real data found all three; tests found none, because there was
  * nothing importable to test. Now there is.
  */
+/**
+ * Fold unified-db `not:` constraints into a match/mask pair.
+ *
+ * A variable field can be narrowed by excluding values rather than by fixing
+ * bits in the match string:
+ *
+ *   - name: rm
+ *     location: 14-12
+ *     not: [0, 2, 3, 4, 5, 6, 7]
+ *
+ * That leaves exactly one legal value, so `rm` is pinned as surely as if the
+ * match string had spelled it out. Reading only the match string missed this
+ * and reported FCVTMOD.W.D as an encoding upstream leaves free, when upstream
+ * constrains it precisely and this catalogue agrees.
+ *
+ * Only a field left with ONE legal value can be folded in. The other twelve
+ * uses upstream merely narrow a field -- `ld` and `sd` excluding odd registers,
+ * `cm.pop` excluding low counts -- and "any value except these four" cannot be
+ * said with a match and a mask. Those are returned as `narrowed` so a caller
+ * can report the limit rather than pretend it does not exist.
+ */
+export function applyNotConstraints({ match, mask }, variables) {
+  let m = match;
+  let k = mask;
+  const narrowed = [];
+
+  for (const v of variables) {
+    if (!v.not || v.not.length === 0) continue;
+    const width = v.hi - v.lo + 1;
+    const total = 1 << width;
+    const excluded = new Set(v.not);
+    if (excluded.size !== total - 1) {
+      narrowed.push({ field: v.name, remaining: total - excluded.size });
+      continue;
+    }
+    let only = null;
+    for (let candidate = 0; candidate < total; candidate += 1) {
+      if (!excluded.has(candidate)) only = candidate;
+    }
+    if (only === null) continue;
+    const fieldMask = ((1n << BigInt(width)) - 1n) << BigInt(v.lo);
+    k |= fieldMask;
+    m = (m & ~fieldMask) | (BigInt(only) << BigInt(v.lo));
+  }
+
+  return { match: m, mask: k, narrowed };
+}
+
+/** The `variables:` block of an encoding: name, bit range, and any `not:` list. */
+export function parseVariables(text) {
+  /*
+   * Capture everything after `variables:` and let the item pattern below decide
+   * what counts, rather than trying to find where the block ends.
+   *
+   * The tempting lookahead is /(?=^\S|$)/m, and it is wrong for the second time
+   * today: in multiline mode `$` is the end of the FIRST line, so the group
+   * captures nothing. definedBy had the identical bug. An item only matches
+   * when `name:` is followed by `location:`, which no later key in these files
+   * produces, so the loose capture is safe.
+   */
+  const block = text.match(/^\s*variables:\n([\s\S]*)/m);
+  if (!block) return [];
+  const out = [];
+  const re = /-\s*name:\s*(\w+)\s*\n\s*location:\s*(\d+)-(\d+)([\s\S]*?)(?=\n\s*-\s*name:|$)/g;
+  for (const m of block[1].matchAll(re)) {
+    const notList = m[4].match(/not:\s*\[([\s\S]*?)\]/);
+    out.push({
+      name: m[1],
+      hi: Number(m[2]),
+      lo: Number(m[3]),
+      not: notList
+        ? notList[1]
+            .split(',')
+            .map((x) => x.trim())
+            .filter((x) => /^\d+$/.test(x))
+            .map(Number)
+        : [],
+    });
+  }
+  return out;
+}
+
 export function parseUpstream(specDir) {
   const readDefinedBy = (text) => {
     /*
@@ -86,11 +168,15 @@ export function parseUpstream(specDir) {
           mask |= 1n;
         }
       }
+      // Fold in any `not:` that pins a field to a single value.
+      const folded = applyNotConstraints({ match, mask }, parseVariables(text));
+
       const owners = readDefinedBy(text);
       instructions.push({
         mnemonic: (name ? name[1] : file.replace(/\.yaml$/, '')).toUpperCase(),
-        match,
-        mask,
+        match: folded.match,
+        mask: folded.mask,
+        narrowedFields: folded.narrowed,
         // Fall back to the directory only when the file names no owner. An
         // empty array is truthy, so `|| [dir]` silently kept the empty list.
         definedBy: owners.length ? owners : [dir],

--- a/tests/fixtures/udb/spec/std/isa/inst/Zfix/narrowedbynot.yaml
+++ b/tests/fixtures/udb/spec/std/isa/inst/Zfix/narrowedbynot.yaml
@@ -1,0 +1,15 @@
+# Fixture: `not:` merely narrows. Four values remain, which a match/mask pair
+# cannot express, so the bits stay free and the limit is reported instead of
+# being quietly flattened into a false constraint.
+$schema: "inst_schema.json#"
+kind: instruction
+name: narrowedbynot
+definedBy:
+  extension:
+    name: Zfix
+encoding:
+  match: 0000100------------------0001011
+  variables:
+    - name: tt
+      location: 14-12
+      not: [0, 1, 2, 3]

--- a/tests/fixtures/udb/spec/std/isa/inst/Zfix/pinnedbynot.yaml
+++ b/tests/fixtures/udb/spec/std/isa/inst/Zfix/pinnedbynot.yaml
@@ -1,0 +1,17 @@
+# Fixture: `not:` leaves exactly ONE legal value, so the field is pinned as
+# surely as if the match string had spelled it out. This is the fcvtmod.w.d
+# shape, and the case that was misreported as "upstream leaves this free".
+$schema: "inst_schema.json#"
+kind: instruction
+name: pinnedbynot
+definedBy:
+  extension:
+    name: Zfix
+encoding:
+  match: 0000011------------------0001011
+  variables:
+    - name: rs1
+      location: 19-15
+    - name: tt
+      location: 14-12
+      not: [0, 2, 3, 4, 5, 6, 7]

--- a/tests/udb-parser.test.mjs
+++ b/tests/udb-parser.test.mjs
@@ -3,7 +3,12 @@ import assert from 'node:assert/strict';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { parseUpstream, EXTENSION_ALIASES } from '../scripts/check-udb-completeness.mjs';
+import {
+  parseUpstream,
+  parseVariables,
+  applyNotConstraints,
+  EXTENSION_ALIASES,
+} from '../scripts/check-udb-completeness.mjs';
 
 /*
  * The parser, against committed fixtures.
@@ -122,4 +127,69 @@ test('the alias map is exported and covers upstream bare I', () => {
 
 test('parseUpstream throws on a directory that is not a checkout', () => {
   assert.throws(() => parseUpstream(path.join(here, 'fixtures', 'nope')));
+});
+
+// ── `not:` constraints ─────────────────────────────────────────────────────
+
+test('a not: list leaving one legal value pins the field', () => {
+  /*
+   * The bug this fixes. unified-db can constrain a field by exclusion rather
+   * than by fixing bits in the match string: fcvtmod.w.d shows rm as dashes and
+   * carries not: [0,2,3,4,5,6,7], which leaves only 1 (RTZ). Reading the match
+   * string alone reported it as free, and this catalogue -- which pins it
+   * correctly -- was flagged as disagreeing with upstream.
+   */
+  const p = inst('PINNEDBYNOT');
+  assert.ok(p, 'the fixture must parse');
+  const RM = 0x7n << 12n;
+  assert.equal(p.mask & RM, RM, 'bits 14-12 must be fixed');
+  assert.equal((p.match >> 12n) & 0x7n, 1n, 'to the single remaining value, 1');
+});
+
+test('a not: list that merely narrows leaves the bits free, and says so', () => {
+  // "any value except these four" cannot be said with a match and a mask.
+  // Flattening it would invent a constraint upstream did not state.
+  const n = inst('NARROWEDBYNOT');
+  const RM = 0x7n << 12n;
+  assert.equal(n.mask & RM, 0n, 'bits 14-12 stay free');
+  assert.deepEqual(n.narrowedFields, [{ field: 'tt', remaining: 4 }]);
+});
+
+test('an instruction with no not: constraints reports none narrowed', () => {
+  assert.deepEqual(inst('SIMPLE').narrowedFields, []);
+});
+
+test('applyNotConstraints is a pure function over match and mask', () => {
+  const base = { match: 0n, mask: 0n };
+  const pinned = applyNotConstraints(base, [
+    { name: 'f', hi: 14, lo: 12, not: [0, 2, 3, 4, 5, 6, 7] },
+  ]);
+  assert.equal(pinned.mask, 0x7n << 12n);
+  assert.equal(pinned.match, 1n << 12n);
+  assert.deepEqual(pinned.narrowed, []);
+
+  const untouched = applyNotConstraints(base, [{ name: 'f', hi: 14, lo: 12, not: [] }]);
+  assert.equal(untouched.mask, 0n, 'an empty not: changes nothing');
+
+  const narrowed = applyNotConstraints(base, [{ name: 'f', hi: 14, lo: 12, not: [0, 1] }]);
+  assert.equal(narrowed.mask, 0n, 'six values remain, so nothing can be pinned');
+  assert.deepEqual(narrowed.narrowed, [{ field: 'f', remaining: 6 }]);
+});
+
+test('parseVariables reads a multi-line not: list', () => {
+  // cm.jalt's exclusion list wraps across lines upstream.
+  const vars = parseVariables(`
+encoding:
+  match: 0000000----------000-----0001011
+  variables:
+    - name: index
+      location: 19-15
+      not: [ 0, 1, 2, 3,
+             4, 5 ]
+    - name: xd
+      location: 11-7
+`);
+  assert.equal(vars.length, 2);
+  assert.deepEqual(vars[0].not, [0, 1, 2, 3, 4, 5]);
+  assert.deepEqual(vars[1].not, []);
 });


### PR DESCRIPTION
Closes #303.

The completeness check reported `Zfa FCVTMOD.W.D` as an encoding upstream leaves free while we pin it. **Upstream pins it too.** Its description says the `rm` field is *"set to 1 (RTZ). Other `rm` values are reserved"*, and its encoding says so as:

```yaml
- name: rm
  location: 14-12
  not: [0, 2, 3, 4, 5, 6, 7]
```

which leaves exactly one legal value. The parser read only the `match` string, saw dashes, and concluded the field was unconstrained.

**This was one step from being raised upstream as a unified-db defect. It was ours.**

### The fix

Fold a `not:` list into match and mask when it leaves one legal value, because such a field is pinned as surely as if the match string had spelled it out.

Of thirteen upstream files using `not:`, exactly one is that shape. The other twelve merely narrow — `ld`/`sd` excluding odd registers, `cm.pop` excluding low counts — and *"any value except these four"* cannot be said with a match and a mask. Those bits stay free and the limit is reported as `narrowedFields` rather than flattened into a constraint upstream never stated.

### A mistake I made twice

Writing this reproduced an earlier bug in the same file. The first `parseVariables` used a `/(?=^\S|$)/m` lookahead, and in multiline mode `$` is the end of the **first line**, so it captured nothing and returned no variables at all. `definedBy` had the identical bug this morning, with a comment already in the file explaining it.

The block is now captured loosely and the item pattern decides what counts, since only a real entry has `name:` followed by `location:`.

### Tests

Five new tests, two fixtures covering both `not:` shapes, plus a multi-line list of the kind `cm.jalt` carries. 315 passing.

Mutation-checked, including reintroducing the bug that shipped:

| mutation | tests failed |
|---|---|
| ignore `not:` entirely (the shipped bug) | 5 |
| fold the narrowing cases too | 5 |
| restore the `/$/m` regex | 7 |

### Result

`npm run udb:check` still reports **complete: true**. The only remaining entry is `Zbb REV8`, where upstream carries RV32 and RV64 forms and we carry one — a real gap in our data, unrelated to this.