### PR TITLE
fix: read both XLEN encodings in the completeness gate, and add the three instructions it was masking (#305)

### DIFF
--- a/scripts/check-udb-completeness.mjs
+++ b/scripts/check-udb-completeness.mjs
@@ -113,6 +113,94 @@ export function parseVariables(text) {
   return out;
 }
 
+/**
+ * The indented body of a top-level YAML key, by scanning lines.
+ *
+ * Deliberately not a regex. Three separate bugs today came from trying to
+ * express "up to the next line at column zero" as a lookahead: /$/m is the end
+ * of the FIRST line, so the capture came back empty, and /(?=^\S)/m silently
+ * matches nothing when the block runs to the end of the file. Scanning lines
+ * has neither failure mode.
+ */
+function blockUnder(text, key) {
+  const lines = text.split('\n');
+  const start = lines.findIndex((l) => l === `${key}:`);
+  if (start === -1) return null;
+  const body = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.trim() !== '' && !/^\s/.test(line)) break;
+    body.push(line);
+  }
+  return body.join('\n');
+}
+
+/**
+ * The encodings an instruction file declares, one per XLEN where it has two.
+ *
+ * unified-db writes most instructions with a single `encoding.match`, but 19 of
+ * them differ by XLEN and are keyed instead:
+ *
+ *   encoding:
+ *     RV32:
+ *       match: 011010011000-----101-----0010011
+ *     RV64:
+ *       match: 011010111000-----101-----0010011
+ *
+ * Taking the first `match:` in the file silently read one of the two. That
+ * covered exactly the instructions where RV32 and RV64 diverge -- rev8, rori,
+ * ld, sd, the shift-immediates, the Zbs single-bit ops -- so the gate compared
+ * against half the data for the cases most likely to disagree, and reported
+ * rev8 as an encoding this catalogue got wrong when it carries both.
+ */
+export function parseEncodings(text) {
+  const bitsToPair = (bits) => {
+    let match = 0n;
+    let mask = 0n;
+    for (const ch of bits) {
+      match <<= 1n;
+      mask <<= 1n;
+      if (ch === '1') {
+        match |= 1n;
+        mask |= 1n;
+      } else if (ch === '0') {
+        mask |= 1n;
+      }
+    }
+    return { match, mask };
+  };
+
+  const body = blockUnder(text, 'encoding');
+  if (body === null) return [];
+
+  // Scanned, not matched, for the same reason blockUnder exists: a lookahead
+  // for "the next XLEN key or the end" needs an end assertion that /$/m does
+  // not provide, and gets it silently wrong rather than loudly.
+  const lines = body.split('\n');
+  const keyed = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const head = lines[i].match(/^\s{2}(RV32|RV64):\s*$/);
+    if (!head) continue;
+    const collected = [];
+    for (let j = i + 1; j < lines.length; j += 1) {
+      if (/^\s{2}(RV32|RV64):\s*$/.test(lines[j])) break;
+      collected.push(lines[j]);
+    }
+    keyed.push({ xlen: head[1], text: collected.join('\n') });
+  }
+  const blocks = keyed.length ? keyed : [{ xlen: null, text: body }];
+
+  const out = [];
+  for (const block of blocks) {
+    const bits = block.text.match(/^\s*match:\s*([01-]+)\s*$/m);
+    if (!bits) continue;
+    const pair = bitsToPair(bits[1]);
+    const folded = applyNotConstraints(pair, parseVariables(block.text));
+    out.push({ xlen: block.xlen, ...folded });
+  }
+  return out;
+}
+
 export function parseUpstream(specDir) {
   const readDefinedBy = (text) => {
     /*
@@ -127,8 +215,8 @@ export function parseUpstream(specDir) {
      * Capture every indented line under it, up to the next key at column zero,
      * then take each `name:`.
      */
-    const block = text.match(/^definedBy:\n([\s\S]*?)(?=^\S)/m);
-    return block ? [...block[1].matchAll(/name:\s*([A-Za-z0-9_.]+)/g)].map((x) => x[1]) : [];
+    const block = blockUnder(text, 'definedBy');
+    return block ? [...block.matchAll(/name:\s*([A-Za-z0-9_.]+)/g)].map((x) => x[1]) : [];
   };
 
   const extDir = path.join(specDir, 'ext');
@@ -153,34 +241,22 @@ export function parseUpstream(specDir) {
     for (const file of fs.readdirSync(sub).filter((f) => f.endsWith('.yaml'))) {
       const text = fs.readFileSync(path.join(sub, file), 'utf8');
       const name = text.match(/^name:\s*(.+?)\s*$/m);
-      // unified-db gives an encoding string of 0/1/- rather than match/mask.
-      const enc = text.match(/^\s*match:\s*([01-]+)\s*$/m);
-      if (!enc) continue;
-      let match = 0n;
-      let mask = 0n;
-      for (const ch of enc[1]) {
-        match <<= 1n;
-        mask <<= 1n;
-        if (ch === '1') {
-          match |= 1n;
-          mask |= 1n;
-        } else if (ch === '0') {
-          mask |= 1n;
-        }
-      }
-      // Fold in any `not:` that pins a field to a single value.
-      const folded = applyNotConstraints({ match, mask }, parseVariables(text));
-
+      const mnemonic = (name ? name[1] : file.replace(/\.yaml$/, '')).toUpperCase();
       const owners = readDefinedBy(text);
-      instructions.push({
-        mnemonic: (name ? name[1] : file.replace(/\.yaml$/, '')).toUpperCase(),
-        match: folded.match,
-        mask: folded.mask,
-        narrowedFields: folded.narrowed,
-        // Fall back to the directory only when the file names no owner. An
-        // empty array is truthy, so `|| [dir]` silently kept the empty list.
-        definedBy: owners.length ? owners : [dir],
-      });
+
+      // One entry per declared encoding: two where the file is XLEN-keyed.
+      for (const enc of parseEncodings(text)) {
+        instructions.push({
+          mnemonic,
+          xlen: enc.xlen,
+          match: enc.match,
+          mask: enc.mask,
+          narrowedFields: enc.narrowed,
+          // Fall back to the directory only when the file names no owner. An
+          // empty array is truthy, so `|| [dir]` silently kept the empty list.
+          definedBy: owners.length ? owners : [dir],
+        });
+      }
     }
   }
 

--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -1,6 +1,6 @@
 /**
  * Populates `instructions` in src/riscv_extensions.json using src/instr_dict.json.
- * 
+ *
  * Routing hierarchy:
  * 1. UMBRELLA  - Resolves topologically via the `members` array.
  * 2. EXPLICIT  - Uses SPLIT_RULES for fine-grained subsets.
@@ -23,8 +23,24 @@ function assert(condition, message) {
 const SPLIT_RULES = {
   // RV32/64 AMO and LR/SC separation
   Zaamo: [
-    'AMOSWAP.W', 'AMOADD.W', 'AMOXOR.W', 'AMOAND.W', 'AMOOR.W', 'AMOMIN.W', 'AMOMINU.W', 'AMOMAX.W', 'AMOMAXU.W',
-    'AMOSWAP.D', 'AMOADD.D', 'AMOXOR.D', 'AMOAND.D', 'AMOOR.D', 'AMOMIN.D', 'AMOMINU.D', 'AMOMAX.D', 'AMOMAXU.D',
+    'AMOSWAP.W',
+    'AMOADD.W',
+    'AMOXOR.W',
+    'AMOAND.W',
+    'AMOOR.W',
+    'AMOMIN.W',
+    'AMOMINU.W',
+    'AMOMAX.W',
+    'AMOMAXU.W',
+    'AMOSWAP.D',
+    'AMOADD.D',
+    'AMOXOR.D',
+    'AMOAND.D',
+    'AMOOR.D',
+    'AMOMIN.D',
+    'AMOMINU.D',
+    'AMOMAX.D',
+    'AMOMAXU.D',
   ],
   Zalrsc: ['LR.W', 'SC.W', 'LR.D', 'SC.D'],
 
@@ -37,44 +53,236 @@ const SPLIT_RULES = {
 
   // Integer-only compressed instructions (excludes FP-compressed ops)
   Zca: [
-    'C.ADDI4SPN', 'C.LW', 'C.SW', 'C.NOP', 'C.ADDI', 'C.LI', 'C.ADDI16SP', 'C.LUI', 'C.ANDI', 'C.SUB', 'C.XOR',
-    'C.OR', 'C.AND', 'C.ADD', 'C.J', 'C.BEQZ', 'C.BNEZ', 'C.LWSP', 'C.SWSP', 'C.JR', 'C.MV', 'C.EBREAK', 'C.JALR',
-    'C.JAL', 'C.LD', 'C.SD', 'C.LDSP', 'C.SDSP', 'C.ADDIW', 'C.ADDW', 'C.SUBW', 'C.SLLI', 'C.SRLI', 'C.SRAI',
+    'C.ADDI4SPN',
+    'C.LW',
+    'C.SW',
+    'C.NOP',
+    'C.ADDI',
+    'C.LI',
+    'C.ADDI16SP',
+    'C.LUI',
+    'C.ANDI',
+    'C.SUB',
+    'C.XOR',
+    'C.OR',
+    'C.AND',
+    'C.ADD',
+    'C.J',
+    'C.BEQZ',
+    'C.BNEZ',
+    'C.LWSP',
+    'C.SWSP',
+    'C.JR',
+    'C.MV',
+    'C.EBREAK',
+    'C.JALR',
+    'C.JAL',
+    'C.LD',
+    'C.SD',
+    'C.LDSP',
+    'C.SDSP',
+    'C.ADDIW',
+    'C.ADDW',
+    'C.SUBW',
+    'C.SLLI',
+    'C.SRLI',
+    'C.SRAI',
   ],
 
   // Vector FP subsets
   Zvfhmin: ['VFWCVT.F.F.V', 'VFNCVT.F.F.W'],
   Zvfh: [
-    'VFADD.VV', 'VFADD.VF', 'VFSUB.VV', 'VFSUB.VF', 'VFMUL.VV', 'VFMUL.VF', 'VFDIV.VV', 'VFDIV.VF',
-    'VFMACC.VV', 'VFMACC.VF', 'VFNMACC.VV', 'VFNMACC.VF', 'VFMSAC.VV', 'VFMSAC.VF', 'VFNMSAC.VV', 'VFNMSAC.VF',
-    'VFMADD.VV', 'VFMADD.VF', 'VFNMADD.VV', 'VFNMADD.VF', 'VFMSUB.VV', 'VFMSUB.VF', 'VFNMSUB.VV', 'VFNMSUB.VF',
-    'VFSQRT.V', 'VFMIN.VV', 'VFMIN.VF', 'VFMAX.VV', 'VFMAX.VF', 'VFSGNJ.VV', 'VFSGNJ.VF', 'VFSGNJN.VV', 'VFSGNJN.VF',
-    'VFSGNJX.VV', 'VFSGNJX.VF', 'VMFEQ.VV', 'VMFEQ.VF', 'VMFNE.VV', 'VMFNE.VF', 'VMFLT.VV', 'VMFLT.VF', 'VMFLE.VV', 'VMFLE.VF',
-    'VMFGT.VF', 'VMFGE.VF', 'VFCVT.X.F.V', 'VFCVT.XU.F.V', 'VFCVT.F.X.V', 'VFCVT.F.XU.V', 'VFCVT.RTZ.X.F.V', 'VFCVT.RTZ.XU.F.V',
-    'VFWCVT.X.F.V', 'VFWCVT.XU.F.V', 'VFWCVT.F.X.V', 'VFWCVT.F.XU.V', 'VFWCVT.F.F.V', 'VFWCVT.RTZ.X.F.V', 'VFWCVT.RTZ.XU.F.V',
-    'VFNCVT.X.F.W', 'VFNCVT.XU.F.W', 'VFNCVT.F.X.W', 'VFNCVT.F.XU.W', 'VFNCVT.F.F.W', 'VFNCVT.ROD.F.F.W',
-    'VFNCVT.RTZ.X.F.W', 'VFNCVT.RTZ.XU.F.W', 'VFREDUSUM.VS', 'VFREDOSUM.VS', 'VFREDMAX.VS', 'VFREDMIN.VS',
-    'VFWREDUSUM.VS', 'VFWREDOSUM.VS', 'VFMV.V.F', 'VFMV.F.S', 'VFMV.S.F', 'VFMERGE.VFM', 'VFSLIDE1UP.VF', 'VFSLIDE1DOWN.VF',
-    'VFREC7.V', 'VFRSQRT7.V', 'VFCLASS.V', 'VFRSUB.VF', 'VFRDIV.VF', 'VFWADD.VV', 'VFWADD.VF', 'VFWADD.WV', 'VFWADD.WF',
-    'VFWSUB.VV', 'VFWSUB.VF', 'VFWSUB.WV', 'VFWSUB.WF', 'VFWMUL.VV', 'VFWMUL.VF', 'VFWMACC.VV', 'VFWMACC.VF', 'VFWNMACC.VV', 'VFWNMACC.VF',
-    'VFWMSAC.VV', 'VFWMSAC.VF', 'VFWNMSAC.VV', 'VFWNMSAC.VF',
+    'VFADD.VV',
+    'VFADD.VF',
+    'VFSUB.VV',
+    'VFSUB.VF',
+    'VFMUL.VV',
+    'VFMUL.VF',
+    'VFDIV.VV',
+    'VFDIV.VF',
+    'VFMACC.VV',
+    'VFMACC.VF',
+    'VFNMACC.VV',
+    'VFNMACC.VF',
+    'VFMSAC.VV',
+    'VFMSAC.VF',
+    'VFNMSAC.VV',
+    'VFNMSAC.VF',
+    'VFMADD.VV',
+    'VFMADD.VF',
+    'VFNMADD.VV',
+    'VFNMADD.VF',
+    'VFMSUB.VV',
+    'VFMSUB.VF',
+    'VFNMSUB.VV',
+    'VFNMSUB.VF',
+    'VFSQRT.V',
+    'VFMIN.VV',
+    'VFMIN.VF',
+    'VFMAX.VV',
+    'VFMAX.VF',
+    'VFSGNJ.VV',
+    'VFSGNJ.VF',
+    'VFSGNJN.VV',
+    'VFSGNJN.VF',
+    'VFSGNJX.VV',
+    'VFSGNJX.VF',
+    'VMFEQ.VV',
+    'VMFEQ.VF',
+    'VMFNE.VV',
+    'VMFNE.VF',
+    'VMFLT.VV',
+    'VMFLT.VF',
+    'VMFLE.VV',
+    'VMFLE.VF',
+    'VMFGT.VF',
+    'VMFGE.VF',
+    'VFCVT.X.F.V',
+    'VFCVT.XU.F.V',
+    'VFCVT.F.X.V',
+    'VFCVT.F.XU.V',
+    'VFCVT.RTZ.X.F.V',
+    'VFCVT.RTZ.XU.F.V',
+    'VFWCVT.X.F.V',
+    'VFWCVT.XU.F.V',
+    'VFWCVT.F.X.V',
+    'VFWCVT.F.XU.V',
+    'VFWCVT.F.F.V',
+    'VFWCVT.RTZ.X.F.V',
+    'VFWCVT.RTZ.XU.F.V',
+    'VFNCVT.X.F.W',
+    'VFNCVT.XU.F.W',
+    'VFNCVT.F.X.W',
+    'VFNCVT.F.XU.W',
+    'VFNCVT.F.F.W',
+    'VFNCVT.ROD.F.F.W',
+    'VFNCVT.RTZ.X.F.W',
+    'VFNCVT.RTZ.XU.F.W',
+    'VFREDUSUM.VS',
+    'VFREDOSUM.VS',
+    'VFREDMAX.VS',
+    'VFREDMIN.VS',
+    'VFWREDUSUM.VS',
+    'VFWREDOSUM.VS',
+    'VFMV.V.F',
+    'VFMV.F.S',
+    'VFMV.S.F',
+    'VFMERGE.VFM',
+    'VFSLIDE1UP.VF',
+    'VFSLIDE1DOWN.VF',
+    'VFREC7.V',
+    'VFRSQRT7.V',
+    'VFCLASS.V',
+    'VFRSUB.VF',
+    'VFRDIV.VF',
+    'VFWADD.VV',
+    'VFWADD.VF',
+    'VFWADD.WV',
+    'VFWADD.WF',
+    'VFWSUB.VV',
+    'VFWSUB.VF',
+    'VFWSUB.WV',
+    'VFWSUB.WF',
+    'VFWMUL.VV',
+    'VFWMUL.VF',
+    'VFWMACC.VV',
+    'VFWMACC.VF',
+    'VFWNMACC.VV',
+    'VFWNMACC.VF',
+    'VFWMSAC.VV',
+    'VFWMSAC.VF',
+    'VFWNMSAC.VV',
+    'VFWNMSAC.VF',
   ],
 
   // In-register FP families (strictly excludes FP-register transfers: FLW/FSW/FMV.*)
   Zfinx: [
-    'FMADD.S', 'FMSUB.S', 'FNMADD.S', 'FNMSUB.S', 'FADD.S', 'FSUB.S', 'FMUL.S', 'FDIV.S', 'FSQRT.S',
-    'FSGNJ.S', 'FSGNJN.S', 'FSGNJX.S', 'FMIN.S', 'FMAX.S', 'FEQ.S', 'FLT.S', 'FLE.S', 'FCLASS.S',
-    'FCVT.W.S', 'FCVT.WU.S', 'FCVT.S.W', 'FCVT.S.WU', 'FCVT.L.S', 'FCVT.LU.S', 'FCVT.S.L', 'FCVT.S.LU',
+    'FMADD.S',
+    'FMSUB.S',
+    'FNMADD.S',
+    'FNMSUB.S',
+    'FADD.S',
+    'FSUB.S',
+    'FMUL.S',
+    'FDIV.S',
+    'FSQRT.S',
+    'FSGNJ.S',
+    'FSGNJN.S',
+    'FSGNJX.S',
+    'FMIN.S',
+    'FMAX.S',
+    'FEQ.S',
+    'FLT.S',
+    'FLE.S',
+    'FCLASS.S',
+    'FCVT.W.S',
+    'FCVT.WU.S',
+    'FCVT.S.W',
+    'FCVT.S.WU',
+    'FCVT.L.S',
+    'FCVT.LU.S',
+    'FCVT.S.L',
+    'FCVT.S.LU',
   ],
   Zdinx: [
-    'FMADD.D', 'FMSUB.D', 'FNMADD.D', 'FNMSUB.D', 'FADD.D', 'FSUB.D', 'FMUL.D', 'FDIV.D', 'FSQRT.D',
-    'FSGNJ.D', 'FSGNJN.D', 'FSGNJX.D', 'FMIN.D', 'FMAX.D', 'FEQ.D', 'FLT.D', 'FLE.D', 'FCLASS.D',
-    'FCVT.W.D', 'FCVT.WU.D', 'FCVT.D.W', 'FCVT.D.WU', 'FCVT.S.D', 'FCVT.D.S', 'FCVT.L.D', 'FCVT.LU.D', 'FCVT.D.L', 'FCVT.D.LU',
+    'FMADD.D',
+    'FMSUB.D',
+    'FNMADD.D',
+    'FNMSUB.D',
+    'FADD.D',
+    'FSUB.D',
+    'FMUL.D',
+    'FDIV.D',
+    'FSQRT.D',
+    'FSGNJ.D',
+    'FSGNJN.D',
+    'FSGNJX.D',
+    'FMIN.D',
+    'FMAX.D',
+    'FEQ.D',
+    'FLT.D',
+    'FLE.D',
+    'FCLASS.D',
+    'FCVT.W.D',
+    'FCVT.WU.D',
+    'FCVT.D.W',
+    'FCVT.D.WU',
+    'FCVT.S.D',
+    'FCVT.D.S',
+    'FCVT.L.D',
+    'FCVT.LU.D',
+    'FCVT.D.L',
+    'FCVT.D.LU',
   ],
   Zhinx: [
-    'FMADD.H', 'FMSUB.H', 'FNMADD.H', 'FNMSUB.H', 'FADD.H', 'FSUB.H', 'FMUL.H', 'FDIV.H', 'FSQRT.H',
-    'FSGNJ.H', 'FSGNJN.H', 'FSGNJX.H', 'FMIN.H', 'FMAX.H', 'FEQ.H', 'FLT.H', 'FLE.H', 'FCLASS.H',
-    'FCVT.W.H', 'FCVT.WU.H', 'FCVT.H.W', 'FCVT.H.WU', 'FCVT.S.H', 'FCVT.H.S', 'FCVT.L.H', 'FCVT.LU.H', 'FCVT.H.L', 'FCVT.H.LU',
+    'FMADD.H',
+    'FMSUB.H',
+    'FNMADD.H',
+    'FNMSUB.H',
+    'FADD.H',
+    'FSUB.H',
+    'FMUL.H',
+    'FDIV.H',
+    'FSQRT.H',
+    'FSGNJ.H',
+    'FSGNJN.H',
+    'FSGNJX.H',
+    'FMIN.H',
+    'FMAX.H',
+    'FEQ.H',
+    'FLT.H',
+    'FLE.H',
+    'FCLASS.H',
+    'FCVT.W.H',
+    'FCVT.WU.H',
+    'FCVT.H.W',
+    'FCVT.H.WU',
+    'FCVT.S.H',
+    'FCVT.H.S',
+    'FCVT.L.H',
+    'FCVT.LU.H',
+    'FCVT.H.L',
+    'FCVT.H.LU',
   ],
   Zhinxmin: ['FCVT.S.H', 'FCVT.H.S'],
 };
@@ -123,7 +331,7 @@ for (const [rawKey, details] of Object.entries(instrDict)) {
   keyMap.set(normKey, rawKey);
 
   const mnemonic = rawKey.toUpperCase().replaceAll('_', '.');
-  for (let tag of (details.extension ?? [])) {
+  for (let tag of details.extension ?? []) {
     tag = tag.toLowerCase();
     if (!tagToMnemonics.has(tag)) tagToMnemonics.set(tag, []);
     tagToMnemonics.get(tag).push(mnemonic);
@@ -166,7 +374,7 @@ for (const entry of extEntries) {
   if (entry.members?.length > 0) continue;
 
   let populated = false;
-  for (let tag of (entry.tags ?? [])) {
+  for (let tag of entry.tags ?? []) {
     tag = tag.toLowerCase();
     const mnemonics = tagToMnemonics.get(tag);
     if (mnemonics?.length) {
@@ -180,15 +388,36 @@ for (const entry of extEntries) {
 // Pass 1b: RV32 Shift Mask Injection (ISA Vol I §2.6)
 const RV32_BASE_IDS = new Set(['RV32I', 'RV32E']);
 const RV32_SHIFTS = {
-  SLLI: { encoding: '0000000----------001-----0010011', variable_fields: ['rd', 'rs1', 'shamt'], extension: ['rv_i'], match: '0x1013', mask: '0xfe00707f' },
-  SRLI: { encoding: '0000000----------101-----0010011', variable_fields: ['rd', 'rs1', 'shamt'], extension: ['rv_i'], match: '0x5013', mask: '0xfe00707f' },
-  SRAI: { encoding: '0100000----------101-----0010011', variable_fields: ['rd', 'rs1', 'shamt'], extension: ['rv_i'], match: '0x40005013', mask: '0xfe00707f' },
+  SLLI: {
+    encoding: '0000000----------001-----0010011',
+    variable_fields: ['rd', 'rs1', 'shamt'],
+    extension: ['rv_i'],
+    match: '0x1013',
+    mask: '0xfe00707f',
+  },
+  SRLI: {
+    encoding: '0000000----------101-----0010011',
+    variable_fields: ['rd', 'rs1', 'shamt'],
+    extension: ['rv_i'],
+    match: '0x5013',
+    mask: '0xfe00707f',
+  },
+  SRAI: {
+    encoding: '0100000----------101-----0010011',
+    variable_fields: ['rd', 'rs1', 'shamt'],
+    extension: ['rv_i'],
+    match: '0x40005013',
+    mask: '0xfe00707f',
+  },
 };
 
 for (const entry of extEntries) {
   if (!RV32_BASE_IDS.has(entry.id)) continue;
   for (const [mnemonic, details] of Object.entries(RV32_SHIFTS)) {
-    assert(!(mnemonic in entry.instructions), `Upstream instr_dict now provides ${mnemonic} for ${entry.id}. Remove this injection.`);
+    assert(
+      !(mnemonic in entry.instructions),
+      `Upstream instr_dict now provides ${mnemonic} for ${entry.id}. Remove this injection.`,
+    );
     entry.instructions[mnemonic] = JSON.parse(JSON.stringify(details));
   }
 }
@@ -205,13 +434,16 @@ assert(!!sctrclrSource, 'Ssctr must supply SCTRCLR before it can be shared with 
 if (sctrclrSource) {
   for (const entry of extEntries) {
     if (!SCTRCLR_SHARED_OWNERS.has(entry.id)) continue;
-    assert(!('SCTRCLR' in entry.instructions), `Upstream instr_dict now provides SCTRCLR for ${entry.id}. Remove this injection.`);
+    assert(
+      !('SCTRCLR' in entry.instructions),
+      `Upstream instr_dict now provides SCTRCLR for ${entry.id}. Remove this injection.`,
+    );
     entry.instructions.SCTRCLR = JSON.parse(JSON.stringify(sctrclrSource));
   }
 }
 
 // Pass 2: Umbrella Topological Resolution
-const umbrellaEntries = extEntries.filter(e => e.members?.length > 0);
+const umbrellaEntries = extEntries.filter((e) => e.members?.length > 0);
 const MAX_UMBRELLA_PASSES = 10;
 
 for (let pass = 0; pass < MAX_UMBRELLA_PASSES; pass++) {
@@ -274,7 +506,20 @@ function assertExtension(id, { count, mustInclude = [], mustExclude = [] } = {})
   if (!ext) return;
 
   if (count !== undefined) {
-    assert(Object.keys(ext.instructions).length === count, `${id}: expected ${count} instructions, found ${Object.keys(ext.instructions).length}`);
+    // Counted as ARCHITECTURAL instructions, not as rows. An instruction whose
+    // encoding differs by width is carried as a pair (REV8 / REV8.RV32,
+    // ZEXT.H / ZEXT.H.RV32) because the bits differ and the app shows bits, but
+    // it is one instruction in the spec and these pins are spec counts. Without
+    // the collapse, adding the missing half of a pair would look like a new
+    // instruction appearing inside a ratified extension, which is exactly the
+    // signal this assertion exists to raise.
+    const architectural = new Set(
+      Object.keys(ext.instructions).map((m) => m.replace(/\.RV(32|64)$/, '')),
+    );
+    assert(
+      architectural.size === count,
+      `${id}: expected ${count} instructions, found ${architectural.size}`,
+    );
   }
   for (const m of mustInclude) {
     assert(m in ext.instructions, `${id} must contain ${m}`);
@@ -285,15 +530,21 @@ function assertExtension(id, { count, mustInclude = [], mustExclude = [] } = {})
 }
 
 // Validations
-Object.keys(SPLIT_RULES).forEach(id => assertExtension(id, { count: SPLIT_RULES[id].length }));
+Object.keys(SPLIT_RULES).forEach((id) => assertExtension(id, { count: SPLIT_RULES[id].length }));
 
 if (process.argv.includes('--strict') && missingLog.size > 0) {
-  assert(false, `Strict mode: ${missingLog.size} extension(s) have unresolved SPLIT_RULES mnemonics.`);
+  assert(
+    false,
+    `Strict mode: ${missingLog.size} extension(s) have unresolved SPLIT_RULES mnemonics.`,
+  );
 }
 
 assertExtension('Zaamo', { mustExclude: ['LR.W', 'SC.W', 'LR.D', 'SC.D'] });
 assertExtension('Zalrsc', { mustInclude: ['LR.W', 'SC.W', 'LR.D', 'SC.D'] });
-assertExtension('Zmmul', { mustInclude: ['MUL'], mustExclude: ['DIV', 'DIVU', 'REM', 'REMU', 'DIVW', 'DIVUW', 'REMW', 'REMUW'] });
+assertExtension('Zmmul', {
+  mustInclude: ['MUL'],
+  mustExclude: ['DIV', 'DIVU', 'REM', 'REMU', 'DIVW', 'DIVUW', 'REMW', 'REMUW'],
+});
 assertExtension('Zicbom', { mustExclude: ['CBO.ZERO'] });
 assertExtension('Zicboz', { mustInclude: ['CBO.ZERO'], mustExclude: ['CBO.CLEAN'] });
 assertExtension('Smctr', { mustInclude: ['SCTRCLR'] });
@@ -305,7 +556,11 @@ if (rv32iExt) {
   for (const mnemonic of ['SLLI', 'SRLI', 'SRAI']) {
     const instr = rv32iExt.instructions[mnemonic];
     assert(!!instr, `RV32I must contain ${mnemonic}`);
-    if (instr) assert(instr.mask === '0xfe00707f', `RV32I ${mnemonic} mask must be 0xfe00707f (5-bit shamt)`);
+    if (instr)
+      assert(
+        instr.mask === '0xfe00707f',
+        `RV32I ${mnemonic} mask must be 0xfe00707f (5-bit shamt)`,
+      );
   }
 }
 
@@ -318,7 +573,10 @@ for (const entry of umbrellaEntries) {
   for (const memberId of entry.members) {
     const memberExt = extMap.get(memberId);
     if (memberExt) {
-      assert(memberId === 'Zkt' || Object.keys(memberExt.instructions).length > 0, `Umbrella ${entry.id} relies on ${memberId}, which is empty.`);
+      assert(
+        memberId === 'Zkt' || Object.keys(memberExt.instructions).length > 0,
+        `Umbrella ${entry.id} relies on ${memberId}, which is empty.`,
+      );
     }
   }
 }
@@ -341,7 +599,10 @@ assert(zkExt?.members?.includes('Zkt'), 'Zk umbrella must include Zkt.');
 assert(!extMap.get('B')?.members?.includes('Zbc'), 'B must not include Zbc.');
 
 for (const entry of extEntries) {
-  assert(!(entry.id in SPLIT_RULES && entry.members?.length > 0), `${entry.id} has both SPLIT_RULES and members.`);
+  assert(
+    !(entry.id in SPLIT_RULES && entry.members?.length > 0),
+    `${entry.id} has both SPLIT_RULES and members.`,
+  );
 }
 
 assertExtension('Zca', { mustExclude: ['C.FLW', 'C.FSW', 'C.FLWSP', 'C.FSWSP'] });
@@ -352,7 +613,8 @@ assertExtension('Zhinxmin');
 const KNOWN_POPULATED_TAG_EXTS = ['RV32I', 'RV64I', 'M', 'A', 'F', 'D', 'C', 'V'];
 for (const id of KNOWN_POPULATED_TAG_EXTS) {
   const ext = extMap.get(id);
-  if (ext) assert(Object.keys(ext.instructions).length > 0, `Core extension ${id} is unexpectedly empty.`);
+  if (ext)
+    assert(Object.keys(ext.instructions).length > 0, `Core extension ${id} is unexpectedly empty.`);
 }
 
 assertExtension('Zkn', { count: 45 });
@@ -364,12 +626,18 @@ if (rv64iExt) {
   for (const mnemonic of ['SLLI', 'SRLI', 'SRAI']) {
     const instr = rv64iExt.instructions[mnemonic];
     assert(!!instr, `RV64I must contain ${mnemonic}`);
-    if (instr) assert(instr.mask === '0xfc00707f', `RV64I ${mnemonic} mask must be 0xfc00707f (6-bit shamt)`);
+    if (instr)
+      assert(
+        instr.mask === '0xfc00707f',
+        `RV64I ${mnemonic} mask must be 0xfc00707f (6-bit shamt)`,
+      );
   }
 }
 
 if (validationErrors > 0) {
-  console.error(`\nValidation failed with ${validationErrors} error(s). riscv_extensions.json was NOT modified.`);
+  console.error(
+    `\nValidation failed with ${validationErrors} error(s). riscv_extensions.json was NOT modified.`,
+  );
   process.exit(1);
 }
 console.log('  All validation checks passed.\n');
@@ -385,9 +653,11 @@ if (dryRun) {
   const next = JSON.stringify(extensionsCatalog, null, 2) + '\n';
   const current = fs.readFileSync(catalogPath, 'utf8');
   console.log('  DRY RUN: no files were modified.');
-  console.log(current === next
-    ? '  riscv_extensions.json is already up to date.\n'
-    : `  riscv_extensions.json would change (${current.length} -> ${next.length} bytes).\n`);
+  console.log(
+    current === next
+      ? '  riscv_extensions.json is already up to date.\n'
+      : `  riscv_extensions.json would change (${current.length} -> ${next.length} bytes).\n`,
+  );
 } else {
   const tmpPath = catalogPath + '.tmp';
   fs.writeFileSync(tmpPath, JSON.stringify(extensionsCatalog, null, 2) + '\n', 'utf8');
@@ -396,7 +666,9 @@ if (dryRun) {
 
 // Counted from the catalog itself, not by summing the pass counters: injection
 // passes populate entries no pass counter owns, so the sum understates coverage.
-const totalPopulated = extEntries.filter(e => Object.keys(e.instructions ?? {}).length > 0).length;
+const totalPopulated = extEntries.filter(
+  (e) => Object.keys(e.instructions ?? {}).length > 0,
+).length;
 const injected = totalPopulated - (tagsPopulated + splitRulePopulated + umbrellaPopulated);
 const emptyExts = totalExts - totalPopulated;
 const coverage = ((totalPopulated / totalExts) * 100).toFixed(1);

--- a/src/completeness.js
+++ b/src/completeness.js
@@ -76,6 +76,27 @@ export function isOrderingRefinement(local, upstream) {
   return extra !== 0n && (extra & ~ORDERING_BITS) === 0n;
 }
 
+/**
+ * Is `local` a variant spelling of the same instruction as `upstream`?
+ *
+ * Coverage by a differently-named row is only meaningful for names that denote
+ * the SAME instruction spelled differently: an ordering suffix upstream
+ * enumerates and we fold into the base row, or an XLEN suffix we use where
+ * upstream keys the encoding by XLEN instead.
+ *
+ * Anything looser is dangerous. Letting any broader pattern in the same
+ * extension claim coverage reported C.ADDIW as covered by C.JAL and C.JALR by
+ * C.ADD -- different instructions that merely share an encoding slot -- and
+ * ZEXT.H as covered by PACKW, which it is only because zext.h is packw with
+ * rs2 = 0. A completeness gate that accepts those is reporting a catalogue
+ * complete because somebody else's bits happen to be a superset.
+ */
+export function isVariantSpelling(local, upstream) {
+  const strip = (m) => m.replace(/\.(AQRL|AQ|RL)$/, '').replace(/\.(RV32|RV64)$/, '');
+  if (local === upstream) return true;
+  return strip(local) === strip(upstream) && strip(local).length > 0;
+}
+
 /** Every instruction in the catalogue, flattened, keeping its owning entry. */
 export function flattenCatalogue(catalogue) {
   const rows = [];
@@ -186,12 +207,47 @@ export function compareAgainstUpstream(catalogue, upstream, options = {}) {
     const owners = (inst.definedBy || []).flatMap(aliasesFor);
     const candidates = owners.flatMap((o) => byExtension.get(o) || []);
 
-    const exact = candidates.find((c) => c.mnemonic === mnemonic);
-    const covering = candidates.find((c) => patternCovers(c, inst));
+    /*
+     * ANY row with this mnemonic that covers the encoding settles it, not the
+     * first one found.
+     *
+     * Upstream declares two encodings for the shift-immediates, one per XLEN,
+     * and this catalogue carries them as separate rows: RV32I pins bit 25
+     * because the shamt is five bits, RV64I leaves it free for the sixth. With
+     * a first-match rule the RV64 encoding was compared against the RV32I row
+     * and reported as a disagreement, when the matching row was sitting right
+     * beside it.
+     */
+    const named = candidates.filter((c) => c.mnemonic === mnemonic);
+    const covering = candidates.find(
+      (c) => patternCovers(c, inst) && isVariantSpelling(c.mnemonic, mnemonic),
+    );
 
-    if (exact && patternCovers(exact, inst)) continue;
+    /*
+     * Coverage is decided before naming. A row that carries the bits covers the
+     * encoding whatever it is called, and only when NOTHING covers it does the
+     * name become evidence of a disagreement.
+     *
+     * rev8 is why. Upstream declares both XLEN encodings under one name; this
+     * catalogue follows riscv-opcodes and splits them into REV8 and REV8.RV32,
+     * the latter filed under Zbkb. Checking the same-named row first found REV8,
+     * saw the RV64 bits, and reported a mismatch without ever looking at
+     * REV8.RV32 sitting beside it with exactly the encoding in question.
+     */
+    if (covering) {
+      if (covering.mnemonic !== mnemonic) {
+        coveredByBroaderRow.push({
+          upstream: mnemonic,
+          coveredBy: covering.mnemonic,
+          extension: covering.extension,
+          orderingOnly: isOrderingRefinement(covering, inst),
+        });
+      }
+      continue;
+    }
 
-    if (exact && !patternCovers(exact, inst)) {
+    const exact = named[0];
+    if (exact) {
       // The name is here but the bits disagree: either we pin something
       // upstream leaves free, or we pin it to a different value.
       /*
@@ -212,16 +268,6 @@ export function compareAgainstUpstream(catalogue, upstream, options = {}) {
       continue;
     }
 
-    if (covering) {
-      coveredByBroaderRow.push({
-        upstream: mnemonic,
-        coveredBy: covering.mnemonic,
-        extension: covering.extension,
-        orderingOnly: isOrderingRefinement(covering, inst),
-      });
-      continue;
-    }
-
     /*
      * Before calling it missing, check whether we carry the encoding at all,
      * just filed elsewhere. AMOCAS.B is the case that forced this: unified-db
@@ -233,7 +279,9 @@ export function compareAgainstUpstream(catalogue, upstream, options = {}) {
      * absent. The encoding check still applies, so this cannot quietly match
      * Zalasr's LB.AQ against the base ISA's LB: their bits differ.
      */
-    const elsewhere = local.find((c) => patternCovers(c, inst));
+    const elsewhere = local.find(
+      (c) => patternCovers(c, inst) && isVariantSpelling(c.mnemonic, mnemonic),
+    );
     if (elsewhere) {
       attributedDifferently.push({
         mnemonic,

--- a/src/instr_dict.json
+++ b/src/instr_dict.json
@@ -1789,13 +1789,25 @@
     "mask": "0xfc7f"
   },
   "zext_h": {
+    "encoding": "000010000000-----100-----0111011",
+    "variable_fields": [
+      "rd",
+      "rs1"
+    ],
+    "extension": [
+      "rv64_zbb"
+    ],
+    "match": "0x800403b",
+    "mask": "0xfff0707f"
+  },
+  "zext_h_rv32": {
     "encoding": "000010000000-----100-----0110011",
     "variable_fields": [
       "rd",
       "rs1"
     ],
     "extension": [
-      "rv_zbb"
+      "rv32_zbb"
     ],
     "match": "0x8004033",
     "mask": "0xfff0707f"
@@ -3048,6 +3060,18 @@
     ],
     "match": "0x100f",
     "mask": "0x707f"
+  },
+  "fence_tso": {
+    "encoding": "100000110011-----000-----0001111",
+    "variable_fields": [
+      "rs1",
+      "rd"
+    ],
+    "extension": [
+      "rv_i"
+    ],
+    "match": "0x8330000f",
+    "mask": "0xfff0707f"
   },
   "feq_d": {
     "encoding": "1010001----------010-----1010011",
@@ -6051,6 +6075,17 @@
     ],
     "match": "0x4800302f",
     "mask": "0xf800707f"
+  },
+  "ssrdp": {
+    "encoding": "11001101110000000100-----1110011",
+    "variable_fields": [
+      "rd_n0"
+    ],
+    "extension": [
+      "rv_zicfiss"
+    ],
+    "match": "0xcdc04073",
+    "mask": "0xfffff07f"
   },
   "ssamoswap_w": {
     "encoding": "01001------------010-----0101111",

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -191,6 +191,18 @@
           "match": "0xf",
           "mask": "0x707f"
         },
+        "FENCE.TSO": {
+          "encoding": "100000110011-----000-----0001111",
+          "variable_fields": [
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_i"
+          ],
+          "match": "0x8330000f",
+          "mask": "0xfff0707f"
+        },
         "JAL": {
           "encoding": "-------------------------1101111",
           "variable_fields": [
@@ -924,6 +936,18 @@
           "match": "0xf",
           "mask": "0x707f"
         },
+        "FENCE.TSO": {
+          "encoding": "100000110011-----000-----0001111",
+          "variable_fields": [
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_i"
+          ],
+          "match": "0x8330000f",
+          "mask": "0xfff0707f"
+        },
         "JAL": {
           "encoding": "-------------------------1101111",
           "variable_fields": [
@@ -1420,6 +1444,18 @@
           ],
           "match": "0xf",
           "mask": "0x707f"
+        },
+        "FENCE.TSO": {
+          "encoding": "100000110011-----000-----0001111",
+          "variable_fields": [
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_i"
+          ],
+          "match": "0x8330000f",
+          "mask": "0xfff0707f"
         },
         "JAL": {
           "encoding": "-------------------------1101111",
@@ -2151,6 +2187,18 @@
           ],
           "match": "0xf",
           "mask": "0x707f"
+        },
+        "FENCE.TSO": {
+          "encoding": "100000110011-----000-----0001111",
+          "variable_fields": [
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_i"
+          ],
+          "match": "0x8330000f",
+          "mask": "0xfff0707f"
         },
         "JAL": {
           "encoding": "-------------------------1101111",
@@ -2928,6 +2976,18 @@
           "match": "0x20006033",
           "mask": "0xfe00707f"
         },
+        "ZEXT.H": {
+          "encoding": "000010000000-----100-----0111011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv64_zbb"
+          ],
+          "match": "0x800403b",
+          "mask": "0xfff0707f"
+        },
         "CLZW": {
           "encoding": "011000000000-----001-----0011011",
           "variable_fields": [
@@ -3060,18 +3120,6 @@
           ],
           "match": "0x40007033",
           "mask": "0xfe00707f"
-        },
-        "ZEXT.H": {
-          "encoding": "000010000000-----100-----0110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zbb"
-          ],
-          "match": "0x8004033",
-          "mask": "0xfff0707f"
         },
         "CLZ": {
           "encoding": "011000000000-----001-----0010011",
@@ -3263,6 +3311,18 @@
             "rv_zbb"
           ],
           "match": "0x28705013",
+          "mask": "0xfff0707f"
+        },
+        "ZEXT.H.RV32": {
+          "encoding": "000010000000-----100-----0110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbb"
+          ],
+          "match": "0x8004033",
           "mask": "0xfff0707f"
         },
         "BCLRI": {
@@ -16080,11 +16140,24 @@
       "short": "Basic Bitmanip",
       "tags": [
         "rv64_zbb",
-        "rv_zbb"
+        "rv_zbb",
+        "rv32_zbb"
       ],
       "desc": "Common bit and word operations such as count leading zeros, population count, min/max, rotate and sign extend.",
       "use": "Bit counting, min/max and byte swapping",
       "instructions": {
+        "ZEXT.H": {
+          "encoding": "000010000000-----100-----0111011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv64_zbb"
+          ],
+          "match": "0x800403b",
+          "mask": "0xfff0707f"
+        },
         "CLZW": {
           "encoding": "011000000000-----001-----0011011",
           "variable_fields": [
@@ -16217,18 +16290,6 @@
           ],
           "match": "0x40007033",
           "mask": "0xfe00707f"
-        },
-        "ZEXT.H": {
-          "encoding": "000010000000-----100-----0110011",
-          "variable_fields": [
-            "rd",
-            "rs1"
-          ],
-          "extension": [
-            "rv_zbb"
-          ],
-          "match": "0x8004033",
-          "mask": "0xfff0707f"
         },
         "CLZ": {
           "encoding": "011000000000-----001-----0010011",
@@ -16420,6 +16481,18 @@
             "rv_zbb"
           ],
           "match": "0x28705013",
+          "mask": "0xfff0707f"
+        },
+        "ZEXT.H.RV32": {
+          "encoding": "000010000000-----100-----0110011",
+          "variable_fields": [
+            "rd",
+            "rs1"
+          ],
+          "extension": [
+            "rv32_zbb"
+          ],
+          "match": "0x8004033",
           "mask": "0xfff0707f"
         }
       },
@@ -23150,6 +23223,17 @@
           ],
           "match": "0x4800302f",
           "mask": "0xf800707f"
+        },
+        "SSRDP": {
+          "encoding": "11001101110000000100-----1110011",
+          "variable_fields": [
+            "rd_n0"
+          ],
+          "extension": [
+            "rv_zicfiss"
+          ],
+          "match": "0xcdc04073",
+          "mask": "0xfffff07f"
         },
         "SSAMOSWAP.W": {
           "encoding": "01001------------010-----0101111",

--- a/tests/catalog-coverage.test.mjs
+++ b/tests/catalog-coverage.test.mjs
@@ -34,7 +34,7 @@ const entries = [];
     if (node.id && node.desc) entries.push(node);
     Object.values(node).forEach(collect);
   }
-}(catalog));
+})(catalog);
 
 const instructionCount = (e) => Object.keys(e.instructions || {}).length;
 const csrCount = (e) => Object.keys(e.csrs || {}).length;
@@ -53,9 +53,10 @@ test('every tagged extension yields instructions or CSRs', () => {
     .map((e) => `${e.id} [${e.tags.join(', ')}]`);
 
   assert.deepEqual(
-    barren, [],
-    'these entries carry tags that resolved to nothing, so the tag is wrong or upstream renamed it:\n  '
-      + barren.join('\n  '),
+    barren,
+    [],
+    'these entries carry tags that resolved to nothing, so the tag is wrong or upstream renamed it:\n  ' +
+      barren.join('\n  '),
   );
 });
 
@@ -67,7 +68,11 @@ test('every umbrella resolves to instructions', () => {
     .filter((e) => instructionCount(e) === 0)
     .map((e) => `${e.id} <- ${e.members.join(', ')}`);
 
-  assert.deepEqual(hollow, [], `umbrella extensions resolved to no instructions:\n  ${hollow.join('\n  ')}`);
+  assert.deepEqual(
+    hollow,
+    [],
+    `umbrella extensions resolved to no instructions:\n  ${hollow.join('\n  ')}`,
+  );
 });
 
 test('umbrella members all exist', () => {
@@ -76,7 +81,11 @@ test('umbrella members all exist', () => {
   for (const e of entries) {
     for (const m of e.members || []) if (!ids.has(m)) dangling.push(`${e.id} -> ${m}`);
   }
-  assert.deepEqual(dangling, [], `umbrella members that are not catalogue entries:\n  ${dangling.join('\n  ')}`);
+  assert.deepEqual(
+    dangling,
+    [],
+    `umbrella members that are not catalogue entries:\n  ${dangling.join('\n  ')}`,
+  );
 });
 
 test('CSR coverage does not regress', () => {
@@ -131,9 +140,16 @@ test('no unratified draft instructions are published', () => {
   // first four rv_zbb / rv64_zbb, so they appeared inside a ratified extension.
   // Zbp was never ratified at all: it is 404 upstream and absent from UDB.
   const withdrawn = [
-    'SLO', 'SLOI', 'SRO', 'SROI',                       // draft Zbb shift-ones
-    'GORCI', 'GREVI', 'SHFLI', 'UNSHFLI',               // draft Zbp
-    'XPERM16', 'XPERM32',                               // draft Zbp
+    'SLO',
+    'SLOI',
+    'SRO',
+    'SROI', // draft Zbb shift-ones
+    'GORCI',
+    'GREVI',
+    'SHFLI',
+    'UNSHFLI', // draft Zbp
+    'XPERM16',
+    'XPERM32', // draft Zbp
   ];
   const published = [];
   for (const e of entries) {
@@ -142,7 +158,8 @@ test('no unratified draft instructions are published', () => {
     }
   }
   assert.deepEqual(
-    published, [],
+    published,
+    [],
     `these instructions were withdrawn before ratification and must not ship:\n  ${published.join('\n  ')}`,
   );
 });
@@ -151,9 +168,25 @@ test('Zbb matches the ratified instruction set', () => {
   // The concrete symptom of the above: Zbb read 28 instructions instead of 24.
   const zbb = entries.find((e) => e.id === 'Zbb');
   assert.ok(zbb, 'Zbb is missing from the catalogue');
+  // Counted as architectural instructions. ZEXT.H encodes differently per width
+  // (pack on RV32, packw on RV64) so it is carried as ZEXT.H + ZEXT.H.RV32, the
+  // same pairing REV8 already uses. That is two rows and one instruction, and
+  // this count is a count of the spec's instructions.
+  const architectural = new Set(
+    Object.keys(zbb.instructions || {}).map((m) => m.replace(/\.RV(32|64)$/, '')),
+  );
+  assert.equal(architectural.size, 24, 'ratified Zbb has 24 instructions across RV32 and RV64');
+});
+
+test('Zbb carries both width-specific encodings of ZEXT.H', () => {
+  // The RV32 encoding sat under the plain name with an rv_zbb tag claiming both
+  // widths, so an RV64 lookup of ZEXT.H returned pack's bits rather than packw's.
+  const zbb = entries.find((e) => e.id === 'Zbb');
+  assert.equal(zbb.instructions['ZEXT.H'].match, '0x800403b', 'RV64 ZEXT.H is packw rd, rs1, x0');
   assert.equal(
-    Object.keys(zbb.instructions || {}).length, 24,
-    'ratified Zbb has 24 instructions across RV32 and RV64',
+    zbb.instructions['ZEXT.H.RV32'].match,
+    '0x8004033',
+    'RV32 ZEXT.H is pack rd, rs1, x0',
   );
 });
 
@@ -181,7 +214,8 @@ test('extensions that define no new opcodes carry their pseudo-instructions', ()
     // base instruction reads as a data error rather than as a fact.
     for (const [mnemonic, details] of instructions) {
       assert.equal(
-        details.alias_of, alias,
+        details.alias_of,
+        alias,
         `${id}.${mnemonic} should record alias_of ${alias}, got ${details.alias_of ?? 'nothing'}`,
       );
     }
@@ -213,8 +247,8 @@ test('a mnemonic never carries two different encodings', () => {
         const widthOnly = XLEN_VARIANTS.has(m.toUpperCase()) && prev.match === d.match;
         assert.ok(
           widthOnly,
-          `${m} has two different encodings: ${prev.ext} says ${prev.match}/${prev.mask}, `
-          + `${e.id} says ${d.match}/${d.mask}`,
+          `${m} has two different encodings: ${prev.ext} says ${prev.match}/${prev.mask}, ` +
+            `${e.id} says ${d.match}/${d.mask}`,
         );
         continue;
       }
@@ -237,7 +271,8 @@ test('ratification labelling does not regress', () => {
   for (const e of labelled) {
     if (!e.ratification_date) continue;
     assert.match(
-      String(e.ratification_date), /^\d{4}-\d{2}$/,
+      String(e.ratification_date),
+      /^\d{4}-\d{2}$/,
       `${e.id} has ratification_date ${e.ratification_date}, expected YYYY-MM`,
     );
   }
@@ -318,7 +353,7 @@ test('RV128I is not labelled ratified, because it is not', () => {
   assert.match(rv128.url, /rv128\.html$/, 'it should link to its own chapter');
 });
 
-test('RV128I does not borrow another extension\'s instruction set', () => {
+test("RV128I does not borrow another extension's instruction set", () => {
   // It carried RV64I's 52 instructions verbatim, each stamped extension
   // ["rv64_i"], and none of the instructions RV128 actually defines — LQ, SQ,
   // LDU, or the *D family. Neither riscv-opcodes nor riscv-unified-db models
@@ -354,10 +389,7 @@ test('an instruction with two owners is attributed to both', () => {
   });
 
   for (const entry of owners) {
-    assert.ok(
-      entry.instructions?.SCTRCLR,
-      `${entry.id} defines SCTRCLR and must carry it`,
-    );
+    assert.ok(entry.instructions?.SCTRCLR, `${entry.id} defines SCTRCLR and must carry it`);
   }
 
   assert.deepEqual(
@@ -394,7 +426,11 @@ test('optional and mandatory sets do not overlap', () => {
     if (!block) continue;
     const mandatory = new Set([...block[1].matchAll(/'([^']+)'/g)].map((m) => m[1]));
     const both = list.filter((id) => mandatory.has(id));
-    assert.deepEqual(both, [], `${profile} lists ${both.join(', ')} as both mandatory and optional`);
+    assert.deepEqual(
+      both,
+      [],
+      `${profile} lists ${both.join(', ')} as both mandatory and optional`,
+    );
   }
 });
 

--- a/tests/completeness.test.mjs
+++ b/tests/completeness.test.mjs
@@ -14,6 +14,7 @@ import {
   isOrderingRefinement,
   flattenCatalogue,
   compareAgainstUpstream,
+  isVariantSpelling,
 } from '../src/completeness.js';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -437,4 +438,46 @@ test('ratification filtering is case-insensitive and defaults to off', () => {
 
   const off = compareAgainstUpstream(catalogue, upstream);
   assert.deepEqual(off.missingExtensions, ['Zsynthetic'], 'unfiltered by default');
+});
+
+// ── variant spellings ──────────────────────────────────────────────────────
+
+test('a variant spelling is an ordering or XLEN suffix, nothing looser', () => {
+  assert.equal(isVariantSpelling('AMOADD.W', 'AMOADD.W.AQ'), true);
+  assert.equal(isVariantSpelling('REV8.RV32', 'REV8'), true);
+  assert.equal(isVariantSpelling('LR.W', 'LR.W.AQRL'), true);
+  assert.equal(isVariantSpelling('ADD', 'ADD'), true);
+
+  /*
+   * The cases that made this necessary. Letting any broader pattern in the same
+   * extension claim coverage reported C.ADDIW as covered by C.JAL and C.JALR by
+   * C.ADD, which merely share an encoding slot, and ZEXT.H as covered by PACKW,
+   * which it is only because zext.h is packw with rs2 = 0. A completeness gate
+   * that accepts those reports a catalogue complete because somebody else's
+   * bits happen to be a superset.
+   */
+  assert.equal(isVariantSpelling('C.JAL', 'C.ADDIW'), false);
+  assert.equal(isVariantSpelling('C.ADD', 'C.JALR'), false);
+  assert.equal(isVariantSpelling('PACKW', 'ZEXT.H'), false);
+  assert.equal(isVariantSpelling('FENCE', 'FENCE.TSO'), false);
+});
+
+test('a broader row with an unrelated name does not count as coverage', () => {
+  // FENCE's mask is broad enough to cover FENCE.TSO's bits. They are different
+  // instructions, so this must surface rather than pass.
+  const fence = flattenCatalogue(catalogue).find((r) => r.mnemonic === 'FENCE');
+  assert.ok(fence, 'FENCE must exist');
+
+  const result = compareAgainstUpstream(catalogue, {
+    extensions: [],
+    instructions: [
+      {
+        mnemonic: 'FENCE.TSO',
+        match: fence.match | (0x8330n << 16n),
+        mask: 0xffffffffn,
+        definedBy: [fence.extension],
+      },
+    ],
+  });
+  assert.equal(result.coveredByBroaderRow.length, 0, 'FENCE must not cover FENCE.TSO');
 });

--- a/tests/udb-parser.test.mjs
+++ b/tests/udb-parser.test.mjs
@@ -7,6 +7,7 @@ import {
   parseUpstream,
   parseVariables,
   applyNotConstraints,
+  parseEncodings,
   EXTENSION_ALIASES,
 } from '../scripts/check-udb-completeness.mjs';
 
@@ -192,4 +193,71 @@ encoding:
   assert.equal(vars.length, 2);
   assert.deepEqual(vars[0].not, [0, 1, 2, 3, 4, 5]);
   assert.deepEqual(vars[1].not, []);
+});
+
+// ── XLEN-keyed encodings ───────────────────────────────────────────────────
+
+test('an XLEN-keyed encoding yields one entry per XLEN', () => {
+  /*
+   * unified-db writes 19 instructions with encodings keyed by XLEN, rev8 among
+   * them. Taking the first `match:` in the file read one of the two, and it did
+   * so for exactly the instructions where RV32 and RV64 diverge -- the shifts,
+   * ld/sd, the Zbs single-bit ops -- so the gate compared half the data for the
+   * cases most likely to disagree.
+   */
+  const encs = parseEncodings(`
+encoding:
+  RV32:
+    match: 011010011000-----101-----0010011
+    variables:
+      - name: xs1
+        location: 19-15
+  RV64:
+    match: 011010111000-----101-----0010011
+    variables:
+      - name: xs1
+        location: 19-15
+access:
+  s: always
+`);
+  assert.equal(encs.length, 2);
+  assert.deepEqual(
+    encs.map((e) => e.xlen),
+    ['RV32', 'RV64'],
+  );
+  assert.equal(encs[0].match, 0x69805013n, 'the RV32 form');
+  assert.equal(encs[1].match, 0x6b805013n, 'the RV64 form');
+});
+
+test('a plain encoding yields exactly one entry, with no xlen', () => {
+  const encs = parseEncodings(`
+encoding:
+  match: 0000000----------000-----0110011
+  variables:
+    - name: xs2
+      location: 24-20
+`);
+  assert.equal(encs.length, 1);
+  assert.equal(encs[0].xlen, null);
+});
+
+test('not: constraints are folded per XLEN block, not across them', () => {
+  const encs = parseEncodings(`
+encoding:
+  RV32:
+    match: 0000000------------------0110011
+    variables:
+      - name: tt
+        location: 14-12
+        not: [0, 2, 3, 4, 5, 6, 7]
+  RV64:
+    match: 0000000------------------0110011
+    variables:
+      - name: tt
+        location: 14-12
+`);
+  assert.equal(encs.length, 2);
+  const RM = 0x7n << 12n;
+  assert.equal(encs[0].mask & RM, RM, 'RV32 pins tt via not:');
+  assert.equal(encs[1].mask & RM, 0n, 'RV64 leaves it free');
 });


### PR DESCRIPTION
Closes #305.

Two commits, in order: the gate fix, then the data it exposed.

## 1. `fix:` the completeness gate

Three faults, all of which made the gate quieter than it should have been.

- **XLEN-keyed encodings.** unified-db keys 19 instructions by width (`encoding: RV32: / RV64:`). Reading only the first `match:` compared against half the data for precisely the instructions where the widths diverge: `rev8`, `rori`, `ld`, `sd`, the shift-immediates, the Zbs bit ops.
- **Naming before coverage.** A same-named row that did not cover short-circuited the search, so `REV8` was compared against the RV32 encoding while `REV8.RV32` sat beside it carrying those exact bits. Checking coverage first fixes that and immediately over-corrects, reporting `C.ADDIW` covered by `C.JAL` and `ZEXT.H` covered by `PACKW`. Coverage by a differing name is now limited to variant spellings, an ordering or XLEN suffix. A gate that accepts anything looser will call a catalogue complete because somebody else bits happen to be a superset.
- **Regex terminators, three of them.** `/$/m` is the end of the first line, so `/(?=^\S|$)/m` captured nothing. It hit `definedBy`, then `parseVariables`, then the `encoding:` block. All three now scan lines through a shared `blockUnder()` helper, which has neither failure mode.

## 2. `data:` the three instructions

All ratified, all absent because riscv-opcodes declares them as `$pseudo_op` lines and the vendored `instr_dict` carries only primary encodings.

| Instruction | Tag | Match / mask |
|---|---|---|
| `FENCE.TSO` | `rv_i` | `0x8330000f` / `0xfff0707f` |
| `SSRDP` | `rv_zicfiss` | `0xcdc04073` / `0xfffff07f` |
| `ZEXT.H` | `rv64_zbb` | `0x800403b` / `0xfff0707f` |

Being an alias is not grounds for omission here. The repo already carries pseudo-instructions on purpose, with a test saying so: Zihintpause, Zihintntl, Zicntr, Zicfilp and Zicbop define no encodings of their own and read as empty extensions unless their aliases ship.

`ZEXT.H` was wrong rather than merely missing: `pack rd, rs1, x0` on RV32, `packw rd, rs1, x0` on RV64, and we carried the RV32 bits under the plain name tagged `rv_zbb`, claiming both widths. An RV64 lookup returned RV32 bits, silently. Now paired as `ZEXT.H` / `ZEXT.H.RV32`, exactly as `REV8` / `REV8.RV32` already is, and as riscv-opcodes splits it across `rv32_zbb` and `rv64_zbb`. Zbb gains the `rv32_zbb` tag so the RV32 half has an owner.

### On the pinned counts

Zbb is pinned at 24 instructions and B at 40, in `sync_instructions.mjs` and mirrored in `catalog-coverage.test.mjs`. Those pins earned their place by catching four draft shift-ones ops that were tagged `rv_zbb` and made Zbb read 28.

Splitting `ZEXT.H` moves the row count to 25 without adding an instruction, so the pins now count architectural instructions, collapsing a trailing `.RV32` or `.RV64`. Bumping the number to 25 was the easy fix and the wrong one: it would redefine the pin as a row count, and a row count cannot tell a width variant from a draft op leaking into a ratified extension, which is the only thing the assertion exists to catch.

## Verification

- 321 tests, all passing. Lint green. Build green.
- Mutation-checked: restoring the single-encoding read fails two tests; letting any broader row claim coverage fails one. Nine tests added across `tests/completeness.test.mjs`, `tests/udb-parser.test.mjs` and `tests/catalog-coverage.test.mjs`.
- Gate now reports 0 missing extensions and 0 encoding mismatches.

## Known and deliberate

`CM.JT` (Zcmt) still reports missing, so `npm run udb:check` exits 1 and the Monday report will file it. Our single `CM.JALT` row spans the index range upstream splits into `cm.jt` (index < 32) and `cm.jalt`. That is a naming question of the same kind as #256, and resolving it is a separate decision.