### PR TITLE
data: separate CM.JT from CM.JALT, closing the last completeness gap (#307)

### DIFF
--- a/src/instr_dict.json
+++ b/src/instr_dict.json
@@ -1927,6 +1927,17 @@
     "match": "0x6000101b",
     "mask": "0xfff0707f"
   },
+  "cm_jt": {
+    "encoding": "----------------101000000-----10",
+    "variable_fields": [
+      "c_index"
+    ],
+    "extension": [
+      "rv_zcmt"
+    ],
+    "match": "0xa002",
+    "mask": "0xff83"
+  },
   "cm_jalt": {
     "encoding": "----------------101000--------10",
     "variable_fields": [

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -18475,6 +18475,17 @@
       "use": "Switch/jumptable compression",
       "url": "https://docs.riscv.org/reference/isa/unpriv/zc.html",
       "instructions": {
+        "CM.JT": {
+          "encoding": "----------------101000000-----10",
+          "variable_fields": [
+            "c_index"
+          ],
+          "extension": [
+            "rv_zcmt"
+          ],
+          "match": "0xa002",
+          "mask": "0xff83"
+        },
         "CM.JALT": {
           "encoding": "----------------101000--------10",
           "variable_fields": [

--- a/tests/catalog-coverage.test.mjs
+++ b/tests/catalog-coverage.test.mjs
@@ -190,6 +190,35 @@ test('Zbb carries both width-specific encodings of ZEXT.H', () => {
   );
 });
 
+test('Zcmt separates CM.JT from CM.JALT', () => {
+  // riscv-opcodes carries one row, cm.jalt, whose 8-bit index spans 0-255. The
+  // Zcmt spec defines two instructions on that range: CM.JT for index < 32,
+  // which jumps, and CM.JALT for index >= 32, which jumps and links. Carrying
+  // only the wide row meant every index below 32 decoded as a linking jump.
+  //
+  // CM.JT pins index[7:5] to zero, so its mask is strictly narrower and a
+  // decoder must prefer it. CM.JALT stays wide because "index >= 32" is not
+  // expressible as a mask, the same reason C.MV stays wide against C.JR and
+  // C.ADD against C.JALR and C.EBREAK.
+  const zcmt = entries.find((e) => e.id === 'Zcmt');
+  assert.ok(zcmt, 'Zcmt is missing from the catalogue');
+  const jt = zcmt.instructions['CM.JT'];
+  const jalt = zcmt.instructions['CM.JALT'];
+  assert.ok(jt, 'Zcmt must carry CM.JT');
+  assert.ok(jalt, 'Zcmt must carry CM.JALT');
+
+  const jtMask = BigInt(jt.mask);
+  const jaltMask = BigInt(jalt.mask);
+  assert.equal(BigInt(jt.match), BigInt(jalt.match), 'both decode from the same base');
+  assert.equal(jtMask & jaltMask, jaltMask, 'CM.JT must be at least as constrained');
+  assert.notEqual(jtMask, jaltMask, 'CM.JT must be strictly narrower, not a duplicate');
+
+  const indexHigh = 0x380n; // index[7:5], bits 9-7 of the halfword
+  assert.equal(jtMask & indexHigh, indexHigh, 'CM.JT must fix index[7:5]');
+  assert.equal(BigInt(jt.match) & indexHigh, 0n, 'CM.JT is the index < 32 half');
+  assert.equal(jaltMask & indexHigh, 0n, 'CM.JALT must leave index[7:5] free');
+});
+
 test('extensions that define no new opcodes carry their pseudo-instructions', () => {
   // Zihintpause, Zihintntl, Zicntr, Zicfilp and Zicbop introduce no encodings of
   // their own; they name specific encodings of existing instructions. They read


### PR DESCRIPTION
Closes #307.

Zcmt carried one instruction, `CM.JALT`, whose 8-bit index spans 0-255. The spec defines two over that range: `CM.JT` for index < 32, which jumps, and `CM.JALT` for index >= 32, which jumps **and links**. Every index below 32 was presented as a linking jump, so this is a wrong answer rather than a missing one.

riscv-opcodes has a single line for the pair, which is how the conflation arrived:

```
cm.jalt  c_index   1..0=2 15..13=5 12..10=0
```

unified-db splits them: `cm.jt` pins `index[7:5]` to zero, `cm.jalt` excludes 0-31 with a `not:` list of 32 values.

## The change

| | match | mask | |
|---|---|---|---|
| `CM.JT` | `0xa002` | `0xff83` | new, `index[7:5]` fixed at 0 |
| `CM.JALT` | `0xa002` | `0xfc03` | unchanged |

The two overlap deliberately. `CM.JT` is strictly narrower so a decoder must prefer it, and `CM.JALT` stays wide because "index >= 32" is not expressible as a mask. That is the shape this catalogue already uses for precisely this case: `C.JR` inside `C.MV`, `C.EBREAK` inside `C.JALR` inside `C.ADD`, each sharing a match and separated only by mask width. Nothing forbids the overlap, and forbidding it would mean deleting one of a real pair.

`CM.JALT` keeps the `c_index` field name rather than gaining an invented suffix. Nothing parses `variable_fields` for meaning (it is displayed and exported only), so a name asserting a constraint the mask does not carry would be decoration.

## Result

`npm run udb:check` now reports 0 missing extensions, 0 missing instructions and 0 encoding mismatches, and exits 0. The weekly report has nothing to file.

322 tests, all passing. Lint and build green. The new assertion is mutation-checked: widening `CM.JT`'s mask to match `CM.JALT`'s fails it.