### PR TITLE
feat: close the coverage gaps the completeness gate could not see

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,27 @@ Then `npm run sync` and `npm test && npm run build`.
   direction, and a weekly workflow files the result as one issue it keeps
   updated. Adding an extension stays a human decision: it needs a description, a
   use case, a doc link and a graph node, none of which UDB supplies.
+  Its "Still missing from UDB" watchlist is *derived* — an entry carrying a
+  `long_name` counts as already synced — so describing an extension ourselves is
+  what drops it off the list. Anything UDB has never carried therefore has to be
+  named in `ALWAYS_WATCH`, or the one part of the catalogue where we are ahead
+  of UDB is the one part the report goes quiet about. The SPMP family is there
+  now; remove an id once UDB ships it. `tests/sync-tooling.test.mjs` guards it.
+- **The Zve\* instruction sets are DERIVED, not synced.** riscv-opcodes has no
+  `rv_zve*` tag and unified-db files all 627 vector instructions under one owner
+  (`Zvl32b`), so nothing upstream says what each embedded subset contains. The
+  rules in `scripts/sync_instructions.mjs` compute them from V using the EEW and
+  FP table in unpriv §30.1.18.2. No upstream check can catch an error in this;
+  `tests/zve-subsets.test.mjs` pins the rules and the exact counts instead.
+  Change a rule, never the 2,500 generated entries.
+- **`npm run udb:check` reports two coverage numbers, and only the first
+  gates.** Global coverage asks "is this encoding in the catalogue anywhere" —
+  that is `complete`, and a failure there is unambiguous. Per-extension coverage
+  asks "does an extension upstream attributes it to actually list it", and sits
+  far lower (≈49%) because attribution differences are often legitimate: UDB
+  files AMOCAS.B under Zabha, this catalogue under Zacas. Watch it move; do not
+  gate on it. Reporting only the first is how five extensions shipped with empty
+  instruction maps while every check passed.
 - **`src/isa-params.json` is definitions, not values.** It says what a parameter
   IS: type, admissible values, and the conditions under which it exists. It
   chooses nothing. Values come from two other places: the constraints in

--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ knowing before changing anything:
 | `src/isa-dependency-graph.json` | dependencies, conflicts and parameters, with a citation on every edge | [riscv-unified-db](https://github.com/riscv/riscv-unified-db) |
 | `src/profiles.js` | the ratified profiles | the profile specifications |
 
+Two things fall outside that table, because no upstream carries them. The
+**Zve\* embedded vector subsets** are derived from V by the EEW/FP rules in
+unpriv §30.1.18.2 — riscv-opcodes has no `rv_zve*` tag and unified-db attributes
+every vector instruction to a single owner, so neither can say what belongs in
+Zve32x. And the **SPMP family** (Sspmp, Sspmpen, Smpmpdeleg) is ratified in a
+specification of its own that unified-db does not model at all; its dependency
+edges cite that document through the graph's `spec` provenance source. Both are
+places where the usual checks cannot help, so both are pinned by tests.
+
 `riscv-unified-db` is normative for dependencies. clang is the check that what we
 emit is actually usable: CI feeds every generated `-march` string to a real
 compiler. `riscv-config`, RISC-V International's own validator, disagrees with

--- a/scripts/check-udb-completeness.mjs
+++ b/scripts/check-udb-completeness.mjs
@@ -201,23 +201,105 @@ export function parseEncodings(text) {
   return out;
 }
 
-export function parseUpstream(specDir) {
-  const readDefinedBy = (text) => {
-    /*
-     * definedBy is a nested block, in one of two shapes:
-     *
-     *   definedBy:            definedBy:
-     *     extension:            extension:
-     *       name: I               anyOf:
-     *                               - name: Zbb
-     *                               - name: Zbkb
-     *
-     * Capture every indented line under it, up to the next key at column zero,
-     * then take each `name:`.
-     */
-    const block = blockUnder(text, 'definedBy');
-    return block ? [...block.matchAll(/name:\s*([A-Za-z0-9_.]+)/g)].map((x) => x[1]) : [];
+/**
+ * definedBy, as the predicate tree it actually is.
+ *
+ * Scraping `name:` out of the block gives the owner list and throws away the
+ * shape around it, which is not a detail: 132 instruction files carry an
+ * `xlen:` inside definedBy, so MULW's "RV64 AND (M OR Zmmul)" flattens to
+ * "[M, Zmmul]" and the RV64 half is gone. That is the same information a
+ * reader needs to tell an RV32-only pairing (Zilsd's LD) from the RV64 one
+ * (I's LD) — the two share a mnemonic and differ only in the condition.
+ *
+ * The grammar unified-db uses here is small and closed. Every shape in the
+ * corpus is one of:
+ *
+ *   extension: <node>        allOf: [<node>…]        name: <id>
+ *   not: <node>              anyOf: [<node>…]        xlen: 32 | 64
+ *                            oneOf: [<node>…]
+ *
+ * so this parses that subset by indentation rather than pulling in a YAML
+ * dependency. Anything it does not recognise yields a null predicate, and the
+ * caller falls back to the flat owner list — degrading to today's behaviour
+ * rather than inventing a condition.
+ */
+export function parseDefinedBy(block) {
+  if (!block) return { owners: [], predicate: null };
+
+  const lines = block
+    .split('\n')
+    .filter((l) => l.trim() !== '' && !/^\s*#/.test(l))
+    .map((l) => ({ indent: l.match(/^\s*/)[0].length, text: l.trim() }));
+
+  let failed = false;
+
+  // Parses the run of lines at `indent` starting at `i`; returns [value, next].
+  const parseBlock = (i, indent) => {
+    if (i >= lines.length) return [null, i];
+
+    if (lines[i].text.startsWith('- ')) {
+      const items = [];
+      while (i < lines.length && lines[i].indent === indent && lines[i].text.startsWith('- ')) {
+        // A sequence item is itself a mapping: `- name: Zbb`, or `- extension:`
+        // with its own indented body on the lines that follow.
+        const [value, next] = parseMapping(lines[i].text.slice(2), i, indent + 2);
+        items.push(value);
+        i = next;
+      }
+      return [items, i];
+    }
+
+    const out = {};
+    while (i < lines.length && lines[i].indent === indent) {
+      const [value, next] = parseMapping(lines[i].text, i, indent);
+      Object.assign(out, value);
+      i = next;
+    }
+    return [out, i];
   };
+
+  // `text` is one `key:` or `key: value`; `i` is its line, `indent` its column.
+  const parseMapping = (text, i, indent) => {
+    const m = text.match(/^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$/);
+    if (!m) {
+      failed = true;
+      return [{}, i + 1];
+    }
+    const [, key, scalar] = m;
+    if (scalar !== '') return [{ [key]: /^\d+$/.test(scalar) ? Number(scalar) : scalar }, i + 1];
+    // Nested: the body is whatever follows at a deeper indent.
+    const bodyIndent = lines[i + 1]?.indent;
+    if (bodyIndent == null || bodyIndent <= indent) {
+      failed = true;
+      return [{ [key]: null }, i + 1];
+    }
+    const [value, next] = parseBlock(i + 1, bodyIndent);
+    return [{ [key]: value }, next];
+  };
+
+  const [tree] = parseBlock(0, lines[0]?.indent ?? 0);
+  const owners = [...block.matchAll(/name:\s*([A-Za-z0-9_.]+)/g)].map((x) => x[1]);
+  return { owners, predicate: failed ? null : tree };
+}
+
+/** The XLEN a predicate pins, or null where it applies to both. */
+export function predicateXlen(predicate) {
+  if (!predicate || typeof predicate !== 'object') return null;
+  if (Array.isArray(predicate)) {
+    for (const item of predicate) {
+      const found = predicateXlen(item);
+      if (found != null) return found;
+    }
+    return null;
+  }
+  if (typeof predicate.xlen === 'number') return predicate.xlen;
+  // Only allOf propagates a condition unconditionally: an xlen inside anyOf is
+  // one alternative among several, not a requirement.
+  return predicateXlen(predicate.allOf ?? null);
+}
+
+export function parseUpstream(specDir) {
+  const readDefinedBy = (text) => parseDefinedBy(blockUnder(text, 'definedBy'));
 
   const extDir = path.join(specDir, 'ext');
   const extensions = [];
@@ -242,19 +324,28 @@ export function parseUpstream(specDir) {
       const text = fs.readFileSync(path.join(sub, file), 'utf8');
       const name = text.match(/^name:\s*(.+?)\s*$/m);
       const mnemonic = (name ? name[1] : file.replace(/\.yaml$/, '')).toUpperCase();
-      const owners = readDefinedBy(text);
+      const { owners, predicate } = readDefinedBy(text);
 
       // One entry per declared encoding: two where the file is XLEN-keyed.
       for (const enc of parseEncodings(text)) {
         instructions.push({
           mnemonic,
+          // An encoding may be XLEN-keyed (`encoding: RV32: …`), and ownership
+          // may be XLEN-conditioned (`definedBy: allOf: [ …, xlen: 64 ]`).
+          // They are different statements and either can be present alone, so
+          // both are carried rather than merged into one field.
           xlen: enc.xlen,
+          ownerXlen: predicateXlen(predicate),
           match: enc.match,
           mask: enc.mask,
           narrowedFields: enc.narrowed,
           // Fall back to the directory only when the file names no owner. An
           // empty array is truthy, so `|| [dir]` silently kept the empty list.
           definedBy: owners.length ? owners : [dir],
+          // The unflattened predicate, kept so a report can say WHY an
+          // instruction belongs where it does. null where the shape was not
+          // recognised, in which case only `definedBy` is trustworthy.
+          definedByPredicate: predicate,
         });
       }
     }
@@ -381,7 +472,33 @@ function main(argv) {
     console.log(list(result.malformed, (x) => `${x.extension} ${x.mnemonic}`));
   }
 
-  console.log(`\ncomplete: ${result.complete}`);
+  /*
+   * Two numbers, because they answer two questions and only the first one used
+   * to be reported. "Is the encoding in the catalogue anywhere" was passing at
+   * 100% while five extensions listed nothing at all — Zve32x, Zve32f, Zve64x,
+   * Zve64f and Zvkb each had every instruction present under V or Zvbb, and
+   * showed up here only as more attribution rows, which the gate never read.
+   */
+  const { coverage: cov } = result;
+  console.log(`\ncoverage over ${cov.considered} upstream encodings:`);
+  console.log(
+    `    global (present anywhere in the catalogue)   ` +
+      `${cov.global.covered}/${cov.considered}  ${cov.global.percent}%`,
+  );
+  console.log(
+    `    per-extension (listed by an owner upstream names)  ` +
+      `${cov.perExtension.covered}/${cov.considered}  ${cov.perExtension.percent}%`,
+  );
+  console.log(
+    `      filed elsewhere ${cov.perExtension.filedElsewhere}` +
+      `   encoding disagrees ${cov.perExtension.encodingDisagrees}` +
+      `   absent ${cov.perExtension.uncovered}`,
+  );
+
+  // Only global coverage gates. Attribution differences are often legitimate
+  // (unified-db files AMOCAS.B under Zabha, this catalogue under Zacas), so
+  // per-extension coverage is a number to watch, not a threshold to pass.
+  console.log(`\ncomplete: ${result.complete}   (global coverage; see the two numbers above)`);
   return result.complete ? 0 : 1;
 }
 

--- a/scripts/map-doc-links.mjs
+++ b/scripts/map-doc-links.mjs
@@ -79,6 +79,13 @@ const OTHER_SPECS = {
   Sdtrigepm: `${REF}/debug/index.html`,  Sdtrigpend: `${REF}/debug/index.html`,
   Ssqosid: `${REF}/cbqri/index.html`,    RERI: `${REF}/ras-eri/index.html`,
 
+  // SPMP is ratified but published only as a PDF attachment — there is no HTML
+  // chapter for it. /isa/extensions/sspmp/ and its index.html are both 404s,
+  // while the attachment resolves, so the attachment is the link.
+  Sspmp: `${REF}/isa/extensions/sspmp/_attachments/riscv-spmp.pdf`,
+  Sspmpen: `${REF}/isa/extensions/sspmp/_attachments/riscv-spmp.pdf`,
+  Smpmpdeleg: `${REF}/isa/extensions/sspmp/_attachments/riscv-spmp.pdf`,
+
   // RV128 is not served by the unversioned snapshot at all — /isa/unpriv/rv128
   // is a 404, as are rv128i, rv-128 and quad — while the dated v20240411 path
   // resolves. It is an unfrozen draft ("We have not frozen the RV128 spec at

--- a/scripts/seed-dependency-graph.mjs
+++ b/scripts/seed-dependency-graph.mjs
@@ -276,6 +276,21 @@ const LOCAL_EDGES = {
   // lists only Zve32f and Zfhmin, so this edge rests on clang plus the scalar
   // analogue rather than on UDB. Marked src:clang so the weaker backing shows.
   Zvfh:     [{ ext: 'Zvfhmin', src: 'clang', ref: 'clang -march=rv64i_zvfh implies +zvfhmin; UDB Zvfh.yaml is silent' }],
+
+  // The SPMP family, ratified 8/2026 as its own specification and absent from
+  // UDB entirely — so nothing above this line can produce these edges, and
+  // `npm run udb:check` cannot see the extensions are missing in the first
+  // place. Every edge below is quoted from the document.
+  Sspmp: [
+    { ext: 'Sscsrind', src: 'spec', ref: 'SPMP v1.0 §2.1 — "The Sscsrind extension for indirect CSR access must be implemented."' },
+  ],
+  Sspmpen: [
+    { ext: 'Sspmp', src: 'spec', ref: 'SPMP v1.0 §3 — an SPMP entry is active only when spmpen[i] is set and spmpcfg[i].A is non-zero' },
+  ],
+  Smpmpdeleg: [
+    { ext: 'Smcsrind', src: 'spec', ref: 'SPMP v1.0 §4 — "The Smcsrind extension for indirect CSR access must be implemented."' },
+    { ext: 'Sspmp', src: 'spec', ref: 'SPMP v1.0 §4.1 — delegates PMP entries to S-mode, "thereby creating SPMP entries"' },
+  ],
 };
 
 /** Base-ISA conflicts. Not dependencies, but they belong to the same graph. */
@@ -410,6 +425,10 @@ const graph = {
       repo: 'llvm/llvm-project',
       note: 'RISCVISAInfo implication, cited per edge; weaker backing than udb or isa-manual',
     },
+    // Ratified specifications published on their own, outside the ISA manual
+    // and outside UDB. SPMP is the whole of it today. Document and section are
+    // cited per edge because there is no single repository to name.
+    spec: { note: 'standalone ratified specification; document and section cited per edge' },
   },
   // Sorted so a regeneration produces a reviewable diff rather than a reshuffle.
   nodes: Object.fromEntries(

--- a/scripts/sync-profile-optional.mjs
+++ b/scripts/sync-profile-optional.mjs
@@ -23,12 +23,53 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+/*
+ * The families, and the UDB profiles each resolves from.
+ *
+ * The A and B families are U64+S64 pairs. RVI20 is unprivileged and has no
+ * supervisor half, so each of its two profiles stands alone — the second slot
+ * is simply absent, and resolve() returns {} for it.
+ *
+ * RVI20 matters more here than its size suggests: it mandates nothing beyond
+ * the base ISA, so ALL of its content is optional. Without an entry the builder
+ * offers no add-chips at all and the profile reads as empty rather than minimal.
+ */
 const PROFILE_PAIRS = {
+  RVI20U32: ['RVI20U32'],
+  /*
+   * RVI20U64 resolves from RVI20U32 rather than from its own file, because its
+   * file has no `extensions:` block at all — it inherits the whole document:
+   *
+   *   $inherits: "profile/RVI20U32.yaml#"
+   *
+   * Teaching resolve() to follow that generally is tempting and wrong. The A
+   * and B chains inherit from RVI20U64 too, and following it there re-admits
+   * Zca, Zcd, Zcf and Zifencei as RVA23 options, which the ratified profile
+   * does not list — SPEC_CHECK below catches it. Naming the parent here keeps
+   * the fix where the difference actually is.
+   */
+  RVI20U64: ['RVI20U32'],
   RVA20: ['RVA20U64', 'RVA20S64'],
   RVA22: ['RVA22U64', 'RVA22S64'],
   RVA23: ['RVA23U64', 'RVA23S64'],
   RVB23: ['RVB23U64', 'RVB23S64'],
 };
+
+/*
+ * Extensions that exist for one XLEN only, and the XLEN they belong to.
+ *
+ * UDB's RVI20U64 inherits RVI20U32 wholesale with no `$remove`, so Zcf — the
+ * compressed single-precision loads and stores, which the Zc specification
+ * defines for RV32 alone — is inherited into a 64-bit profile. Offering it
+ * there would put an unbuildable chip in front of the reader. The catalogue
+ * already carries the same fact in its tags: Zcf is `rv32_c_f`, while Zcd is
+ * `rv_c_d` and is correctly available to both.
+ */
+const XLEN_ONLY = { Zcf: 32 };
+
+/** The XLEN each family targets. Everything but RVI20U32 is 64-bit. */
+const FAMILY_XLEN = { RVI20U32: 32 };
+const xlenOf = (family) => FAMILY_XLEN[family] ?? 64;
 
 // From the ratified RVA23 profiles document. The resolver must reproduce these
 // exactly; if it cannot, the inheritance rules have changed upstream and the
@@ -146,6 +187,8 @@ for (const [family, [u, s]] of Object.entries(PROFILE_PAIRS)) {
   ]
     // An extension mandatory in either half is not optional for the pair.
     .filter((k) => !mandatory.has(k))
+    // ...nor is one that cannot exist at this profile's XLEN.
+    .filter((k) => !(k in XLEN_ONLY) || XLEN_ONLY[k] === xlenOf(family))
     .sort();
   optionalByFamily[family] = optional;
   void merged;

--- a/scripts/sync_instructions.mjs
+++ b/scripts/sync_instructions.mjs
@@ -90,6 +90,27 @@ const SPLIT_RULES = {
   ],
 
   // Vector FP subsets
+  /*
+   * Zvkb is the bit-manipulation subset the vector-crypto extensions share.
+   * riscv-opcodes has no `rv_zvkb` tag: upstream expresses the sharing by
+   * giving each of these nine forms three memberships (rv_zvbb, rv_zvkn,
+   * rv_zvks) instead. Tag routing therefore files them under Zvbb/Zvkn/Zvks
+   * and leaves Zvkb empty, so the subset has to be named here.
+   *
+   * Source: vector-crypto spec, "Zvkb - Vector Cryptography Bit-manipulation".
+   */
+  Zvkb: [
+    'VANDN.VV',
+    'VANDN.VX',
+    'VBREV8.V',
+    'VREV8.V',
+    'VROL.VV',
+    'VROL.VX',
+    'VROR.VI',
+    'VROR.VV',
+    'VROR.VX',
+  ],
+
   Zvfhmin: ['VFWCVT.F.F.V', 'VFNCVT.F.F.W'],
   Zvfh: [
     'VFADD.VV',
@@ -383,6 +404,138 @@ for (const entry of extEntries) {
     }
   }
   if (populated) tagsPopulated++;
+}
+
+// ---------------------------------------------------------------------------
+// Pass 1a-bis: Zve*, the embedded vector subsets.
+//
+// These five have no upstream instruction source at all. riscv-opcodes has no
+// `rv_zve*` tag (every vector encoding is `rv_v`), and unified-db attributes
+// all 627 of them to a single owner, Zvl32b. Neither says which instructions
+// each subset carries. The dependency graph cannot supply them either: V
+// *requires* Zve64d, so closure runs upward from the subsets to V and never
+// back down. Left alone, every Zve* tile reads "0 instructions", which is
+// wrong — Zve32x has hundreds.
+//
+// So the sets are derived here, from V, by the rules the specification states
+// in unpriv §30.1.18.2 ("Zve*: Vector Extensions for Embedded Processors").
+// That section does not enumerate mnemonics; it gives a table of supported
+// EEWs and FP types per extension, then says each subset supports *all*
+// configuration, load/store, integer, fixed-point, reduction, mask and
+// permutation instructions, carving out only what the EEW/FP limits exclude.
+// The rule applied below is that framing, made mechanical:
+//
+//   a mnemonic belongs to an extension iff at least one legal (SEW, EEW)
+//   configuration of it exists under that extension's supported EEW set and
+//   floating-point types.
+//
+// This is a DERIVATION, not a transcription — no upstream list exists to sync
+// against, and neither `npm run udb:check` nor the completeness gate can catch
+// an error in it. tests/zve-subsets.test.mjs pins the rules and the carve-outs
+// so a correction is a change to one rule rather than to 2,500 entries.
+// ---------------------------------------------------------------------------
+
+/**
+ * Vector floating-point instructions (§30.1.13, plus the FP reductions of
+ * §30.1.14.3 and the FP-operand permutes of §30.1.16).
+ *
+ * Two traps in the mnemonic spelling, both load-bearing:
+ *   - VFIRST.M is a *mask* instruction (find-first-set), not floating-point.
+ *   - VSEXT.VF2 / VZEXT.VF4 and friends are integer; the "VF" there is the
+ *     widening factor, not a float operand.
+ * The predicate is cross-checked in tests against the hand-curated Zvfh list,
+ * which is the same 101 mnemonics viewed at EEW=16.
+ */
+const isVectorFP = (m) => (/^VF/.test(m) && m !== 'VFIRST.M') || /^VMF/.test(m);
+
+/**
+ * Mnemonics that name EEW=64 in the opcode itself, so no legal configuration
+ * of them survives without EEW=64: the element loads/stores (VLE64.V,
+ * VLSEG8E64FF.V, the whole-register VL4RE64.V …) and the 64-bit indexed forms
+ * (VLOXEI64.V, VSUXSEG3EI64.V …). Everything else scales with SEW and stays.
+ */
+const isEew64Only = (m) => /E64/.test(m) || /EI64/.test(m);
+
+/**
+ * FP work that cannot be done without FP64, whatever the SEW.
+ *
+ * The widening FP arithmetic and the widening FP reductions produce a 2×SEW
+ * float; with FP32 as the widest type available that result is FP64, and the
+ * only alternative (2×SEW=32, i.e. FP16 sources) needs Zvfh, which is a
+ * separate extension. §30.1.18.2 says as much for the reductions outright:
+ * widening reductions from FP32 to FP64 are listed for Zve64d only.
+ * VFWCVT.F.F.V, VFNCVT.F.F.W and VFNCVT.ROD.F.F.W convert between two float
+ * widths and so need both.
+ */
+const isFp64Only = (m) =>
+  /^VFW(ADD|SUB|MUL|MACC|NMACC|MSAC|NMSAC)\./.test(m) ||
+  /^VFWRED(U|O)SUM\./.test(m) ||
+  m === 'VFWCVT.F.F.V' ||
+  m === 'VFNCVT.F.F.W' ||
+  m === 'VFNCVT.ROD.F.F.W';
+
+/**
+ * FP↔integer conversions whose integer side is 2×SEW, so they need an integer
+ * EEW of 64 even though they need no FP64: FP32→int64 widening and int64→FP32
+ * narrowing. Available under Zve64f, which has EEW=64 integers, but not under
+ * Zve32f, which stops at 32.
+ *
+ * Their mirror images stay in both — VFWCVT.F.X.V widens int16 to FP32, and
+ * VFNCVT.X.F.W narrows FP32 to int16, neither of which exceeds EEW=32.
+ */
+const needsEew64Integer = (m) =>
+  /^VFWCVT\.(RTZ\.)?XU?\.F\.V$/.test(m) || /^VFNCVT\.F\.XU?\.W$/.test(m);
+
+const vectorBase = extMap.get('V');
+assert(!!vectorBase, 'V must be populated before the Zve* subsets can be derived from it');
+
+if (vectorBase) {
+  const allVector = Object.entries(vectorBase.instructions);
+
+  // Supported EEW / FP per §30.1.18.2 Table 19, expressed as a membership test.
+  const ZVE_RULES = {
+    // EEW 8/16/32, no FP.
+    Zve32x: (m) => !isVectorFP(m) && !isEew64Only(m),
+    // EEW 8/16/32, FP32.
+    Zve32f: (m) =>
+      isVectorFP(m) ? !isFp64Only(m) && !needsEew64Integer(m) : !isEew64Only(m),
+    // EEW 8/16/32/64, no FP.
+    Zve64x: (m) => !isVectorFP(m),
+    // EEW 8/16/32/64, FP32.
+    Zve64f: (m) => (isVectorFP(m) ? !isFp64Only(m) : true),
+    // EEW 8/16/32/64, FP32 + FP64 — the same instruction set as V, which is
+    // defined as Zve64d plus a wider minimum VLEN (Zvl128b) and nothing else.
+    Zve64d: () => true,
+  };
+
+  for (const [id, belongs] of Object.entries(ZVE_RULES)) {
+    const entry = extMap.get(id);
+    assert(!!entry, `${id} must exist in the catalog to receive derived instructions`);
+    if (!entry) continue;
+    assert(
+      Object.keys(entry.instructions).length === 0,
+      `${id} now has an upstream instruction source. Remove this derivation.`,
+    );
+    for (const [mnemonic, details] of allVector) {
+      if (belongs(mnemonic)) entry.instructions[mnemonic] = JSON.parse(JSON.stringify(details));
+    }
+  }
+
+  // The subsets nest. Any rule change that breaks the chain is a bug, and the
+  // chain forks — Zve32f and Zve64x are both supersets of Zve32x but neither
+  // contains the other.
+  const setOf = (id) => new Set(Object.keys(extMap.get(id)?.instructions ?? {}));
+  for (const [sub, sup] of [
+    ['Zve32x', 'Zve32f'],
+    ['Zve32x', 'Zve64x'],
+    ['Zve32f', 'Zve64f'],
+    ['Zve64x', 'Zve64f'],
+    ['Zve64f', 'Zve64d'],
+  ]) {
+    const [a, b] = [setOf(sub), setOf(sup)];
+    const escaped = [...a].filter((m) => !b.has(m));
+    assert(escaped.length === 0, `${sub} must be a subset of ${sup}; ${escaped.join(', ')} is not`);
+  }
 }
 
 // Pass 1b: RV32 Shift Mask Injection (ISA Vol I §2.6)

--- a/scripts/sync_udb_extensions.cjs
+++ b/scripts/sync_udb_extensions.cjs
@@ -306,13 +306,35 @@ for (const [category, entries] of Object.entries(catalog)) {
 // We skip entries that already have csrs, behavior, or long_name — the
 // presence of long_name means a previous sync already processed this
 // extension (it may just not have enough UDB data for csrs/behavior).
+// ALWAYS_WATCH below is the exception: extensions UDB has never carried, which
+// that rule would otherwise drop the moment we describe them ourselves.
 const supervisorPattern = /^(Ss|Sm|Sv|Sd|Su|Sh|Sn)/;
+
+/*
+ * Extensions UDB does not model at all, kept on the watchlist by name.
+ *
+ * The rule above is a proxy for "nothing is known about this yet", and the SPMP
+ * family breaks it in both directions: these are ratified, their metadata was
+ * transcribed by hand from the specification PDF, and carrying a long_name is
+ * precisely what drops an entry off the derived list. So the one part of the
+ * catalogue where we are AHEAD of UDB is the one part this report would go
+ * quiet about — and the hand-written version, CSR addresses and ratification
+ * date would never be reconciled against upstream's once it catches up.
+ *
+ * Naming them keeps them in "Still missing from UDB" until UDB ships them, at
+ * which point this run populates them from upstream and the id can be dropped
+ * from this set. Everything here must match supervisorPattern.
+ */
+const ALWAYS_WATCH = new Set(['Sspmp', 'Sspmpen', 'Smpmpdeleg']);
+
 const gaps = [];
 for (const [id, loc] of entryIndex) {
   const entry = loc.entries[loc.index];
   if (!supervisorPattern.test(id)) continue;
-  if (entry.csrs || entry.behavior || entry.long_name) continue;
-  if (entry.tags && entry.tags.length > 0) continue;
+  if (!ALWAYS_WATCH.has(id)) {
+    if (entry.csrs || entry.behavior || entry.long_name) continue;
+    if (entry.tags && entry.tags.length > 0) continue;
+  }
   gaps.push(id);
 }
 

--- a/src/completeness.js
+++ b/src/completeness.js
@@ -192,11 +192,13 @@ export function compareAgainstUpstream(catalogue, upstream, options = {}) {
   const attributedDifferently = [];
   const coveredByBroaderRow = [];
   const encodingMismatches = [];
+  let considered = 0;
 
   for (const inst of upstream.instructions || []) {
     const mnemonic = inst.mnemonic.toUpperCase();
     if (allowMissingInstructions.includes(mnemonic)) continue;
     if (!upstreamIsRatified(inst)) continue;
+    considered++;
 
     /*
      * Only rows in an extension upstream attributes the instruction to are
@@ -304,6 +306,50 @@ export function compareAgainstUpstream(catalogue, upstream, options = {}) {
     .filter((r) => !encodingIsWellFormed(r))
     .map((r) => ({ mnemonic: r.mnemonic, extension: r.extension }));
 
+  /*
+   * TWO COVERAGE QUESTIONS, NOT ONE
+   *
+   * "Do we carry this encoding anywhere?" and "does the extension upstream
+   * attributes it to list it?" are different questions with different answers,
+   * and reporting only the first is how five real gaps passed this gate.
+   *
+   * Zve32x is the clearest: every one of its instructions is present in the
+   * catalogue, under V, so global coverage is perfect while the Zve32x entry
+   * itself listed nothing. Zvkb and Zilsd were the same shape. Each showed up
+   * here only as another attributedDifferently row among hundreds, and the
+   * `complete` flag never looked at that bucket.
+   *
+   * So both numbers are reported. Global coverage is the build gate, because a
+   * missing encoding is unambiguously a gap. Per-extension coverage is NOT a
+   * gate: attribution differences are frequently legitimate — unified-db puts
+   * AMOCAS.B under Zabha and this catalogue under Zacas, and both readings are
+   * defensible — so it is a number to watch move, not a threshold to pass.
+   */
+  const coveredInAttributedExtension =
+    considered -
+    encodingMismatches.length -
+    attributedDifferently.length -
+    missingInstructions.length;
+  const pct = (n) => (considered === 0 ? 100 : Math.round((n / considered) * 1000) / 10);
+
+  const coverage = {
+    considered,
+    // "Is the encoding in the catalogue at all?"
+    global: {
+      covered: considered - missingInstructions.length,
+      uncovered: missingInstructions.length,
+      percent: pct(considered - missingInstructions.length),
+    },
+    // "Does an extension upstream attributes it to actually list it?"
+    perExtension: {
+      covered: coveredInAttributedExtension,
+      filedElsewhere: attributedDifferently.length,
+      encodingDisagrees: encodingMismatches.length,
+      uncovered: missingInstructions.length,
+      percent: pct(coveredInAttributedExtension),
+    },
+  };
+
   return {
     missingExtensions,
     missingInstructions: missingInstructions.sort((a, b) => a.mnemonic.localeCompare(b.mnemonic)),
@@ -314,6 +360,14 @@ export function compareAgainstUpstream(catalogue, upstream, options = {}) {
     encodingMismatches,
     surplusInstructions,
     malformed,
+    coverage,
+    /*
+     * What `complete` does and does not assert, stated rather than implied.
+     * It is global coverage only. Encoding disagreements and malformed rows are
+     * reported beside it and deliberately excluded: REV8 legitimately carries
+     * two XLEN encodings under one upstream name, so gating on
+     * encodingMismatches would fail every run for a reason nobody can fix.
+     */
     complete: missingExtensions.length === 0 && missingInstructions.length === 0,
   };
 }

--- a/src/instr_dict.json
+++ b/src/instr_dict.json
@@ -1293,6 +1293,20 @@
     "match": "0x6000",
     "mask": "0xe003"
   },
+  "c_ld_rv32": {
+    "encoding": "----------------011----------000",
+    "variable_fields": [
+      "rd_p_e",
+      "rs1_p",
+      "c_uimm8lo",
+      "c_uimm8hi"
+    ],
+    "extension": [
+      "rv32_zclsd"
+    ],
+    "match": "0x6000",
+    "mask": "0xe007"
+  },
   "c_flwsp": {
     "encoding": "----------------011-----------10",
     "variable_fields": [
@@ -1305,6 +1319,19 @@
     ],
     "match": "0x6002",
     "mask": "0xe003"
+  },
+  "c_ldsp_rv32": {
+    "encoding": "----------------011-----0-----10",
+    "variable_fields": [
+      "rd_n0_e",
+      "c_uimm9sphi",
+      "c_uimm9splo"
+    ],
+    "extension": [
+      "rv32_zclsd"
+    ],
+    "match": "0x6002",
+    "mask": "0xe083"
   },
   "c_fsd": {
     "encoding": "----------------101-----------00",
@@ -1346,6 +1373,20 @@
     "match": "0xe000",
     "mask": "0xe003"
   },
+  "c_sd_rv32": {
+    "encoding": "----------------111----------000",
+    "variable_fields": [
+      "rs1_p",
+      "rs2_p_e",
+      "c_uimm8hi",
+      "c_uimm8lo"
+    ],
+    "extension": [
+      "rv32_zclsd"
+    ],
+    "match": "0xe000",
+    "mask": "0xe007"
+  },
   "c_fswsp": {
     "encoding": "----------------111-----------10",
     "variable_fields": [
@@ -1357,6 +1398,18 @@
     ],
     "match": "0xe002",
     "mask": "0xe003"
+  },
+  "c_sdsp_rv32": {
+    "encoding": "----------------111----------010",
+    "variable_fields": [
+      "c_rs2_e",
+      "c_uimm9sp_s"
+    ],
+    "extension": [
+      "rv32_zclsd"
+    ],
+    "match": "0xe002",
+    "mask": "0xe007"
   },
   "c_j": {
     "encoding": "----------------101-----------01",
@@ -4809,6 +4862,19 @@
     "match": "0x3003",
     "mask": "0x707f"
   },
+  "ld_rv32": {
+    "encoding": "-----------------011----00000011",
+    "variable_fields": [
+      "rd_e",
+      "rs1",
+      "imm12"
+    ],
+    "extension": [
+      "rv32_zilsd"
+    ],
+    "match": "0x3003",
+    "mask": "0x70ff"
+  },
   "ld_aq": {
     "encoding": "001101-00000-----011-----0101111",
     "variable_fields": [
@@ -5399,6 +5465,20 @@
     ],
     "match": "0x3023",
     "mask": "0x707f"
+  },
+  "sd_rv32": {
+    "encoding": "-----------0-----011-----0100011",
+    "variable_fields": [
+      "imm12hi",
+      "rs1",
+      "rs2_e",
+      "imm12lo"
+    ],
+    "extension": [
+      "rv32_zilsd"
+    ],
+    "match": "0x3023",
+    "mask": "0x10707f"
   },
   "sd_rl": {
     "encoding": "00111-1----------011000000101111",

--- a/src/isa-dependency-graph.json
+++ b/src/isa-dependency-graph.json
@@ -15,6 +15,9 @@
     "clang": {
       "repo": "llvm/llvm-project",
       "note": "RISCVISAInfo implication, cited per edge; weaker backing than udb or isa-manual"
+    },
+    "spec": {
+      "note": "standalone ratified specification; document and section cited per edge"
     }
   },
   "nodes": {
@@ -392,6 +395,20 @@
       "requires": [],
       "verified": "udb"
     },
+    "Smpmpdeleg": {
+      "requires": [
+        {
+          "ext": "Smcsrind",
+          "src": "spec",
+          "ref": "SPMP v1.0 §4 — \"The Smcsrind extension for indirect CSR access must be implemented.\""
+        },
+        {
+          "ext": "Sspmp",
+          "src": "spec",
+          "ref": "SPMP v1.0 §4.1 — delegates PMP entries to S-mode, \"thereby creating SPMP entries\""
+        }
+      ]
+    },
     "Smpmpmt": {
       "requires": [],
       "verified": "udb"
@@ -516,6 +533,24 @@
           "ext": "Smnpm",
           "src": "udb",
           "ref": "Sspm.yaml requirements.extension"
+        }
+      ]
+    },
+    "Sspmp": {
+      "requires": [
+        {
+          "ext": "Sscsrind",
+          "src": "spec",
+          "ref": "SPMP v1.0 §2.1 — \"The Sscsrind extension for indirect CSR access must be implemented.\""
+        }
+      ]
+    },
+    "Sspmpen": {
+      "requires": [
+        {
+          "ext": "Sspmp",
+          "src": "spec",
+          "ref": "SPMP v1.0 §3 — an SPMP entry is active only when spmpen[i] is set and spmpcfg[i].A is non-zero"
         }
       ]
     },

--- a/src/isaGraph.js
+++ b/src/isaGraph.js
@@ -33,8 +33,15 @@ import graphData from './isa-dependency-graph.json' with { type: 'json' };
 
 export const DEPENDENCY_GRAPH = graphData;
 
-/** Provenance values an edge may claim. An edge citing anything else is a bug. */
-export const EDGE_SOURCES = new Set(['udb', 'isa-manual', 'clang']);
+/**
+ * Provenance values an edge may claim. An edge citing anything else is a bug.
+ *
+ * 'spec' is for the ratified standalone specifications — the ones that are
+ * neither in the ISA manual nor modelled by unified-db. SPMP is the case that
+ * forced it: ratified 8/2026, absent from UDB, and its dependency on Sscsrind
+ * stated only in its own document. Cite document and section in `ref`.
+ */
+export const EDGE_SOURCES = new Set(['udb', 'isa-manual', 'clang', 'spec']);
 
 // ---------------------------------------------------------------------------
 // Derived views (same shape as the flat tables they replace)
@@ -100,7 +107,9 @@ export function validateGraph(graph = graphData, catalogIds = null) {
       if (seenTargets.has(edge.ext)) errors.push(`${id} -> ${edge.ext}: duplicate edge`);
       seenTargets.add(edge.ext);
       if (!EDGE_SOURCES.has(edge.src)) {
-        errors.push(`${id} -> ${edge.ext}: src "${edge.src}" is not one of ${[...EDGE_SOURCES].join(', ')}`);
+        errors.push(
+          `${id} -> ${edge.ext}: src "${edge.src}" is not one of ${[...EDGE_SOURCES].join(', ')}`,
+        );
       }
       // An uncited edge cannot be audited, and an unauditable graph is one
       // nobody can safely change later.
@@ -134,7 +143,12 @@ export function validateGraph(graph = graphData, catalogIds = null) {
       }
     }
 
-    if (requires.length === 0 && !node.requiresOneOf && !node.verified && !node.conditionalRequirements) {
+    if (
+      requires.length === 0 &&
+      !node.requiresOneOf &&
+      !node.verified &&
+      !node.conditionalRequirements
+    ) {
       warnings.push(`${id}: no dependencies and no "verified" marker — checked, or assumed?`);
     }
   }
@@ -145,7 +159,9 @@ export function validateGraph(graph = graphData, catalogIds = null) {
     const inGraph = new Set(ids);
     for (const id of catalogIds) {
       if (!inGraph.has(id)) {
-        errors.push(`${id} is in the catalog but has no graph node — add one to isa-dependency-graph.json`);
+        errors.push(
+          `${id} is in the catalog but has no graph node — add one to isa-dependency-graph.json`,
+        );
       }
     }
     const inCatalog = new Set(catalogIds);
@@ -396,8 +412,7 @@ export function resolveParams(ids, graph = graphData) {
         }
         case 'equal':
           if (existing.value !== prm.value) {
-            existing.conflict =
-              `${prm.name}: ${existing.from.join(' and ')} require ${existing.value} and ${prm.value}`;
+            existing.conflict = `${prm.name}: ${existing.from.join(' and ')} require ${existing.value} and ${prm.value}`;
           }
           break;
         default:

--- a/src/profile-optional.json
+++ b/src/profile-optional.json
@@ -1,4 +1,29 @@
 {
+  "RVI20U32": [
+    "A",
+    "C",
+    "D",
+    "F",
+    "M",
+    "Zca",
+    "Zcd",
+    "Zcf",
+    "Zicntr",
+    "Zifencei",
+    "Zihpm"
+  ],
+  "RVI20U64": [
+    "A",
+    "C",
+    "D",
+    "F",
+    "M",
+    "Zca",
+    "Zcd",
+    "Zicntr",
+    "Zifencei",
+    "Zihpm"
+  ],
   "RVA20": [
     "Ssu64xl",
     "Sv48"

--- a/src/profiles.js
+++ b/src/profiles.js
@@ -8,15 +8,37 @@
  * than an -march token). scripts/emit-march-matrix.mjs now emits a string per
  * profile so CI checks them against a real toolchain on every commit.
  *
- * Each entry lists the MANDATORY extensions of the profile's U64+S64 pair, by
- * catalog id. Dependencies are deliberately NOT expanded here: the graph does
- * that, so this stays a faithful transcription of the specification.
+ * Each entry lists the MANDATORY extensions of a profile, by catalog id.
+ * Dependencies are deliberately NOT expanded here: the graph does that, so
+ * this stays a faithful transcription of the specification.
+ *
+ * For the A and B families an entry is the profile's U64+S64 pair merged, so
+ * "RVA23" means RVA23U64 plus RVA23S64. RVI20 has no supervisor half, so its
+ * two profiles appear under their own names.
  */
 
 // ---------------------------------------------------------------------------
-// Profile Definitions – mandatory sets (U64+S64) for RVA20/22/23/RVB23
+// Profile Definitions – RVI20 (unprivileged), and the mandatory U64+S64 sets
+// for RVA20/22/23 and RVB23
 // ---------------------------------------------------------------------------
 export const PROFILES = {
+  /*
+   * RVI20U32 / RVI20U64 — the unprivileged profiles, and the floor of the
+   * whole scheme: "the minimum level of compatibility with RISC-V ratified
+   * standards" (Profiles v1.0 §4.1).
+   *
+   * Both lists are the base ISA alone, which is not an omission. §4.1.1.2 and
+   * §4.1.2.2 each read, in full, "There are no mandatory extensions for
+   * RVI20U32/RVI20U64." M, A, F, D, C, Zifencei, Zicntr and Zihpm are all
+   * *options* here, which is exactly what separates RVI20 from RVA20.
+   *
+   * They are also the only entries named U32/U64 rather than by family. The
+   * others below merge a U64 and an S64 profile under one name; RVI20 is
+   * unprivileged, has no supervisor half to merge, and exists in both XLENs.
+   */
+  RVI20U32: ['RV32I'],
+  RVI20U64: ['RV64I'],
+
   // RVA20U64 + RVA20S64 – baseline “RV64GC-like” profile
   RVA20: [
     'RV64I',

--- a/src/riscv_extensions.json
+++ b/src/riscv_extensions.json
@@ -18299,10 +18299,675 @@
       "name": "Zce",
       "short": "Embedded Compressed",
       "tags": [],
+      "members": [
+        "Zca",
+        "Zcb",
+        "Zcmp",
+        "Zcmt"
+      ],
       "desc": "Bundles the code-size-reduction Zc extensions that microcontroller-class cores are expected to implement.",
       "use": "RV32E/RV64E-focused compressed subset",
       "url": "https://docs.riscv.org/reference/isa/unpriv/zc.html",
-      "instructions": {},
+      "instructions": {
+        "C.ADDI4SPN": {
+          "encoding": "----------------000-----------00",
+          "variable_fields": [
+            "rd_p",
+            "c_nzuimm10"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x0",
+          "mask": "0xe003"
+        },
+        "C.LW": {
+          "encoding": "----------------010-----------00",
+          "variable_fields": [
+            "rd_p",
+            "rs1_p",
+            "c_uimm7lo",
+            "c_uimm7hi"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x4000",
+          "mask": "0xe003"
+        },
+        "C.SW": {
+          "encoding": "----------------110-----------00",
+          "variable_fields": [
+            "rs1_p",
+            "rs2_p",
+            "c_uimm7lo",
+            "c_uimm7hi"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0xc000",
+          "mask": "0xe003"
+        },
+        "C.NOP": {
+          "encoding": "----------------000-00000-----01",
+          "variable_fields": [
+            "c_nzimm6hi",
+            "c_nzimm6lo"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x1",
+          "mask": "0xef83"
+        },
+        "C.ADDI": {
+          "encoding": "----------------000-----------01",
+          "variable_fields": [
+            "rd_rs1_n0",
+            "c_nzimm6lo",
+            "c_nzimm6hi"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x1",
+          "mask": "0xe003"
+        },
+        "C.LI": {
+          "encoding": "----------------010-----------01",
+          "variable_fields": [
+            "rd_n0",
+            "c_imm6lo",
+            "c_imm6hi"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x4001",
+          "mask": "0xe003"
+        },
+        "C.ADDI16SP": {
+          "encoding": "----------------011-00010-----01",
+          "variable_fields": [
+            "c_nzimm10hi",
+            "c_nzimm10lo"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x6101",
+          "mask": "0xef83"
+        },
+        "C.LUI": {
+          "encoding": "----------------011-----------01",
+          "variable_fields": [
+            "rd_n2",
+            "c_nzimm18hi",
+            "c_nzimm18lo"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x6001",
+          "mask": "0xe003"
+        },
+        "C.ANDI": {
+          "encoding": "----------------100-10--------01",
+          "variable_fields": [
+            "rd_rs1_p",
+            "c_imm6hi",
+            "c_imm6lo"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x8801",
+          "mask": "0xec03"
+        },
+        "C.SUB": {
+          "encoding": "----------------100011---00---01",
+          "variable_fields": [
+            "rd_rs1_p",
+            "rs2_p"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x8c01",
+          "mask": "0xfc63"
+        },
+        "C.XOR": {
+          "encoding": "----------------100011---01---01",
+          "variable_fields": [
+            "rd_rs1_p",
+            "rs2_p"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x8c21",
+          "mask": "0xfc63"
+        },
+        "C.OR": {
+          "encoding": "----------------100011---10---01",
+          "variable_fields": [
+            "rd_rs1_p",
+            "rs2_p"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x8c41",
+          "mask": "0xfc63"
+        },
+        "C.AND": {
+          "encoding": "----------------100011---11---01",
+          "variable_fields": [
+            "rd_rs1_p",
+            "rs2_p"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x8c61",
+          "mask": "0xfc63"
+        },
+        "C.ADD": {
+          "encoding": "----------------1001----------10",
+          "variable_fields": [
+            "rd_rs1_n0",
+            "c_rs2_n0"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x9002",
+          "mask": "0xf003"
+        },
+        "C.J": {
+          "encoding": "----------------101-----------01",
+          "variable_fields": [
+            "c_imm12"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0xa001",
+          "mask": "0xe003"
+        },
+        "C.BEQZ": {
+          "encoding": "----------------110-----------01",
+          "variable_fields": [
+            "rs1_p",
+            "c_bimm9lo",
+            "c_bimm9hi"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0xc001",
+          "mask": "0xe003"
+        },
+        "C.BNEZ": {
+          "encoding": "----------------111-----------01",
+          "variable_fields": [
+            "rs1_p",
+            "c_bimm9lo",
+            "c_bimm9hi"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0xe001",
+          "mask": "0xe003"
+        },
+        "C.LWSP": {
+          "encoding": "----------------010-----------10",
+          "variable_fields": [
+            "rd_n0",
+            "c_uimm8sphi",
+            "c_uimm8splo"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x4002",
+          "mask": "0xe003"
+        },
+        "C.SWSP": {
+          "encoding": "----------------110-----------10",
+          "variable_fields": [
+            "c_rs2",
+            "c_uimm8sp_s"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0xc002",
+          "mask": "0xe003"
+        },
+        "C.JR": {
+          "encoding": "----------------1000-----0000010",
+          "variable_fields": [
+            "rs1_n0"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x8002",
+          "mask": "0xf07f"
+        },
+        "C.MV": {
+          "encoding": "----------------1000----------10",
+          "variable_fields": [
+            "rd_n0",
+            "c_rs2_n0"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x8002",
+          "mask": "0xf003"
+        },
+        "C.EBREAK": {
+          "encoding": "----------------1001000000000010",
+          "variable_fields": [],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x9002",
+          "mask": "0xffff"
+        },
+        "C.JALR": {
+          "encoding": "----------------1001-----0000010",
+          "variable_fields": [
+            "c_rs1_n0"
+          ],
+          "extension": [
+            "rv_c"
+          ],
+          "match": "0x9002",
+          "mask": "0xf07f"
+        },
+        "C.JAL": {
+          "encoding": "----------------001-----------01",
+          "variable_fields": [
+            "c_imm12"
+          ],
+          "extension": [
+            "rv32_c"
+          ],
+          "match": "0x2001",
+          "mask": "0xe003"
+        },
+        "C.LD": {
+          "encoding": "----------------011-----------00",
+          "variable_fields": [
+            "rd_p",
+            "rs1_p",
+            "c_uimm8lo",
+            "c_uimm8hi"
+          ],
+          "extension": [
+            "rv64_c"
+          ],
+          "match": "0x6000",
+          "mask": "0xe003"
+        },
+        "C.SD": {
+          "encoding": "----------------111-----------00",
+          "variable_fields": [
+            "rs1_p",
+            "rs2_p",
+            "c_uimm8hi",
+            "c_uimm8lo"
+          ],
+          "extension": [
+            "rv64_c"
+          ],
+          "match": "0xe000",
+          "mask": "0xe003"
+        },
+        "C.LDSP": {
+          "encoding": "----------------011-----------10",
+          "variable_fields": [
+            "rd_n0",
+            "c_uimm9sphi",
+            "c_uimm9splo"
+          ],
+          "extension": [
+            "rv64_c"
+          ],
+          "match": "0x6002",
+          "mask": "0xe003"
+        },
+        "C.SDSP": {
+          "encoding": "----------------111-----------10",
+          "variable_fields": [
+            "c_rs2",
+            "c_uimm9sp_s"
+          ],
+          "extension": [
+            "rv64_c"
+          ],
+          "match": "0xe002",
+          "mask": "0xe003"
+        },
+        "C.ADDIW": {
+          "encoding": "----------------001-----------01",
+          "variable_fields": [
+            "rd_rs1_n0",
+            "c_imm6lo",
+            "c_imm6hi"
+          ],
+          "extension": [
+            "rv64_c"
+          ],
+          "match": "0x2001",
+          "mask": "0xe003"
+        },
+        "C.ADDW": {
+          "encoding": "----------------100111---01---01",
+          "variable_fields": [
+            "rd_rs1_p",
+            "rs2_p"
+          ],
+          "extension": [
+            "rv64_c"
+          ],
+          "match": "0x9c21",
+          "mask": "0xfc63"
+        },
+        "C.SUBW": {
+          "encoding": "----------------100111---00---01",
+          "variable_fields": [
+            "rd_rs1_p",
+            "rs2_p"
+          ],
+          "extension": [
+            "rv64_c"
+          ],
+          "match": "0x9c01",
+          "mask": "0xfc63"
+        },
+        "C.SLLI": {
+          "encoding": "----------------000-----------10",
+          "variable_fields": [
+            "rd_rs1_n0",
+            "c_nzuimm6hi",
+            "c_nzuimm6lo"
+          ],
+          "extension": [
+            "rv64_c"
+          ],
+          "match": "0x2",
+          "mask": "0xe003"
+        },
+        "C.SRLI": {
+          "encoding": "----------------100-00--------01",
+          "variable_fields": [
+            "rd_rs1_p",
+            "c_nzuimm6lo",
+            "c_nzuimm6hi"
+          ],
+          "extension": [
+            "rv64_c"
+          ],
+          "match": "0x8001",
+          "mask": "0xec03"
+        },
+        "C.SRAI": {
+          "encoding": "----------------100-01--------01",
+          "variable_fields": [
+            "rd_rs1_p",
+            "c_nzuimm6lo",
+            "c_nzuimm6hi"
+          ],
+          "extension": [
+            "rv64_c"
+          ],
+          "match": "0x8401",
+          "mask": "0xec03"
+        },
+        "C.ZEXT.W": {
+          "encoding": "----------------100111---1110001",
+          "variable_fields": [
+            "rd_rs1_p"
+          ],
+          "extension": [
+            "rv64_zcb"
+          ],
+          "match": "0x9c71",
+          "mask": "0xfc7f"
+        },
+        "C.LBU": {
+          "encoding": "----------------100000--------00",
+          "variable_fields": [
+            "rd_p",
+            "rs1_p",
+            "c_uimm2"
+          ],
+          "extension": [
+            "rv_zcb"
+          ],
+          "match": "0x8000",
+          "mask": "0xfc03"
+        },
+        "C.LH": {
+          "encoding": "----------------100001---1----00",
+          "variable_fields": [
+            "rd_p",
+            "rs1_p",
+            "c_uimm1"
+          ],
+          "extension": [
+            "rv_zcb"
+          ],
+          "match": "0x8440",
+          "mask": "0xfc43"
+        },
+        "C.LHU": {
+          "encoding": "----------------100001---0----00",
+          "variable_fields": [
+            "rd_p",
+            "rs1_p",
+            "c_uimm1"
+          ],
+          "extension": [
+            "rv_zcb"
+          ],
+          "match": "0x8400",
+          "mask": "0xfc43"
+        },
+        "C.MUL": {
+          "encoding": "----------------100111---10---01",
+          "variable_fields": [
+            "rd_rs1_p",
+            "rs2_p"
+          ],
+          "extension": [
+            "rv_zcb"
+          ],
+          "match": "0x9c41",
+          "mask": "0xfc63"
+        },
+        "C.NOT": {
+          "encoding": "----------------100111---1110101",
+          "variable_fields": [
+            "rd_rs1_p"
+          ],
+          "extension": [
+            "rv_zcb"
+          ],
+          "match": "0x9c75",
+          "mask": "0xfc7f"
+        },
+        "C.SB": {
+          "encoding": "----------------100010--------00",
+          "variable_fields": [
+            "rs2_p",
+            "rs1_p",
+            "c_uimm2"
+          ],
+          "extension": [
+            "rv_zcb"
+          ],
+          "match": "0x8800",
+          "mask": "0xfc03"
+        },
+        "C.SEXT.B": {
+          "encoding": "----------------100111---1100101",
+          "variable_fields": [
+            "rd_rs1_p"
+          ],
+          "extension": [
+            "rv_zcb"
+          ],
+          "match": "0x9c65",
+          "mask": "0xfc7f"
+        },
+        "C.SEXT.H": {
+          "encoding": "----------------100111---1101101",
+          "variable_fields": [
+            "rd_rs1_p"
+          ],
+          "extension": [
+            "rv_zcb"
+          ],
+          "match": "0x9c6d",
+          "mask": "0xfc7f"
+        },
+        "C.SH": {
+          "encoding": "----------------100011---0----00",
+          "variable_fields": [
+            "rs2_p",
+            "rs1_p",
+            "c_uimm1"
+          ],
+          "extension": [
+            "rv_zcb"
+          ],
+          "match": "0x8c00",
+          "mask": "0xfc43"
+        },
+        "C.ZEXT.B": {
+          "encoding": "----------------100111---1100001",
+          "variable_fields": [
+            "rd_rs1_p"
+          ],
+          "extension": [
+            "rv_zcb"
+          ],
+          "match": "0x9c61",
+          "mask": "0xfc7f"
+        },
+        "C.ZEXT.H": {
+          "encoding": "----------------100111---1101001",
+          "variable_fields": [
+            "rd_rs1_p"
+          ],
+          "extension": [
+            "rv_zcb"
+          ],
+          "match": "0x9c69",
+          "mask": "0xfc7f"
+        },
+        "CM.MVA01S": {
+          "encoding": "----------------101011---11---10",
+          "variable_fields": [
+            "c_sreg1",
+            "c_sreg2"
+          ],
+          "extension": [
+            "rv_zcmp"
+          ],
+          "match": "0xac62",
+          "mask": "0xfc63"
+        },
+        "CM.MVSA01": {
+          "encoding": "----------------101011---01---10",
+          "variable_fields": [
+            "c_sreg1",
+            "c_sreg2"
+          ],
+          "extension": [
+            "rv_zcmp"
+          ],
+          "match": "0xac22",
+          "mask": "0xfc63"
+        },
+        "CM.POP": {
+          "encoding": "----------------10111010------10",
+          "variable_fields": [
+            "c_rlist",
+            "c_spimm"
+          ],
+          "extension": [
+            "rv_zcmp"
+          ],
+          "match": "0xba02",
+          "mask": "0xff03"
+        },
+        "CM.POPRET": {
+          "encoding": "----------------10111110------10",
+          "variable_fields": [
+            "c_rlist",
+            "c_spimm"
+          ],
+          "extension": [
+            "rv_zcmp"
+          ],
+          "match": "0xbe02",
+          "mask": "0xff03"
+        },
+        "CM.POPRETZ": {
+          "encoding": "----------------10111100------10",
+          "variable_fields": [
+            "c_rlist",
+            "c_spimm"
+          ],
+          "extension": [
+            "rv_zcmp"
+          ],
+          "match": "0xbc02",
+          "mask": "0xff03"
+        },
+        "CM.PUSH": {
+          "encoding": "----------------10111000------10",
+          "variable_fields": [
+            "c_rlist",
+            "c_spimm"
+          ],
+          "extension": [
+            "rv_zcmp"
+          ],
+          "match": "0xb802",
+          "mask": "0xff03"
+        },
+        "CM.JT": {
+          "encoding": "----------------101000000-----10",
+          "variable_fields": [
+            "c_index"
+          ],
+          "extension": [
+            "rv_zcmt"
+          ],
+          "match": "0xa002",
+          "mask": "0xff83"
+        },
+        "CM.JALT": {
+          "encoding": "----------------101000--------10",
+          "variable_fields": [
+            "c_index"
+          ],
+          "extension": [
+            "rv_zcmt"
+          ],
+          "match": "0xa002",
+          "mask": "0xfc03"
+        }
+      },
       "state": "ratified",
       "ratification_date": "2023-04",
       "version": "1.0.0"
@@ -18602,11 +19267,67 @@
       "id": "Zclsd",
       "name": "Zclsd",
       "short": "Compressed LS-Pair",
-      "tags": [],
+      "tags": [
+        "rv32_zclsd"
+      ],
       "desc": "Loads or stores a register pair in a single 16-bit RV32 instruction, cutting code size further.",
       "use": "Compressed load/store pairs",
       "url": "https://docs.riscv.org/reference/isa/unpriv/zilsd.html",
-      "instructions": {},
+      "instructions": {
+        "C.LD.RV32": {
+          "encoding": "----------------011----------000",
+          "variable_fields": [
+            "rd_p_e",
+            "rs1_p",
+            "c_uimm8lo",
+            "c_uimm8hi"
+          ],
+          "extension": [
+            "rv32_zclsd"
+          ],
+          "match": "0x6000",
+          "mask": "0xe007"
+        },
+        "C.LDSP.RV32": {
+          "encoding": "----------------011-----0-----10",
+          "variable_fields": [
+            "rd_n0_e",
+            "c_uimm9sphi",
+            "c_uimm9splo"
+          ],
+          "extension": [
+            "rv32_zclsd"
+          ],
+          "match": "0x6002",
+          "mask": "0xe083"
+        },
+        "C.SD.RV32": {
+          "encoding": "----------------111----------000",
+          "variable_fields": [
+            "rs1_p",
+            "rs2_p_e",
+            "c_uimm8hi",
+            "c_uimm8lo"
+          ],
+          "extension": [
+            "rv32_zclsd"
+          ],
+          "match": "0xe000",
+          "mask": "0xe007"
+        },
+        "C.SDSP.RV32": {
+          "encoding": "----------------111----------010",
+          "variable_fields": [
+            "c_rs2_e",
+            "c_uimm9sp_s"
+          ],
+          "extension": [
+            "rv32_zclsd"
+          ],
+          "match": "0xe002",
+          "mask": "0xe007"
+        }
+      },
       "state": "ratified",
       "ratification_date": "2025-02",
       "version": "1.0"
@@ -20811,11 +21532,41 @@
       "id": "Zilsd",
       "name": "Zilsd",
       "short": "Load/Store Pair for RV32",
-      "tags": [],
+      "tags": [
+        "rv32_zilsd"
+      ],
       "desc": "Loads or stores an even-odd register pair in one RV32 instruction instead of two separate accesses.",
       "use": "Streaming loads/stores (data)",
       "url": "https://docs.riscv.org/reference/isa/unpriv/zilsd.html",
-      "instructions": {},
+      "instructions": {
+        "LD.RV32": {
+          "encoding": "-----------------011----00000011",
+          "variable_fields": [
+            "rd_e",
+            "rs1",
+            "imm12"
+          ],
+          "extension": [
+            "rv32_zilsd"
+          ],
+          "match": "0x3003",
+          "mask": "0x70ff"
+        },
+        "SD.RV32": {
+          "encoding": "-----------0-----011-----0100011",
+          "variable_fields": [
+            "imm12hi",
+            "rs1",
+            "rs2_e",
+            "imm12lo"
+          ],
+          "extension": [
+            "rv32_zilsd"
+          ],
+          "match": "0x3023",
+          "mask": "0x10707f"
+        }
+      },
       "state": "ratified",
       "ratification_date": "2025-02",
       "version": "1.0"
@@ -20963,7 +21714,6138 @@
       "desc": "Integer, fixed-point, mask, and permute vector operations on elements up to 32 bits, with no floating-point needed.",
       "use": "Int-only embedded vectors",
       "url": "https://docs.riscv.org/reference/isa/unpriv/v-st-ext.html",
-      "instructions": {},
+      "instructions": {
+        "VAADD.VV": {
+          "encoding": "001001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24002057",
+          "mask": "0xfc00707f"
+        },
+        "VAADD.VX": {
+          "encoding": "001001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006057",
+          "mask": "0xfc00707f"
+        },
+        "VAADDU.VV": {
+          "encoding": "001000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20002057",
+          "mask": "0xfc00707f"
+        },
+        "VAADDU.VX": {
+          "encoding": "001000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006057",
+          "mask": "0xfc00707f"
+        },
+        "VADC.VIM": {
+          "encoding": "0100000----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40003057",
+          "mask": "0xfe00707f"
+        },
+        "VADC.VVM": {
+          "encoding": "0100000----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000057",
+          "mask": "0xfe00707f"
+        },
+        "VADC.VXM": {
+          "encoding": "0100000----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40004057",
+          "mask": "0xfe00707f"
+        },
+        "VADD.VI": {
+          "encoding": "000000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3057",
+          "mask": "0xfc00707f"
+        },
+        "VADD.VV": {
+          "encoding": "000000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x57",
+          "mask": "0xfc00707f"
+        },
+        "VADD.VX": {
+          "encoding": "000000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VI": {
+          "encoding": "001001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24003057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VV": {
+          "encoding": "001001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VX": {
+          "encoding": "001001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24004057",
+          "mask": "0xfc00707f"
+        },
+        "VASUB.VV": {
+          "encoding": "001011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c002057",
+          "mask": "0xfc00707f"
+        },
+        "VASUB.VX": {
+          "encoding": "001011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006057",
+          "mask": "0xfc00707f"
+        },
+        "VASUBU.VV": {
+          "encoding": "001010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28002057",
+          "mask": "0xfc00707f"
+        },
+        "VASUBU.VX": {
+          "encoding": "001010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006057",
+          "mask": "0xfc00707f"
+        },
+        "VCOMPRESS.VM": {
+          "encoding": "0101111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e002057",
+          "mask": "0xfe00707f"
+        },
+        "VCPOP.M": {
+          "encoding": "010000------10000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40082057",
+          "mask": "0xfc0ff07f"
+        },
+        "VDIV.VV": {
+          "encoding": "100001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84002057",
+          "mask": "0xfc00707f"
+        },
+        "VDIV.VX": {
+          "encoding": "100001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006057",
+          "mask": "0xfc00707f"
+        },
+        "VDIVU.VV": {
+          "encoding": "100000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80002057",
+          "mask": "0xfc00707f"
+        },
+        "VDIVU.VX": {
+          "encoding": "100000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006057",
+          "mask": "0xfc00707f"
+        },
+        "VFIRST.M": {
+          "encoding": "010000------10001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4008a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VID.V": {
+          "encoding": "010100-0000010001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5008a057",
+          "mask": "0xfdfff07f"
+        },
+        "VIOTA.M": {
+          "encoding": "010100------10000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x50082057",
+          "mask": "0xfc0ff07f"
+        },
+        "VL1RE16.V": {
+          "encoding": "000000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2805007",
+          "mask": "0xfff0707f"
+        },
+        "VL1RE32.V": {
+          "encoding": "000000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2806007",
+          "mask": "0xfff0707f"
+        },
+        "VL1RE8.V": {
+          "encoding": "000000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2800007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE16.V": {
+          "encoding": "001000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22805007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE32.V": {
+          "encoding": "001000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22806007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE8.V": {
+          "encoding": "001000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22800007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE16.V": {
+          "encoding": "011000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62805007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE32.V": {
+          "encoding": "011000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62806007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE8.V": {
+          "encoding": "011000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62800007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE16.V": {
+          "encoding": "111000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2805007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE32.V": {
+          "encoding": "111000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2806007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE8.V": {
+          "encoding": "111000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2800007",
+          "mask": "0xfff0707f"
+        },
+        "VLE16.V": {
+          "encoding": "000000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E16.V": {
+          "encoding": "001000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E16.V": {
+          "encoding": "010000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E16.V": {
+          "encoding": "011000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E16.V": {
+          "encoding": "100000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E16.V": {
+          "encoding": "101000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E16.V": {
+          "encoding": "110000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E16.V": {
+          "encoding": "111000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE16FF.V": {
+          "encoding": "000000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E16FF.V": {
+          "encoding": "001000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E16FF.V": {
+          "encoding": "010000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E16FF.V": {
+          "encoding": "011000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E16FF.V": {
+          "encoding": "100000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E16FF.V": {
+          "encoding": "101000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E16FF.V": {
+          "encoding": "110000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E16FF.V": {
+          "encoding": "111000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE32.V": {
+          "encoding": "000000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E32.V": {
+          "encoding": "001000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E32.V": {
+          "encoding": "010000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E32.V": {
+          "encoding": "011000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E32.V": {
+          "encoding": "100000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E32.V": {
+          "encoding": "101000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E32.V": {
+          "encoding": "110000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E32.V": {
+          "encoding": "111000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE32FF.V": {
+          "encoding": "000000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E32FF.V": {
+          "encoding": "001000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E32FF.V": {
+          "encoding": "010000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E32FF.V": {
+          "encoding": "011000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E32FF.V": {
+          "encoding": "100000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E32FF.V": {
+          "encoding": "101000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E32FF.V": {
+          "encoding": "110000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E32FF.V": {
+          "encoding": "111000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE8.V": {
+          "encoding": "000000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E8.V": {
+          "encoding": "001000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E8.V": {
+          "encoding": "010000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E8.V": {
+          "encoding": "011000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E8.V": {
+          "encoding": "100000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E8.V": {
+          "encoding": "101000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E8.V": {
+          "encoding": "110000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E8.V": {
+          "encoding": "111000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE8FF.V": {
+          "encoding": "000000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E8FF.V": {
+          "encoding": "001000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E8FF.V": {
+          "encoding": "010000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E8FF.V": {
+          "encoding": "011000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E8FF.V": {
+          "encoding": "100000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E8FF.V": {
+          "encoding": "101000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E8FF.V": {
+          "encoding": "110000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E8FF.V": {
+          "encoding": "111000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLM.V": {
+          "encoding": "000000101011-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2b00007",
+          "mask": "0xfff0707f"
+        },
+        "VLOXEI16.V": {
+          "encoding": "000011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI16.V": {
+          "encoding": "001011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI16.V": {
+          "encoding": "010011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI16.V": {
+          "encoding": "011011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI16.V": {
+          "encoding": "100011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI16.V": {
+          "encoding": "101011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI16.V": {
+          "encoding": "110011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI16.V": {
+          "encoding": "111011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXEI32.V": {
+          "encoding": "000011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI32.V": {
+          "encoding": "001011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI32.V": {
+          "encoding": "010011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI32.V": {
+          "encoding": "011011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI32.V": {
+          "encoding": "100011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI32.V": {
+          "encoding": "101011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI32.V": {
+          "encoding": "110011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI32.V": {
+          "encoding": "111011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXEI8.V": {
+          "encoding": "000011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI8.V": {
+          "encoding": "001011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI8.V": {
+          "encoding": "010011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI8.V": {
+          "encoding": "011011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI8.V": {
+          "encoding": "100011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI8.V": {
+          "encoding": "101011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI8.V": {
+          "encoding": "110011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI8.V": {
+          "encoding": "111011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE16.V": {
+          "encoding": "000010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E16.V": {
+          "encoding": "001010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E16.V": {
+          "encoding": "010010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E16.V": {
+          "encoding": "011010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E16.V": {
+          "encoding": "100010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E16.V": {
+          "encoding": "101010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E16.V": {
+          "encoding": "110010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E16.V": {
+          "encoding": "111010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE32.V": {
+          "encoding": "000010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E32.V": {
+          "encoding": "001010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E32.V": {
+          "encoding": "010010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E32.V": {
+          "encoding": "011010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E32.V": {
+          "encoding": "100010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E32.V": {
+          "encoding": "101010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E32.V": {
+          "encoding": "110010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E32.V": {
+          "encoding": "111010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE8.V": {
+          "encoding": "000010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E8.V": {
+          "encoding": "001010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E8.V": {
+          "encoding": "010010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E8.V": {
+          "encoding": "011010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E8.V": {
+          "encoding": "100010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E8.V": {
+          "encoding": "101010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E8.V": {
+          "encoding": "110010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E8.V": {
+          "encoding": "111010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI16.V": {
+          "encoding": "000001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI16.V": {
+          "encoding": "001001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI16.V": {
+          "encoding": "010001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI16.V": {
+          "encoding": "011001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI16.V": {
+          "encoding": "100001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI16.V": {
+          "encoding": "101001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI16.V": {
+          "encoding": "110001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI16.V": {
+          "encoding": "111001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI32.V": {
+          "encoding": "000001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI32.V": {
+          "encoding": "001001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI32.V": {
+          "encoding": "010001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI32.V": {
+          "encoding": "011001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI32.V": {
+          "encoding": "100001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI32.V": {
+          "encoding": "101001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI32.V": {
+          "encoding": "110001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI32.V": {
+          "encoding": "111001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI8.V": {
+          "encoding": "000001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI8.V": {
+          "encoding": "001001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI8.V": {
+          "encoding": "010001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI8.V": {
+          "encoding": "011001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI8.V": {
+          "encoding": "100001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI8.V": {
+          "encoding": "101001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI8.V": {
+          "encoding": "110001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI8.V": {
+          "encoding": "111001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4000007",
+          "mask": "0xfc00707f"
+        },
+        "VMACC.VV": {
+          "encoding": "101101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4002057",
+          "mask": "0xfc00707f"
+        },
+        "VMACC.VX": {
+          "encoding": "101101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4006057",
+          "mask": "0xfc00707f"
+        },
+        "VMADC.VI": {
+          "encoding": "0100011----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46003057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VIM": {
+          "encoding": "0100010----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44003057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VV": {
+          "encoding": "0100011----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46000057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VVM": {
+          "encoding": "0100010----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VX": {
+          "encoding": "0100011----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46004057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VXM": {
+          "encoding": "0100010----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44004057",
+          "mask": "0xfe00707f"
+        },
+        "VMADD.VV": {
+          "encoding": "101001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4002057",
+          "mask": "0xfc00707f"
+        },
+        "VMADD.VX": {
+          "encoding": "101001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006057",
+          "mask": "0xfc00707f"
+        },
+        "VMAND.MM": {
+          "encoding": "0110011----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x66002057",
+          "mask": "0xfe00707f"
+        },
+        "VMANDN.MM": {
+          "encoding": "0110001----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62002057",
+          "mask": "0xfe00707f"
+        },
+        "VMAX.VV": {
+          "encoding": "000111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c000057",
+          "mask": "0xfc00707f"
+        },
+        "VMAX.VX": {
+          "encoding": "000111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMAXU.VV": {
+          "encoding": "000110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18000057",
+          "mask": "0xfc00707f"
+        },
+        "VMAXU.VX": {
+          "encoding": "000110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18004057",
+          "mask": "0xfc00707f"
+        },
+        "VMERGE.VIM": {
+          "encoding": "0101110----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c003057",
+          "mask": "0xfe00707f"
+        },
+        "VMERGE.VVM": {
+          "encoding": "0101110----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c000057",
+          "mask": "0xfe00707f"
+        },
+        "VMERGE.VXM": {
+          "encoding": "0101110----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c004057",
+          "mask": "0xfe00707f"
+        },
+        "VMIN.VV": {
+          "encoding": "000101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14000057",
+          "mask": "0xfc00707f"
+        },
+        "VMIN.VX": {
+          "encoding": "000101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14004057",
+          "mask": "0xfc00707f"
+        },
+        "VMINU.VV": {
+          "encoding": "000100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10000057",
+          "mask": "0xfc00707f"
+        },
+        "VMINU.VX": {
+          "encoding": "000100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10004057",
+          "mask": "0xfc00707f"
+        },
+        "VMNAND.MM": {
+          "encoding": "0111011----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x76002057",
+          "mask": "0xfe00707f"
+        },
+        "VMNOR.MM": {
+          "encoding": "0111101----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7a002057",
+          "mask": "0xfe00707f"
+        },
+        "VMOR.MM": {
+          "encoding": "0110101----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6a002057",
+          "mask": "0xfe00707f"
+        },
+        "VMORN.MM": {
+          "encoding": "0111001----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x72002057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VV": {
+          "encoding": "0100111----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4e000057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VVM": {
+          "encoding": "0100110----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VX": {
+          "encoding": "0100111----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4e004057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VXM": {
+          "encoding": "0100110----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c004057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBF.M": {
+          "encoding": "010100------00001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5000a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMSEQ.VI": {
+          "encoding": "011000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSEQ.VV": {
+          "encoding": "011000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSEQ.VX": {
+          "encoding": "011000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGT.VI": {
+          "encoding": "011111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7c003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGT.VX": {
+          "encoding": "011111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGTU.VI": {
+          "encoding": "011110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x78003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGTU.VX": {
+          "encoding": "011110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x78004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSIF.M": {
+          "encoding": "010100------00011010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5001a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMSLE.VI": {
+          "encoding": "011101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLE.VV": {
+          "encoding": "011101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLE.VX": {
+          "encoding": "011101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VI": {
+          "encoding": "011100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VV": {
+          "encoding": "011100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VX": {
+          "encoding": "011100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLT.VV": {
+          "encoding": "011011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLT.VX": {
+          "encoding": "011011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLTU.VV": {
+          "encoding": "011010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLTU.VX": {
+          "encoding": "011010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VI": {
+          "encoding": "011001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VV": {
+          "encoding": "011001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VX": {
+          "encoding": "011001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSOF.M": {
+          "encoding": "010100------00010010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x50012057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMUL.VV": {
+          "encoding": "100101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94002057",
+          "mask": "0xfc00707f"
+        },
+        "VMUL.VX": {
+          "encoding": "100101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULH.VV": {
+          "encoding": "100111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULH.VX": {
+          "encoding": "100111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHSU.VV": {
+          "encoding": "100110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x98002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHSU.VX": {
+          "encoding": "100110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x98006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHU.VV": {
+          "encoding": "100100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHU.VX": {
+          "encoding": "100100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90006057",
+          "mask": "0xfc00707f"
+        },
+        "VMV1R.V": {
+          "encoding": "1001111-----00000011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e003057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV2R.V": {
+          "encoding": "1001111-----00001011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e00b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV4R.V": {
+          "encoding": "1001111-----00011011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e01b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV8R.V": {
+          "encoding": "1001111-----00111011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e03b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV.S.X": {
+          "encoding": "010000100000-----110-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42006057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.I": {
+          "encoding": "010111100000-----011-----1010111",
+          "variable_fields": [
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e003057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.V": {
+          "encoding": "010111100000-----000-----1010111",
+          "variable_fields": [
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e000057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.X": {
+          "encoding": "010111100000-----100-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e004057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.X.S": {
+          "encoding": "0100001-----00000010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42002057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMXNOR.MM": {
+          "encoding": "0111111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7e002057",
+          "mask": "0xfe00707f"
+        },
+        "VMXOR.MM": {
+          "encoding": "0110111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6e002057",
+          "mask": "0xfe00707f"
+        },
+        "VNCLIP.WI": {
+          "encoding": "101111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc003057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIP.WV": {
+          "encoding": "101111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc000057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIP.WX": {
+          "encoding": "101111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc004057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WI": {
+          "encoding": "101110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8003057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WV": {
+          "encoding": "101110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8000057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WX": {
+          "encoding": "101110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8004057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSAC.VV": {
+          "encoding": "101111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc002057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSAC.VX": {
+          "encoding": "101111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc006057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSUB.VV": {
+          "encoding": "101011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac002057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSUB.VX": {
+          "encoding": "101011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WI": {
+          "encoding": "101101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4003057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WV": {
+          "encoding": "101101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4000057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WX": {
+          "encoding": "101101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4004057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WI": {
+          "encoding": "101100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0003057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WV": {
+          "encoding": "101100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0000057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WX": {
+          "encoding": "101100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0004057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VI": {
+          "encoding": "001010-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28003057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VV": {
+          "encoding": "001010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VX": {
+          "encoding": "001010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28004057",
+          "mask": "0xfc00707f"
+        },
+        "VREDAND.VS": {
+          "encoding": "000001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMAX.VS": {
+          "encoding": "000111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMAXU.VS": {
+          "encoding": "000110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMIN.VS": {
+          "encoding": "000101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMINU.VS": {
+          "encoding": "000100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDOR.VS": {
+          "encoding": "000010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDSUM.VS": {
+          "encoding": "000000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2057",
+          "mask": "0xfc00707f"
+        },
+        "VREDXOR.VS": {
+          "encoding": "000011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc002057",
+          "mask": "0xfc00707f"
+        },
+        "VREM.VV": {
+          "encoding": "100011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c002057",
+          "mask": "0xfc00707f"
+        },
+        "VREM.VX": {
+          "encoding": "100011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006057",
+          "mask": "0xfc00707f"
+        },
+        "VREMU.VV": {
+          "encoding": "100010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88002057",
+          "mask": "0xfc00707f"
+        },
+        "VREMU.VX": {
+          "encoding": "100010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VI": {
+          "encoding": "001100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30003057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VV": {
+          "encoding": "001100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30000057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VX": {
+          "encoding": "001100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30004057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHEREI16.VV": {
+          "encoding": "001110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38000057",
+          "mask": "0xfc00707f"
+        },
+        "VRSUB.VI": {
+          "encoding": "000011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc003057",
+          "mask": "0xfc00707f"
+        },
+        "VRSUB.VX": {
+          "encoding": "000011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc004057",
+          "mask": "0xfc00707f"
+        },
+        "VS1R.V": {
+          "encoding": "000000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2800027",
+          "mask": "0xfff0707f"
+        },
+        "VS2R.V": {
+          "encoding": "001000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22800027",
+          "mask": "0xfff0707f"
+        },
+        "VS4R.V": {
+          "encoding": "011000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62800027",
+          "mask": "0xfff0707f"
+        },
+        "VS8R.V": {
+          "encoding": "111000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2800027",
+          "mask": "0xfff0707f"
+        },
+        "VSADD.VI": {
+          "encoding": "100001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84003057",
+          "mask": "0xfc00707f"
+        },
+        "VSADD.VV": {
+          "encoding": "100001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000057",
+          "mask": "0xfc00707f"
+        },
+        "VSADD.VX": {
+          "encoding": "100001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84004057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VI": {
+          "encoding": "100000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80003057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VV": {
+          "encoding": "100000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VX": {
+          "encoding": "100000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80004057",
+          "mask": "0xfc00707f"
+        },
+        "VSBC.VVM": {
+          "encoding": "0100100----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000057",
+          "mask": "0xfe00707f"
+        },
+        "VSBC.VXM": {
+          "encoding": "0100100----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48004057",
+          "mask": "0xfe00707f"
+        },
+        "VSE16.V": {
+          "encoding": "000000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E16.V": {
+          "encoding": "001000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E16.V": {
+          "encoding": "010000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E16.V": {
+          "encoding": "011000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E16.V": {
+          "encoding": "100000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E16.V": {
+          "encoding": "101000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E16.V": {
+          "encoding": "110000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E16.V": {
+          "encoding": "111000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSE32.V": {
+          "encoding": "000000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E32.V": {
+          "encoding": "001000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E32.V": {
+          "encoding": "010000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E32.V": {
+          "encoding": "011000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E32.V": {
+          "encoding": "100000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E32.V": {
+          "encoding": "101000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E32.V": {
+          "encoding": "110000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E32.V": {
+          "encoding": "111000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSE8.V": {
+          "encoding": "000000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x27",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E8.V": {
+          "encoding": "001000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E8.V": {
+          "encoding": "010000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E8.V": {
+          "encoding": "011000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E8.V": {
+          "encoding": "100000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E8.V": {
+          "encoding": "101000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E8.V": {
+          "encoding": "110000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E8.V": {
+          "encoding": "111000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSETIVLI": {
+          "encoding": "11---------------111-----1010111",
+          "variable_fields": [
+            "zimm10",
+            "zimm5",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0007057",
+          "mask": "0xc000707f"
+        },
+        "VSETVL": {
+          "encoding": "1000000----------111-----1010111",
+          "variable_fields": [
+            "rs2",
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80007057",
+          "mask": "0xfe00707f"
+        },
+        "VSETVLI": {
+          "encoding": "0----------------111-----1010111",
+          "variable_fields": [
+            "zimm11",
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7057",
+          "mask": "0x8000707f"
+        },
+        "VSEXT.VF2": {
+          "encoding": "010010------00111010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4803a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSEXT.VF4": {
+          "encoding": "010010------00101010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4802a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSEXT.VF8": {
+          "encoding": "010010------00011010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4801a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSLIDE1DOWN.VX": {
+          "encoding": "001111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c006057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDE1UP.VX": {
+          "encoding": "001110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38006057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEDOWN.VI": {
+          "encoding": "001111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEDOWN.VX": {
+          "encoding": "001111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEUP.VI": {
+          "encoding": "001110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEUP.VX": {
+          "encoding": "001110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38004057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VI": {
+          "encoding": "100101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VV": {
+          "encoding": "100101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94000057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VX": {
+          "encoding": "100101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94004057",
+          "mask": "0xfc00707f"
+        },
+        "VSM.V": {
+          "encoding": "000000101011-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2b00027",
+          "mask": "0xfff0707f"
+        },
+        "VSMUL.VV": {
+          "encoding": "100111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c000057",
+          "mask": "0xfc00707f"
+        },
+        "VSMUL.VX": {
+          "encoding": "100111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI16.V": {
+          "encoding": "000011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI16.V": {
+          "encoding": "001011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI16.V": {
+          "encoding": "010011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI16.V": {
+          "encoding": "011011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI16.V": {
+          "encoding": "100011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI16.V": {
+          "encoding": "101011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI16.V": {
+          "encoding": "110011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI16.V": {
+          "encoding": "111011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI32.V": {
+          "encoding": "000011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI32.V": {
+          "encoding": "001011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI32.V": {
+          "encoding": "010011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI32.V": {
+          "encoding": "011011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI32.V": {
+          "encoding": "100011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI32.V": {
+          "encoding": "101011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI32.V": {
+          "encoding": "110011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI32.V": {
+          "encoding": "111011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI8.V": {
+          "encoding": "000011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI8.V": {
+          "encoding": "001011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI8.V": {
+          "encoding": "010011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI8.V": {
+          "encoding": "011011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI8.V": {
+          "encoding": "100011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI8.V": {
+          "encoding": "101011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI8.V": {
+          "encoding": "110011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI8.V": {
+          "encoding": "111011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec000027",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VI": {
+          "encoding": "101001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4003057",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VV": {
+          "encoding": "101001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000057",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VX": {
+          "encoding": "101001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4004057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VI": {
+          "encoding": "101000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0003057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VV": {
+          "encoding": "101000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VX": {
+          "encoding": "101000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSE16.V": {
+          "encoding": "000010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E16.V": {
+          "encoding": "001010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E16.V": {
+          "encoding": "010010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E16.V": {
+          "encoding": "011010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E16.V": {
+          "encoding": "100010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E16.V": {
+          "encoding": "101010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E16.V": {
+          "encoding": "110010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E16.V": {
+          "encoding": "111010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSE32.V": {
+          "encoding": "000010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E32.V": {
+          "encoding": "001010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E32.V": {
+          "encoding": "010010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E32.V": {
+          "encoding": "011010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E32.V": {
+          "encoding": "100010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E32.V": {
+          "encoding": "101010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E32.V": {
+          "encoding": "110010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E32.V": {
+          "encoding": "111010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSE8.V": {
+          "encoding": "000010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E8.V": {
+          "encoding": "001010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E8.V": {
+          "encoding": "010010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E8.V": {
+          "encoding": "011010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E8.V": {
+          "encoding": "100010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E8.V": {
+          "encoding": "101010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E8.V": {
+          "encoding": "110010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E8.V": {
+          "encoding": "111010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VI": {
+          "encoding": "101011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac003057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VV": {
+          "encoding": "101011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VX": {
+          "encoding": "101011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VI": {
+          "encoding": "101010-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8003057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VV": {
+          "encoding": "101010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VX": {
+          "encoding": "101010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUB.VV": {
+          "encoding": "100011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUB.VX": {
+          "encoding": "100011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUBU.VV": {
+          "encoding": "100010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUBU.VX": {
+          "encoding": "100010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88004057",
+          "mask": "0xfc00707f"
+        },
+        "VSUB.VV": {
+          "encoding": "000010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000057",
+          "mask": "0xfc00707f"
+        },
+        "VSUB.VX": {
+          "encoding": "000010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8004057",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI16.V": {
+          "encoding": "000001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI16.V": {
+          "encoding": "001001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI16.V": {
+          "encoding": "010001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI16.V": {
+          "encoding": "011001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI16.V": {
+          "encoding": "100001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI16.V": {
+          "encoding": "101001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI16.V": {
+          "encoding": "110001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI16.V": {
+          "encoding": "111001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI32.V": {
+          "encoding": "000001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI32.V": {
+          "encoding": "001001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI32.V": {
+          "encoding": "010001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI32.V": {
+          "encoding": "011001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI32.V": {
+          "encoding": "100001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI32.V": {
+          "encoding": "101001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI32.V": {
+          "encoding": "110001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI32.V": {
+          "encoding": "111001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI8.V": {
+          "encoding": "000001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI8.V": {
+          "encoding": "001001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI8.V": {
+          "encoding": "010001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI8.V": {
+          "encoding": "011001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI8.V": {
+          "encoding": "100001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI8.V": {
+          "encoding": "101001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI8.V": {
+          "encoding": "110001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI8.V": {
+          "encoding": "111001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4000027",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.VV": {
+          "encoding": "110001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.VX": {
+          "encoding": "110001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.WV": {
+          "encoding": "110101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.WX": {
+          "encoding": "110101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.VV": {
+          "encoding": "110000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.VX": {
+          "encoding": "110000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.WV": {
+          "encoding": "110100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.WX": {
+          "encoding": "110100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACC.VV": {
+          "encoding": "111101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACC.VX": {
+          "encoding": "111101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCSU.VV": {
+          "encoding": "111111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xfc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCSU.VX": {
+          "encoding": "111111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xfc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCU.VV": {
+          "encoding": "111100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCU.VX": {
+          "encoding": "111100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCUS.VX": {
+          "encoding": "111110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMUL.VV": {
+          "encoding": "111011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMUL.VX": {
+          "encoding": "111011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULSU.VV": {
+          "encoding": "111010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULSU.VX": {
+          "encoding": "111010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULU.VV": {
+          "encoding": "111000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULU.VX": {
+          "encoding": "111000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWREDSUM.VS": {
+          "encoding": "110001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000057",
+          "mask": "0xfc00707f"
+        },
+        "VWREDSUMU.VS": {
+          "encoding": "110000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.VV": {
+          "encoding": "110011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.VX": {
+          "encoding": "110011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.WV": {
+          "encoding": "110111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xdc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.WX": {
+          "encoding": "110111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xdc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.VV": {
+          "encoding": "110010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.VX": {
+          "encoding": "110010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.WV": {
+          "encoding": "110110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.WX": {
+          "encoding": "110110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd8006057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VI": {
+          "encoding": "001011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c003057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VV": {
+          "encoding": "001011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VX": {
+          "encoding": "001011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c004057",
+          "mask": "0xfc00707f"
+        },
+        "VZEXT.VF2": {
+          "encoding": "010010------00110010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48032057",
+          "mask": "0xfc0ff07f"
+        },
+        "VZEXT.VF4": {
+          "encoding": "010010------00100010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48022057",
+          "mask": "0xfc0ff07f"
+        },
+        "VZEXT.VF8": {
+          "encoding": "010010------00010010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48012057",
+          "mask": "0xfc0ff07f"
+        }
+      },
       "state": "ratified",
       "ratification_date": "2021-11",
       "version": "1.0.0"
@@ -20976,7 +27858,7123 @@
       "desc": "Single-precision vector floating-point on top of the Zve32x embedded subset, with elements still capped at 32 bits.",
       "use": "Embedded DSP with single-precision vectors",
       "url": "https://docs.riscv.org/reference/isa/unpriv/bfloat16.html",
-      "instructions": {},
+      "instructions": {
+        "VAADD.VV": {
+          "encoding": "001001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24002057",
+          "mask": "0xfc00707f"
+        },
+        "VAADD.VX": {
+          "encoding": "001001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006057",
+          "mask": "0xfc00707f"
+        },
+        "VAADDU.VV": {
+          "encoding": "001000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20002057",
+          "mask": "0xfc00707f"
+        },
+        "VAADDU.VX": {
+          "encoding": "001000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006057",
+          "mask": "0xfc00707f"
+        },
+        "VADC.VIM": {
+          "encoding": "0100000----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40003057",
+          "mask": "0xfe00707f"
+        },
+        "VADC.VVM": {
+          "encoding": "0100000----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000057",
+          "mask": "0xfe00707f"
+        },
+        "VADC.VXM": {
+          "encoding": "0100000----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40004057",
+          "mask": "0xfe00707f"
+        },
+        "VADD.VI": {
+          "encoding": "000000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3057",
+          "mask": "0xfc00707f"
+        },
+        "VADD.VV": {
+          "encoding": "000000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x57",
+          "mask": "0xfc00707f"
+        },
+        "VADD.VX": {
+          "encoding": "000000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VI": {
+          "encoding": "001001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24003057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VV": {
+          "encoding": "001001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VX": {
+          "encoding": "001001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24004057",
+          "mask": "0xfc00707f"
+        },
+        "VASUB.VV": {
+          "encoding": "001011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c002057",
+          "mask": "0xfc00707f"
+        },
+        "VASUB.VX": {
+          "encoding": "001011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006057",
+          "mask": "0xfc00707f"
+        },
+        "VASUBU.VV": {
+          "encoding": "001010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28002057",
+          "mask": "0xfc00707f"
+        },
+        "VASUBU.VX": {
+          "encoding": "001010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006057",
+          "mask": "0xfc00707f"
+        },
+        "VCOMPRESS.VM": {
+          "encoding": "0101111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e002057",
+          "mask": "0xfe00707f"
+        },
+        "VCPOP.M": {
+          "encoding": "010000------10000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40082057",
+          "mask": "0xfc0ff07f"
+        },
+        "VDIV.VV": {
+          "encoding": "100001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84002057",
+          "mask": "0xfc00707f"
+        },
+        "VDIV.VX": {
+          "encoding": "100001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006057",
+          "mask": "0xfc00707f"
+        },
+        "VDIVU.VV": {
+          "encoding": "100000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80002057",
+          "mask": "0xfc00707f"
+        },
+        "VDIVU.VX": {
+          "encoding": "100000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006057",
+          "mask": "0xfc00707f"
+        },
+        "VFADD.VF": {
+          "encoding": "000000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5057",
+          "mask": "0xfc00707f"
+        },
+        "VFADD.VV": {
+          "encoding": "000000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1057",
+          "mask": "0xfc00707f"
+        },
+        "VFCLASS.V": {
+          "encoding": "010011------10000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c081057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.F.X.V": {
+          "encoding": "010010------00011001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48019057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.F.XU.V": {
+          "encoding": "010010------00010001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48011057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.RTZ.X.F.V": {
+          "encoding": "010010------00111001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48039057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.RTZ.XU.F.V": {
+          "encoding": "010010------00110001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48031057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.X.F.V": {
+          "encoding": "010010------00001001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48009057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.XU.F.V": {
+          "encoding": "010010------00000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48001057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFDIV.VF": {
+          "encoding": "100000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80005057",
+          "mask": "0xfc00707f"
+        },
+        "VFDIV.VV": {
+          "encoding": "100000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80001057",
+          "mask": "0xfc00707f"
+        },
+        "VFIRST.M": {
+          "encoding": "010000------10001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4008a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFMACC.VF": {
+          "encoding": "101100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMACC.VV": {
+          "encoding": "101100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMADD.VF": {
+          "encoding": "101000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMADD.VV": {
+          "encoding": "101000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMAX.VF": {
+          "encoding": "000110-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMAX.VV": {
+          "encoding": "000110-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMERGE.VFM": {
+          "encoding": "0101110----------101-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c005057",
+          "mask": "0xfe00707f"
+        },
+        "VFMIN.VF": {
+          "encoding": "000100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMIN.VV": {
+          "encoding": "000100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMSAC.VF": {
+          "encoding": "101110-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMSAC.VV": {
+          "encoding": "101110-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMSUB.VF": {
+          "encoding": "101010-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMSUB.VV": {
+          "encoding": "101010-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMUL.VF": {
+          "encoding": "100100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMUL.VV": {
+          "encoding": "100100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMV.F.S": {
+          "encoding": "0100001-----00000001-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42001057",
+          "mask": "0xfe0ff07f"
+        },
+        "VFMV.S.F": {
+          "encoding": "010000100000-----101-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42005057",
+          "mask": "0xfff0707f"
+        },
+        "VFMV.V.F": {
+          "encoding": "010111100000-----101-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e005057",
+          "mask": "0xfff0707f"
+        },
+        "VFNCVT.RTZ.X.F.W": {
+          "encoding": "010010------10111001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x480b9057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.RTZ.XU.F.W": {
+          "encoding": "010010------10110001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x480b1057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.X.F.W": {
+          "encoding": "010010------10001001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48089057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.XU.F.W": {
+          "encoding": "010010------10000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48081057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNMACC.VF": {
+          "encoding": "101101-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4005057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMACC.VV": {
+          "encoding": "101101-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4001057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMADD.VF": {
+          "encoding": "101001-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4005057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMADD.VV": {
+          "encoding": "101001-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4001057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMSAC.VF": {
+          "encoding": "101111-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc005057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMSAC.VV": {
+          "encoding": "101111-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc001057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMSUB.VF": {
+          "encoding": "101011-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac005057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMSUB.VV": {
+          "encoding": "101011-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac001057",
+          "mask": "0xfc00707f"
+        },
+        "VFRDIV.VF": {
+          "encoding": "100001-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84005057",
+          "mask": "0xfc00707f"
+        },
+        "VFREC7.V": {
+          "encoding": "010011------00101001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c029057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFREDMAX.VS": {
+          "encoding": "000111-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c001057",
+          "mask": "0xfc00707f"
+        },
+        "VFREDMIN.VS": {
+          "encoding": "000101-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14001057",
+          "mask": "0xfc00707f"
+        },
+        "VFREDOSUM.VS": {
+          "encoding": "000011-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc001057",
+          "mask": "0xfc00707f"
+        },
+        "VFREDUSUM.VS": {
+          "encoding": "000001-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4001057",
+          "mask": "0xfc00707f"
+        },
+        "VFRSQRT7.V": {
+          "encoding": "010011------00100001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c021057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFRSUB.VF": {
+          "encoding": "100111-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJ.VF": {
+          "encoding": "001000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJ.VV": {
+          "encoding": "001000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20001057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJN.VF": {
+          "encoding": "001001-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJN.VV": {
+          "encoding": "001001-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24001057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJX.VF": {
+          "encoding": "001010-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJX.VV": {
+          "encoding": "001010-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28001057",
+          "mask": "0xfc00707f"
+        },
+        "VFSLIDE1DOWN.VF": {
+          "encoding": "001111-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSLIDE1UP.VF": {
+          "encoding": "001110-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSQRT.V": {
+          "encoding": "010011------00000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c001057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFSUB.VF": {
+          "encoding": "000010-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSUB.VV": {
+          "encoding": "000010-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8001057",
+          "mask": "0xfc00707f"
+        },
+        "VFWCVT.F.X.V": {
+          "encoding": "010010------01011001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48059057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFWCVT.F.XU.V": {
+          "encoding": "010010------01010001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48051057",
+          "mask": "0xfc0ff07f"
+        },
+        "VID.V": {
+          "encoding": "010100-0000010001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5008a057",
+          "mask": "0xfdfff07f"
+        },
+        "VIOTA.M": {
+          "encoding": "010100------10000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x50082057",
+          "mask": "0xfc0ff07f"
+        },
+        "VL1RE16.V": {
+          "encoding": "000000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2805007",
+          "mask": "0xfff0707f"
+        },
+        "VL1RE32.V": {
+          "encoding": "000000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2806007",
+          "mask": "0xfff0707f"
+        },
+        "VL1RE8.V": {
+          "encoding": "000000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2800007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE16.V": {
+          "encoding": "001000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22805007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE32.V": {
+          "encoding": "001000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22806007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE8.V": {
+          "encoding": "001000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22800007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE16.V": {
+          "encoding": "011000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62805007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE32.V": {
+          "encoding": "011000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62806007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE8.V": {
+          "encoding": "011000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62800007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE16.V": {
+          "encoding": "111000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2805007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE32.V": {
+          "encoding": "111000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2806007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE8.V": {
+          "encoding": "111000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2800007",
+          "mask": "0xfff0707f"
+        },
+        "VLE16.V": {
+          "encoding": "000000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E16.V": {
+          "encoding": "001000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E16.V": {
+          "encoding": "010000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E16.V": {
+          "encoding": "011000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E16.V": {
+          "encoding": "100000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E16.V": {
+          "encoding": "101000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E16.V": {
+          "encoding": "110000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E16.V": {
+          "encoding": "111000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE16FF.V": {
+          "encoding": "000000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E16FF.V": {
+          "encoding": "001000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E16FF.V": {
+          "encoding": "010000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E16FF.V": {
+          "encoding": "011000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E16FF.V": {
+          "encoding": "100000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E16FF.V": {
+          "encoding": "101000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E16FF.V": {
+          "encoding": "110000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E16FF.V": {
+          "encoding": "111000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE32.V": {
+          "encoding": "000000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E32.V": {
+          "encoding": "001000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E32.V": {
+          "encoding": "010000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E32.V": {
+          "encoding": "011000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E32.V": {
+          "encoding": "100000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E32.V": {
+          "encoding": "101000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E32.V": {
+          "encoding": "110000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E32.V": {
+          "encoding": "111000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE32FF.V": {
+          "encoding": "000000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E32FF.V": {
+          "encoding": "001000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E32FF.V": {
+          "encoding": "010000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E32FF.V": {
+          "encoding": "011000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E32FF.V": {
+          "encoding": "100000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E32FF.V": {
+          "encoding": "101000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E32FF.V": {
+          "encoding": "110000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E32FF.V": {
+          "encoding": "111000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE8.V": {
+          "encoding": "000000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E8.V": {
+          "encoding": "001000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E8.V": {
+          "encoding": "010000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E8.V": {
+          "encoding": "011000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E8.V": {
+          "encoding": "100000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E8.V": {
+          "encoding": "101000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E8.V": {
+          "encoding": "110000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E8.V": {
+          "encoding": "111000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE8FF.V": {
+          "encoding": "000000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E8FF.V": {
+          "encoding": "001000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E8FF.V": {
+          "encoding": "010000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E8FF.V": {
+          "encoding": "011000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E8FF.V": {
+          "encoding": "100000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E8FF.V": {
+          "encoding": "101000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E8FF.V": {
+          "encoding": "110000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E8FF.V": {
+          "encoding": "111000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLM.V": {
+          "encoding": "000000101011-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2b00007",
+          "mask": "0xfff0707f"
+        },
+        "VLOXEI16.V": {
+          "encoding": "000011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI16.V": {
+          "encoding": "001011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI16.V": {
+          "encoding": "010011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI16.V": {
+          "encoding": "011011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI16.V": {
+          "encoding": "100011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI16.V": {
+          "encoding": "101011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI16.V": {
+          "encoding": "110011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI16.V": {
+          "encoding": "111011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXEI32.V": {
+          "encoding": "000011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI32.V": {
+          "encoding": "001011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI32.V": {
+          "encoding": "010011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI32.V": {
+          "encoding": "011011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI32.V": {
+          "encoding": "100011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI32.V": {
+          "encoding": "101011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI32.V": {
+          "encoding": "110011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI32.V": {
+          "encoding": "111011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXEI8.V": {
+          "encoding": "000011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI8.V": {
+          "encoding": "001011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI8.V": {
+          "encoding": "010011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI8.V": {
+          "encoding": "011011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI8.V": {
+          "encoding": "100011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI8.V": {
+          "encoding": "101011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI8.V": {
+          "encoding": "110011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI8.V": {
+          "encoding": "111011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE16.V": {
+          "encoding": "000010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E16.V": {
+          "encoding": "001010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E16.V": {
+          "encoding": "010010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E16.V": {
+          "encoding": "011010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E16.V": {
+          "encoding": "100010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E16.V": {
+          "encoding": "101010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E16.V": {
+          "encoding": "110010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E16.V": {
+          "encoding": "111010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE32.V": {
+          "encoding": "000010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E32.V": {
+          "encoding": "001010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E32.V": {
+          "encoding": "010010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E32.V": {
+          "encoding": "011010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E32.V": {
+          "encoding": "100010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E32.V": {
+          "encoding": "101010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E32.V": {
+          "encoding": "110010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E32.V": {
+          "encoding": "111010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE8.V": {
+          "encoding": "000010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E8.V": {
+          "encoding": "001010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E8.V": {
+          "encoding": "010010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E8.V": {
+          "encoding": "011010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E8.V": {
+          "encoding": "100010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E8.V": {
+          "encoding": "101010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E8.V": {
+          "encoding": "110010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E8.V": {
+          "encoding": "111010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI16.V": {
+          "encoding": "000001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI16.V": {
+          "encoding": "001001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI16.V": {
+          "encoding": "010001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI16.V": {
+          "encoding": "011001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI16.V": {
+          "encoding": "100001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI16.V": {
+          "encoding": "101001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI16.V": {
+          "encoding": "110001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI16.V": {
+          "encoding": "111001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI32.V": {
+          "encoding": "000001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI32.V": {
+          "encoding": "001001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI32.V": {
+          "encoding": "010001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI32.V": {
+          "encoding": "011001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI32.V": {
+          "encoding": "100001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI32.V": {
+          "encoding": "101001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI32.V": {
+          "encoding": "110001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI32.V": {
+          "encoding": "111001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI8.V": {
+          "encoding": "000001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI8.V": {
+          "encoding": "001001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI8.V": {
+          "encoding": "010001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI8.V": {
+          "encoding": "011001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI8.V": {
+          "encoding": "100001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI8.V": {
+          "encoding": "101001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI8.V": {
+          "encoding": "110001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI8.V": {
+          "encoding": "111001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4000007",
+          "mask": "0xfc00707f"
+        },
+        "VMACC.VV": {
+          "encoding": "101101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4002057",
+          "mask": "0xfc00707f"
+        },
+        "VMACC.VX": {
+          "encoding": "101101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4006057",
+          "mask": "0xfc00707f"
+        },
+        "VMADC.VI": {
+          "encoding": "0100011----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46003057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VIM": {
+          "encoding": "0100010----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44003057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VV": {
+          "encoding": "0100011----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46000057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VVM": {
+          "encoding": "0100010----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VX": {
+          "encoding": "0100011----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46004057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VXM": {
+          "encoding": "0100010----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44004057",
+          "mask": "0xfe00707f"
+        },
+        "VMADD.VV": {
+          "encoding": "101001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4002057",
+          "mask": "0xfc00707f"
+        },
+        "VMADD.VX": {
+          "encoding": "101001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006057",
+          "mask": "0xfc00707f"
+        },
+        "VMAND.MM": {
+          "encoding": "0110011----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x66002057",
+          "mask": "0xfe00707f"
+        },
+        "VMANDN.MM": {
+          "encoding": "0110001----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62002057",
+          "mask": "0xfe00707f"
+        },
+        "VMAX.VV": {
+          "encoding": "000111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c000057",
+          "mask": "0xfc00707f"
+        },
+        "VMAX.VX": {
+          "encoding": "000111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMAXU.VV": {
+          "encoding": "000110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18000057",
+          "mask": "0xfc00707f"
+        },
+        "VMAXU.VX": {
+          "encoding": "000110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18004057",
+          "mask": "0xfc00707f"
+        },
+        "VMERGE.VIM": {
+          "encoding": "0101110----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c003057",
+          "mask": "0xfe00707f"
+        },
+        "VMERGE.VVM": {
+          "encoding": "0101110----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c000057",
+          "mask": "0xfe00707f"
+        },
+        "VMERGE.VXM": {
+          "encoding": "0101110----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c004057",
+          "mask": "0xfe00707f"
+        },
+        "VMFEQ.VF": {
+          "encoding": "011000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFEQ.VV": {
+          "encoding": "011000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60001057",
+          "mask": "0xfc00707f"
+        },
+        "VMFGE.VF": {
+          "encoding": "011111-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7c005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFGT.VF": {
+          "encoding": "011101-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFLE.VF": {
+          "encoding": "011001-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFLE.VV": {
+          "encoding": "011001-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64001057",
+          "mask": "0xfc00707f"
+        },
+        "VMFLT.VF": {
+          "encoding": "011011-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFLT.VV": {
+          "encoding": "011011-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c001057",
+          "mask": "0xfc00707f"
+        },
+        "VMFNE.VF": {
+          "encoding": "011100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFNE.VV": {
+          "encoding": "011100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70001057",
+          "mask": "0xfc00707f"
+        },
+        "VMIN.VV": {
+          "encoding": "000101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14000057",
+          "mask": "0xfc00707f"
+        },
+        "VMIN.VX": {
+          "encoding": "000101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14004057",
+          "mask": "0xfc00707f"
+        },
+        "VMINU.VV": {
+          "encoding": "000100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10000057",
+          "mask": "0xfc00707f"
+        },
+        "VMINU.VX": {
+          "encoding": "000100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10004057",
+          "mask": "0xfc00707f"
+        },
+        "VMNAND.MM": {
+          "encoding": "0111011----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x76002057",
+          "mask": "0xfe00707f"
+        },
+        "VMNOR.MM": {
+          "encoding": "0111101----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7a002057",
+          "mask": "0xfe00707f"
+        },
+        "VMOR.MM": {
+          "encoding": "0110101----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6a002057",
+          "mask": "0xfe00707f"
+        },
+        "VMORN.MM": {
+          "encoding": "0111001----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x72002057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VV": {
+          "encoding": "0100111----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4e000057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VVM": {
+          "encoding": "0100110----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VX": {
+          "encoding": "0100111----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4e004057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VXM": {
+          "encoding": "0100110----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c004057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBF.M": {
+          "encoding": "010100------00001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5000a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMSEQ.VI": {
+          "encoding": "011000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSEQ.VV": {
+          "encoding": "011000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSEQ.VX": {
+          "encoding": "011000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGT.VI": {
+          "encoding": "011111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7c003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGT.VX": {
+          "encoding": "011111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGTU.VI": {
+          "encoding": "011110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x78003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGTU.VX": {
+          "encoding": "011110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x78004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSIF.M": {
+          "encoding": "010100------00011010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5001a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMSLE.VI": {
+          "encoding": "011101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLE.VV": {
+          "encoding": "011101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLE.VX": {
+          "encoding": "011101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VI": {
+          "encoding": "011100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VV": {
+          "encoding": "011100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VX": {
+          "encoding": "011100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLT.VV": {
+          "encoding": "011011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLT.VX": {
+          "encoding": "011011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLTU.VV": {
+          "encoding": "011010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLTU.VX": {
+          "encoding": "011010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VI": {
+          "encoding": "011001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VV": {
+          "encoding": "011001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VX": {
+          "encoding": "011001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSOF.M": {
+          "encoding": "010100------00010010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x50012057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMUL.VV": {
+          "encoding": "100101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94002057",
+          "mask": "0xfc00707f"
+        },
+        "VMUL.VX": {
+          "encoding": "100101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULH.VV": {
+          "encoding": "100111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULH.VX": {
+          "encoding": "100111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHSU.VV": {
+          "encoding": "100110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x98002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHSU.VX": {
+          "encoding": "100110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x98006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHU.VV": {
+          "encoding": "100100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHU.VX": {
+          "encoding": "100100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90006057",
+          "mask": "0xfc00707f"
+        },
+        "VMV1R.V": {
+          "encoding": "1001111-----00000011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e003057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV2R.V": {
+          "encoding": "1001111-----00001011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e00b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV4R.V": {
+          "encoding": "1001111-----00011011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e01b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV8R.V": {
+          "encoding": "1001111-----00111011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e03b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV.S.X": {
+          "encoding": "010000100000-----110-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42006057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.I": {
+          "encoding": "010111100000-----011-----1010111",
+          "variable_fields": [
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e003057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.V": {
+          "encoding": "010111100000-----000-----1010111",
+          "variable_fields": [
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e000057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.X": {
+          "encoding": "010111100000-----100-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e004057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.X.S": {
+          "encoding": "0100001-----00000010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42002057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMXNOR.MM": {
+          "encoding": "0111111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7e002057",
+          "mask": "0xfe00707f"
+        },
+        "VMXOR.MM": {
+          "encoding": "0110111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6e002057",
+          "mask": "0xfe00707f"
+        },
+        "VNCLIP.WI": {
+          "encoding": "101111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc003057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIP.WV": {
+          "encoding": "101111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc000057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIP.WX": {
+          "encoding": "101111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc004057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WI": {
+          "encoding": "101110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8003057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WV": {
+          "encoding": "101110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8000057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WX": {
+          "encoding": "101110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8004057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSAC.VV": {
+          "encoding": "101111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc002057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSAC.VX": {
+          "encoding": "101111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc006057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSUB.VV": {
+          "encoding": "101011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac002057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSUB.VX": {
+          "encoding": "101011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WI": {
+          "encoding": "101101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4003057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WV": {
+          "encoding": "101101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4000057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WX": {
+          "encoding": "101101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4004057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WI": {
+          "encoding": "101100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0003057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WV": {
+          "encoding": "101100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0000057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WX": {
+          "encoding": "101100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0004057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VI": {
+          "encoding": "001010-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28003057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VV": {
+          "encoding": "001010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VX": {
+          "encoding": "001010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28004057",
+          "mask": "0xfc00707f"
+        },
+        "VREDAND.VS": {
+          "encoding": "000001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMAX.VS": {
+          "encoding": "000111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMAXU.VS": {
+          "encoding": "000110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMIN.VS": {
+          "encoding": "000101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMINU.VS": {
+          "encoding": "000100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDOR.VS": {
+          "encoding": "000010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDSUM.VS": {
+          "encoding": "000000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2057",
+          "mask": "0xfc00707f"
+        },
+        "VREDXOR.VS": {
+          "encoding": "000011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc002057",
+          "mask": "0xfc00707f"
+        },
+        "VREM.VV": {
+          "encoding": "100011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c002057",
+          "mask": "0xfc00707f"
+        },
+        "VREM.VX": {
+          "encoding": "100011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006057",
+          "mask": "0xfc00707f"
+        },
+        "VREMU.VV": {
+          "encoding": "100010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88002057",
+          "mask": "0xfc00707f"
+        },
+        "VREMU.VX": {
+          "encoding": "100010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VI": {
+          "encoding": "001100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30003057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VV": {
+          "encoding": "001100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30000057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VX": {
+          "encoding": "001100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30004057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHEREI16.VV": {
+          "encoding": "001110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38000057",
+          "mask": "0xfc00707f"
+        },
+        "VRSUB.VI": {
+          "encoding": "000011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc003057",
+          "mask": "0xfc00707f"
+        },
+        "VRSUB.VX": {
+          "encoding": "000011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc004057",
+          "mask": "0xfc00707f"
+        },
+        "VS1R.V": {
+          "encoding": "000000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2800027",
+          "mask": "0xfff0707f"
+        },
+        "VS2R.V": {
+          "encoding": "001000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22800027",
+          "mask": "0xfff0707f"
+        },
+        "VS4R.V": {
+          "encoding": "011000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62800027",
+          "mask": "0xfff0707f"
+        },
+        "VS8R.V": {
+          "encoding": "111000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2800027",
+          "mask": "0xfff0707f"
+        },
+        "VSADD.VI": {
+          "encoding": "100001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84003057",
+          "mask": "0xfc00707f"
+        },
+        "VSADD.VV": {
+          "encoding": "100001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000057",
+          "mask": "0xfc00707f"
+        },
+        "VSADD.VX": {
+          "encoding": "100001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84004057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VI": {
+          "encoding": "100000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80003057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VV": {
+          "encoding": "100000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VX": {
+          "encoding": "100000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80004057",
+          "mask": "0xfc00707f"
+        },
+        "VSBC.VVM": {
+          "encoding": "0100100----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000057",
+          "mask": "0xfe00707f"
+        },
+        "VSBC.VXM": {
+          "encoding": "0100100----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48004057",
+          "mask": "0xfe00707f"
+        },
+        "VSE16.V": {
+          "encoding": "000000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E16.V": {
+          "encoding": "001000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E16.V": {
+          "encoding": "010000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E16.V": {
+          "encoding": "011000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E16.V": {
+          "encoding": "100000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E16.V": {
+          "encoding": "101000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E16.V": {
+          "encoding": "110000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E16.V": {
+          "encoding": "111000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSE32.V": {
+          "encoding": "000000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E32.V": {
+          "encoding": "001000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E32.V": {
+          "encoding": "010000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E32.V": {
+          "encoding": "011000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E32.V": {
+          "encoding": "100000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E32.V": {
+          "encoding": "101000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E32.V": {
+          "encoding": "110000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E32.V": {
+          "encoding": "111000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSE8.V": {
+          "encoding": "000000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x27",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E8.V": {
+          "encoding": "001000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E8.V": {
+          "encoding": "010000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E8.V": {
+          "encoding": "011000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E8.V": {
+          "encoding": "100000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E8.V": {
+          "encoding": "101000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E8.V": {
+          "encoding": "110000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E8.V": {
+          "encoding": "111000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSETIVLI": {
+          "encoding": "11---------------111-----1010111",
+          "variable_fields": [
+            "zimm10",
+            "zimm5",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0007057",
+          "mask": "0xc000707f"
+        },
+        "VSETVL": {
+          "encoding": "1000000----------111-----1010111",
+          "variable_fields": [
+            "rs2",
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80007057",
+          "mask": "0xfe00707f"
+        },
+        "VSETVLI": {
+          "encoding": "0----------------111-----1010111",
+          "variable_fields": [
+            "zimm11",
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7057",
+          "mask": "0x8000707f"
+        },
+        "VSEXT.VF2": {
+          "encoding": "010010------00111010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4803a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSEXT.VF4": {
+          "encoding": "010010------00101010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4802a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSEXT.VF8": {
+          "encoding": "010010------00011010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4801a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSLIDE1DOWN.VX": {
+          "encoding": "001111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c006057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDE1UP.VX": {
+          "encoding": "001110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38006057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEDOWN.VI": {
+          "encoding": "001111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEDOWN.VX": {
+          "encoding": "001111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEUP.VI": {
+          "encoding": "001110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEUP.VX": {
+          "encoding": "001110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38004057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VI": {
+          "encoding": "100101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VV": {
+          "encoding": "100101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94000057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VX": {
+          "encoding": "100101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94004057",
+          "mask": "0xfc00707f"
+        },
+        "VSM.V": {
+          "encoding": "000000101011-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2b00027",
+          "mask": "0xfff0707f"
+        },
+        "VSMUL.VV": {
+          "encoding": "100111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c000057",
+          "mask": "0xfc00707f"
+        },
+        "VSMUL.VX": {
+          "encoding": "100111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI16.V": {
+          "encoding": "000011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI16.V": {
+          "encoding": "001011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI16.V": {
+          "encoding": "010011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI16.V": {
+          "encoding": "011011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI16.V": {
+          "encoding": "100011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI16.V": {
+          "encoding": "101011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI16.V": {
+          "encoding": "110011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI16.V": {
+          "encoding": "111011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI32.V": {
+          "encoding": "000011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI32.V": {
+          "encoding": "001011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI32.V": {
+          "encoding": "010011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI32.V": {
+          "encoding": "011011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI32.V": {
+          "encoding": "100011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI32.V": {
+          "encoding": "101011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI32.V": {
+          "encoding": "110011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI32.V": {
+          "encoding": "111011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI8.V": {
+          "encoding": "000011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI8.V": {
+          "encoding": "001011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI8.V": {
+          "encoding": "010011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI8.V": {
+          "encoding": "011011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI8.V": {
+          "encoding": "100011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI8.V": {
+          "encoding": "101011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI8.V": {
+          "encoding": "110011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI8.V": {
+          "encoding": "111011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec000027",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VI": {
+          "encoding": "101001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4003057",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VV": {
+          "encoding": "101001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000057",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VX": {
+          "encoding": "101001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4004057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VI": {
+          "encoding": "101000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0003057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VV": {
+          "encoding": "101000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VX": {
+          "encoding": "101000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSE16.V": {
+          "encoding": "000010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E16.V": {
+          "encoding": "001010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E16.V": {
+          "encoding": "010010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E16.V": {
+          "encoding": "011010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E16.V": {
+          "encoding": "100010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E16.V": {
+          "encoding": "101010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E16.V": {
+          "encoding": "110010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E16.V": {
+          "encoding": "111010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSE32.V": {
+          "encoding": "000010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E32.V": {
+          "encoding": "001010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E32.V": {
+          "encoding": "010010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E32.V": {
+          "encoding": "011010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E32.V": {
+          "encoding": "100010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E32.V": {
+          "encoding": "101010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E32.V": {
+          "encoding": "110010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E32.V": {
+          "encoding": "111010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSE8.V": {
+          "encoding": "000010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E8.V": {
+          "encoding": "001010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E8.V": {
+          "encoding": "010010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E8.V": {
+          "encoding": "011010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E8.V": {
+          "encoding": "100010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E8.V": {
+          "encoding": "101010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E8.V": {
+          "encoding": "110010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E8.V": {
+          "encoding": "111010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VI": {
+          "encoding": "101011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac003057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VV": {
+          "encoding": "101011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VX": {
+          "encoding": "101011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VI": {
+          "encoding": "101010-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8003057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VV": {
+          "encoding": "101010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VX": {
+          "encoding": "101010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUB.VV": {
+          "encoding": "100011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUB.VX": {
+          "encoding": "100011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUBU.VV": {
+          "encoding": "100010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUBU.VX": {
+          "encoding": "100010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88004057",
+          "mask": "0xfc00707f"
+        },
+        "VSUB.VV": {
+          "encoding": "000010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000057",
+          "mask": "0xfc00707f"
+        },
+        "VSUB.VX": {
+          "encoding": "000010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8004057",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI16.V": {
+          "encoding": "000001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI16.V": {
+          "encoding": "001001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI16.V": {
+          "encoding": "010001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI16.V": {
+          "encoding": "011001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI16.V": {
+          "encoding": "100001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI16.V": {
+          "encoding": "101001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI16.V": {
+          "encoding": "110001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI16.V": {
+          "encoding": "111001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI32.V": {
+          "encoding": "000001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI32.V": {
+          "encoding": "001001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI32.V": {
+          "encoding": "010001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI32.V": {
+          "encoding": "011001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI32.V": {
+          "encoding": "100001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI32.V": {
+          "encoding": "101001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI32.V": {
+          "encoding": "110001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI32.V": {
+          "encoding": "111001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI8.V": {
+          "encoding": "000001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI8.V": {
+          "encoding": "001001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI8.V": {
+          "encoding": "010001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI8.V": {
+          "encoding": "011001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI8.V": {
+          "encoding": "100001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI8.V": {
+          "encoding": "101001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI8.V": {
+          "encoding": "110001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI8.V": {
+          "encoding": "111001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4000027",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.VV": {
+          "encoding": "110001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.VX": {
+          "encoding": "110001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.WV": {
+          "encoding": "110101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.WX": {
+          "encoding": "110101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.VV": {
+          "encoding": "110000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.VX": {
+          "encoding": "110000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.WV": {
+          "encoding": "110100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.WX": {
+          "encoding": "110100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACC.VV": {
+          "encoding": "111101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACC.VX": {
+          "encoding": "111101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCSU.VV": {
+          "encoding": "111111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xfc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCSU.VX": {
+          "encoding": "111111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xfc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCU.VV": {
+          "encoding": "111100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCU.VX": {
+          "encoding": "111100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCUS.VX": {
+          "encoding": "111110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMUL.VV": {
+          "encoding": "111011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMUL.VX": {
+          "encoding": "111011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULSU.VV": {
+          "encoding": "111010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULSU.VX": {
+          "encoding": "111010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULU.VV": {
+          "encoding": "111000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULU.VX": {
+          "encoding": "111000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWREDSUM.VS": {
+          "encoding": "110001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000057",
+          "mask": "0xfc00707f"
+        },
+        "VWREDSUMU.VS": {
+          "encoding": "110000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.VV": {
+          "encoding": "110011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.VX": {
+          "encoding": "110011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.WV": {
+          "encoding": "110111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xdc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.WX": {
+          "encoding": "110111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xdc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.VV": {
+          "encoding": "110010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.VX": {
+          "encoding": "110010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.WV": {
+          "encoding": "110110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.WX": {
+          "encoding": "110110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd8006057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VI": {
+          "encoding": "001011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c003057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VV": {
+          "encoding": "001011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VX": {
+          "encoding": "001011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c004057",
+          "mask": "0xfc00707f"
+        },
+        "VZEXT.VF2": {
+          "encoding": "010010------00110010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48032057",
+          "mask": "0xfc0ff07f"
+        },
+        "VZEXT.VF4": {
+          "encoding": "010010------00100010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48022057",
+          "mask": "0xfc0ff07f"
+        },
+        "VZEXT.VF8": {
+          "encoding": "010010------00010010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48012057",
+          "mask": "0xfc0ff07f"
+        }
+      },
       "state": "ratified",
       "ratification_date": "2021-11",
       "version": "1.0.0"
@@ -20989,7 +34987,7170 @@
       "desc": "Integer and fixed-point vector operations on elements up to 64 bits, for embedded cores that need no floating-point.",
       "use": "64-bit int embedded vectors",
       "url": "https://docs.riscv.org/reference/isa/unpriv/v-st-ext.html",
-      "instructions": {},
+      "instructions": {
+        "VAADD.VV": {
+          "encoding": "001001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24002057",
+          "mask": "0xfc00707f"
+        },
+        "VAADD.VX": {
+          "encoding": "001001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006057",
+          "mask": "0xfc00707f"
+        },
+        "VAADDU.VV": {
+          "encoding": "001000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20002057",
+          "mask": "0xfc00707f"
+        },
+        "VAADDU.VX": {
+          "encoding": "001000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006057",
+          "mask": "0xfc00707f"
+        },
+        "VADC.VIM": {
+          "encoding": "0100000----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40003057",
+          "mask": "0xfe00707f"
+        },
+        "VADC.VVM": {
+          "encoding": "0100000----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000057",
+          "mask": "0xfe00707f"
+        },
+        "VADC.VXM": {
+          "encoding": "0100000----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40004057",
+          "mask": "0xfe00707f"
+        },
+        "VADD.VI": {
+          "encoding": "000000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3057",
+          "mask": "0xfc00707f"
+        },
+        "VADD.VV": {
+          "encoding": "000000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x57",
+          "mask": "0xfc00707f"
+        },
+        "VADD.VX": {
+          "encoding": "000000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VI": {
+          "encoding": "001001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24003057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VV": {
+          "encoding": "001001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VX": {
+          "encoding": "001001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24004057",
+          "mask": "0xfc00707f"
+        },
+        "VASUB.VV": {
+          "encoding": "001011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c002057",
+          "mask": "0xfc00707f"
+        },
+        "VASUB.VX": {
+          "encoding": "001011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006057",
+          "mask": "0xfc00707f"
+        },
+        "VASUBU.VV": {
+          "encoding": "001010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28002057",
+          "mask": "0xfc00707f"
+        },
+        "VASUBU.VX": {
+          "encoding": "001010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006057",
+          "mask": "0xfc00707f"
+        },
+        "VCOMPRESS.VM": {
+          "encoding": "0101111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e002057",
+          "mask": "0xfe00707f"
+        },
+        "VCPOP.M": {
+          "encoding": "010000------10000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40082057",
+          "mask": "0xfc0ff07f"
+        },
+        "VDIV.VV": {
+          "encoding": "100001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84002057",
+          "mask": "0xfc00707f"
+        },
+        "VDIV.VX": {
+          "encoding": "100001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006057",
+          "mask": "0xfc00707f"
+        },
+        "VDIVU.VV": {
+          "encoding": "100000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80002057",
+          "mask": "0xfc00707f"
+        },
+        "VDIVU.VX": {
+          "encoding": "100000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006057",
+          "mask": "0xfc00707f"
+        },
+        "VFIRST.M": {
+          "encoding": "010000------10001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4008a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VID.V": {
+          "encoding": "010100-0000010001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5008a057",
+          "mask": "0xfdfff07f"
+        },
+        "VIOTA.M": {
+          "encoding": "010100------10000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x50082057",
+          "mask": "0xfc0ff07f"
+        },
+        "VL1RE16.V": {
+          "encoding": "000000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2805007",
+          "mask": "0xfff0707f"
+        },
+        "VL1RE32.V": {
+          "encoding": "000000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2806007",
+          "mask": "0xfff0707f"
+        },
+        "VL1RE64.V": {
+          "encoding": "000000101000-----111-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2807007",
+          "mask": "0xfff0707f"
+        },
+        "VL1RE8.V": {
+          "encoding": "000000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2800007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE16.V": {
+          "encoding": "001000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22805007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE32.V": {
+          "encoding": "001000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22806007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE64.V": {
+          "encoding": "001000101000-----111-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22807007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE8.V": {
+          "encoding": "001000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22800007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE16.V": {
+          "encoding": "011000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62805007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE32.V": {
+          "encoding": "011000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62806007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE64.V": {
+          "encoding": "011000101000-----111-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62807007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE8.V": {
+          "encoding": "011000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62800007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE16.V": {
+          "encoding": "111000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2805007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE32.V": {
+          "encoding": "111000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2806007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE64.V": {
+          "encoding": "111000101000-----111-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2807007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE8.V": {
+          "encoding": "111000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2800007",
+          "mask": "0xfff0707f"
+        },
+        "VLE16.V": {
+          "encoding": "000000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E16.V": {
+          "encoding": "001000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E16.V": {
+          "encoding": "010000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E16.V": {
+          "encoding": "011000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E16.V": {
+          "encoding": "100000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E16.V": {
+          "encoding": "101000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E16.V": {
+          "encoding": "110000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E16.V": {
+          "encoding": "111000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE16FF.V": {
+          "encoding": "000000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E16FF.V": {
+          "encoding": "001000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E16FF.V": {
+          "encoding": "010000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E16FF.V": {
+          "encoding": "011000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E16FF.V": {
+          "encoding": "100000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E16FF.V": {
+          "encoding": "101000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E16FF.V": {
+          "encoding": "110000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E16FF.V": {
+          "encoding": "111000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE32.V": {
+          "encoding": "000000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E32.V": {
+          "encoding": "001000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E32.V": {
+          "encoding": "010000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E32.V": {
+          "encoding": "011000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E32.V": {
+          "encoding": "100000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E32.V": {
+          "encoding": "101000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E32.V": {
+          "encoding": "110000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E32.V": {
+          "encoding": "111000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE32FF.V": {
+          "encoding": "000000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E32FF.V": {
+          "encoding": "001000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E32FF.V": {
+          "encoding": "010000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E32FF.V": {
+          "encoding": "011000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E32FF.V": {
+          "encoding": "100000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E32FF.V": {
+          "encoding": "101000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E32FF.V": {
+          "encoding": "110000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E32FF.V": {
+          "encoding": "111000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE64.V": {
+          "encoding": "000000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E64.V": {
+          "encoding": "001000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E64.V": {
+          "encoding": "010000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E64.V": {
+          "encoding": "011000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E64.V": {
+          "encoding": "100000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E64.V": {
+          "encoding": "101000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E64.V": {
+          "encoding": "110000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E64.V": {
+          "encoding": "111000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE64FF.V": {
+          "encoding": "000000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E64FF.V": {
+          "encoding": "001000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E64FF.V": {
+          "encoding": "010000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E64FF.V": {
+          "encoding": "011000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E64FF.V": {
+          "encoding": "100000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E64FF.V": {
+          "encoding": "101000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E64FF.V": {
+          "encoding": "110000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E64FF.V": {
+          "encoding": "111000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE8.V": {
+          "encoding": "000000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E8.V": {
+          "encoding": "001000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E8.V": {
+          "encoding": "010000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E8.V": {
+          "encoding": "011000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E8.V": {
+          "encoding": "100000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E8.V": {
+          "encoding": "101000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E8.V": {
+          "encoding": "110000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E8.V": {
+          "encoding": "111000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE8FF.V": {
+          "encoding": "000000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E8FF.V": {
+          "encoding": "001000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E8FF.V": {
+          "encoding": "010000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E8FF.V": {
+          "encoding": "011000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E8FF.V": {
+          "encoding": "100000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E8FF.V": {
+          "encoding": "101000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E8FF.V": {
+          "encoding": "110000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E8FF.V": {
+          "encoding": "111000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLM.V": {
+          "encoding": "000000101011-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2b00007",
+          "mask": "0xfff0707f"
+        },
+        "VLOXEI16.V": {
+          "encoding": "000011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI16.V": {
+          "encoding": "001011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI16.V": {
+          "encoding": "010011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI16.V": {
+          "encoding": "011011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI16.V": {
+          "encoding": "100011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI16.V": {
+          "encoding": "101011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI16.V": {
+          "encoding": "110011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI16.V": {
+          "encoding": "111011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXEI32.V": {
+          "encoding": "000011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI32.V": {
+          "encoding": "001011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI32.V": {
+          "encoding": "010011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI32.V": {
+          "encoding": "011011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI32.V": {
+          "encoding": "100011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI32.V": {
+          "encoding": "101011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI32.V": {
+          "encoding": "110011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI32.V": {
+          "encoding": "111011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXEI64.V": {
+          "encoding": "000011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI64.V": {
+          "encoding": "001011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI64.V": {
+          "encoding": "010011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI64.V": {
+          "encoding": "011011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI64.V": {
+          "encoding": "100011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI64.V": {
+          "encoding": "101011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI64.V": {
+          "encoding": "110011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI64.V": {
+          "encoding": "111011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXEI8.V": {
+          "encoding": "000011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI8.V": {
+          "encoding": "001011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI8.V": {
+          "encoding": "010011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI8.V": {
+          "encoding": "011011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI8.V": {
+          "encoding": "100011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI8.V": {
+          "encoding": "101011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI8.V": {
+          "encoding": "110011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI8.V": {
+          "encoding": "111011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE16.V": {
+          "encoding": "000010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E16.V": {
+          "encoding": "001010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E16.V": {
+          "encoding": "010010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E16.V": {
+          "encoding": "011010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E16.V": {
+          "encoding": "100010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E16.V": {
+          "encoding": "101010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E16.V": {
+          "encoding": "110010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E16.V": {
+          "encoding": "111010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE32.V": {
+          "encoding": "000010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E32.V": {
+          "encoding": "001010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E32.V": {
+          "encoding": "010010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E32.V": {
+          "encoding": "011010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E32.V": {
+          "encoding": "100010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E32.V": {
+          "encoding": "101010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E32.V": {
+          "encoding": "110010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E32.V": {
+          "encoding": "111010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE64.V": {
+          "encoding": "000010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E64.V": {
+          "encoding": "001010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E64.V": {
+          "encoding": "010010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E64.V": {
+          "encoding": "011010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E64.V": {
+          "encoding": "100010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E64.V": {
+          "encoding": "101010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E64.V": {
+          "encoding": "110010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E64.V": {
+          "encoding": "111010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE8.V": {
+          "encoding": "000010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E8.V": {
+          "encoding": "001010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E8.V": {
+          "encoding": "010010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E8.V": {
+          "encoding": "011010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E8.V": {
+          "encoding": "100010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E8.V": {
+          "encoding": "101010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E8.V": {
+          "encoding": "110010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E8.V": {
+          "encoding": "111010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI16.V": {
+          "encoding": "000001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI16.V": {
+          "encoding": "001001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI16.V": {
+          "encoding": "010001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI16.V": {
+          "encoding": "011001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI16.V": {
+          "encoding": "100001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI16.V": {
+          "encoding": "101001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI16.V": {
+          "encoding": "110001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI16.V": {
+          "encoding": "111001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI32.V": {
+          "encoding": "000001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI32.V": {
+          "encoding": "001001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI32.V": {
+          "encoding": "010001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI32.V": {
+          "encoding": "011001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI32.V": {
+          "encoding": "100001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI32.V": {
+          "encoding": "101001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI32.V": {
+          "encoding": "110001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI32.V": {
+          "encoding": "111001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI64.V": {
+          "encoding": "000001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI64.V": {
+          "encoding": "001001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI64.V": {
+          "encoding": "010001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI64.V": {
+          "encoding": "011001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI64.V": {
+          "encoding": "100001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI64.V": {
+          "encoding": "101001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI64.V": {
+          "encoding": "110001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI64.V": {
+          "encoding": "111001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI8.V": {
+          "encoding": "000001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI8.V": {
+          "encoding": "001001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI8.V": {
+          "encoding": "010001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI8.V": {
+          "encoding": "011001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI8.V": {
+          "encoding": "100001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI8.V": {
+          "encoding": "101001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI8.V": {
+          "encoding": "110001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI8.V": {
+          "encoding": "111001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4000007",
+          "mask": "0xfc00707f"
+        },
+        "VMACC.VV": {
+          "encoding": "101101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4002057",
+          "mask": "0xfc00707f"
+        },
+        "VMACC.VX": {
+          "encoding": "101101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4006057",
+          "mask": "0xfc00707f"
+        },
+        "VMADC.VI": {
+          "encoding": "0100011----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46003057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VIM": {
+          "encoding": "0100010----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44003057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VV": {
+          "encoding": "0100011----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46000057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VVM": {
+          "encoding": "0100010----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VX": {
+          "encoding": "0100011----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46004057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VXM": {
+          "encoding": "0100010----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44004057",
+          "mask": "0xfe00707f"
+        },
+        "VMADD.VV": {
+          "encoding": "101001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4002057",
+          "mask": "0xfc00707f"
+        },
+        "VMADD.VX": {
+          "encoding": "101001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006057",
+          "mask": "0xfc00707f"
+        },
+        "VMAND.MM": {
+          "encoding": "0110011----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x66002057",
+          "mask": "0xfe00707f"
+        },
+        "VMANDN.MM": {
+          "encoding": "0110001----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62002057",
+          "mask": "0xfe00707f"
+        },
+        "VMAX.VV": {
+          "encoding": "000111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c000057",
+          "mask": "0xfc00707f"
+        },
+        "VMAX.VX": {
+          "encoding": "000111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMAXU.VV": {
+          "encoding": "000110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18000057",
+          "mask": "0xfc00707f"
+        },
+        "VMAXU.VX": {
+          "encoding": "000110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18004057",
+          "mask": "0xfc00707f"
+        },
+        "VMERGE.VIM": {
+          "encoding": "0101110----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c003057",
+          "mask": "0xfe00707f"
+        },
+        "VMERGE.VVM": {
+          "encoding": "0101110----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c000057",
+          "mask": "0xfe00707f"
+        },
+        "VMERGE.VXM": {
+          "encoding": "0101110----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c004057",
+          "mask": "0xfe00707f"
+        },
+        "VMIN.VV": {
+          "encoding": "000101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14000057",
+          "mask": "0xfc00707f"
+        },
+        "VMIN.VX": {
+          "encoding": "000101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14004057",
+          "mask": "0xfc00707f"
+        },
+        "VMINU.VV": {
+          "encoding": "000100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10000057",
+          "mask": "0xfc00707f"
+        },
+        "VMINU.VX": {
+          "encoding": "000100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10004057",
+          "mask": "0xfc00707f"
+        },
+        "VMNAND.MM": {
+          "encoding": "0111011----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x76002057",
+          "mask": "0xfe00707f"
+        },
+        "VMNOR.MM": {
+          "encoding": "0111101----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7a002057",
+          "mask": "0xfe00707f"
+        },
+        "VMOR.MM": {
+          "encoding": "0110101----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6a002057",
+          "mask": "0xfe00707f"
+        },
+        "VMORN.MM": {
+          "encoding": "0111001----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x72002057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VV": {
+          "encoding": "0100111----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4e000057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VVM": {
+          "encoding": "0100110----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VX": {
+          "encoding": "0100111----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4e004057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VXM": {
+          "encoding": "0100110----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c004057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBF.M": {
+          "encoding": "010100------00001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5000a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMSEQ.VI": {
+          "encoding": "011000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSEQ.VV": {
+          "encoding": "011000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSEQ.VX": {
+          "encoding": "011000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGT.VI": {
+          "encoding": "011111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7c003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGT.VX": {
+          "encoding": "011111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGTU.VI": {
+          "encoding": "011110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x78003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGTU.VX": {
+          "encoding": "011110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x78004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSIF.M": {
+          "encoding": "010100------00011010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5001a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMSLE.VI": {
+          "encoding": "011101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLE.VV": {
+          "encoding": "011101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLE.VX": {
+          "encoding": "011101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VI": {
+          "encoding": "011100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VV": {
+          "encoding": "011100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VX": {
+          "encoding": "011100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLT.VV": {
+          "encoding": "011011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLT.VX": {
+          "encoding": "011011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLTU.VV": {
+          "encoding": "011010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLTU.VX": {
+          "encoding": "011010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VI": {
+          "encoding": "011001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VV": {
+          "encoding": "011001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VX": {
+          "encoding": "011001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSOF.M": {
+          "encoding": "010100------00010010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x50012057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMUL.VV": {
+          "encoding": "100101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94002057",
+          "mask": "0xfc00707f"
+        },
+        "VMUL.VX": {
+          "encoding": "100101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULH.VV": {
+          "encoding": "100111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULH.VX": {
+          "encoding": "100111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHSU.VV": {
+          "encoding": "100110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x98002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHSU.VX": {
+          "encoding": "100110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x98006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHU.VV": {
+          "encoding": "100100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHU.VX": {
+          "encoding": "100100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90006057",
+          "mask": "0xfc00707f"
+        },
+        "VMV1R.V": {
+          "encoding": "1001111-----00000011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e003057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV2R.V": {
+          "encoding": "1001111-----00001011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e00b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV4R.V": {
+          "encoding": "1001111-----00011011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e01b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV8R.V": {
+          "encoding": "1001111-----00111011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e03b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV.S.X": {
+          "encoding": "010000100000-----110-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42006057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.I": {
+          "encoding": "010111100000-----011-----1010111",
+          "variable_fields": [
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e003057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.V": {
+          "encoding": "010111100000-----000-----1010111",
+          "variable_fields": [
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e000057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.X": {
+          "encoding": "010111100000-----100-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e004057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.X.S": {
+          "encoding": "0100001-----00000010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42002057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMXNOR.MM": {
+          "encoding": "0111111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7e002057",
+          "mask": "0xfe00707f"
+        },
+        "VMXOR.MM": {
+          "encoding": "0110111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6e002057",
+          "mask": "0xfe00707f"
+        },
+        "VNCLIP.WI": {
+          "encoding": "101111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc003057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIP.WV": {
+          "encoding": "101111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc000057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIP.WX": {
+          "encoding": "101111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc004057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WI": {
+          "encoding": "101110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8003057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WV": {
+          "encoding": "101110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8000057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WX": {
+          "encoding": "101110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8004057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSAC.VV": {
+          "encoding": "101111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc002057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSAC.VX": {
+          "encoding": "101111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc006057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSUB.VV": {
+          "encoding": "101011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac002057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSUB.VX": {
+          "encoding": "101011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WI": {
+          "encoding": "101101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4003057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WV": {
+          "encoding": "101101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4000057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WX": {
+          "encoding": "101101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4004057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WI": {
+          "encoding": "101100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0003057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WV": {
+          "encoding": "101100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0000057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WX": {
+          "encoding": "101100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0004057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VI": {
+          "encoding": "001010-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28003057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VV": {
+          "encoding": "001010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VX": {
+          "encoding": "001010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28004057",
+          "mask": "0xfc00707f"
+        },
+        "VREDAND.VS": {
+          "encoding": "000001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMAX.VS": {
+          "encoding": "000111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMAXU.VS": {
+          "encoding": "000110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMIN.VS": {
+          "encoding": "000101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMINU.VS": {
+          "encoding": "000100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDOR.VS": {
+          "encoding": "000010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDSUM.VS": {
+          "encoding": "000000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2057",
+          "mask": "0xfc00707f"
+        },
+        "VREDXOR.VS": {
+          "encoding": "000011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc002057",
+          "mask": "0xfc00707f"
+        },
+        "VREM.VV": {
+          "encoding": "100011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c002057",
+          "mask": "0xfc00707f"
+        },
+        "VREM.VX": {
+          "encoding": "100011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006057",
+          "mask": "0xfc00707f"
+        },
+        "VREMU.VV": {
+          "encoding": "100010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88002057",
+          "mask": "0xfc00707f"
+        },
+        "VREMU.VX": {
+          "encoding": "100010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VI": {
+          "encoding": "001100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30003057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VV": {
+          "encoding": "001100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30000057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VX": {
+          "encoding": "001100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30004057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHEREI16.VV": {
+          "encoding": "001110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38000057",
+          "mask": "0xfc00707f"
+        },
+        "VRSUB.VI": {
+          "encoding": "000011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc003057",
+          "mask": "0xfc00707f"
+        },
+        "VRSUB.VX": {
+          "encoding": "000011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc004057",
+          "mask": "0xfc00707f"
+        },
+        "VS1R.V": {
+          "encoding": "000000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2800027",
+          "mask": "0xfff0707f"
+        },
+        "VS2R.V": {
+          "encoding": "001000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22800027",
+          "mask": "0xfff0707f"
+        },
+        "VS4R.V": {
+          "encoding": "011000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62800027",
+          "mask": "0xfff0707f"
+        },
+        "VS8R.V": {
+          "encoding": "111000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2800027",
+          "mask": "0xfff0707f"
+        },
+        "VSADD.VI": {
+          "encoding": "100001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84003057",
+          "mask": "0xfc00707f"
+        },
+        "VSADD.VV": {
+          "encoding": "100001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000057",
+          "mask": "0xfc00707f"
+        },
+        "VSADD.VX": {
+          "encoding": "100001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84004057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VI": {
+          "encoding": "100000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80003057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VV": {
+          "encoding": "100000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VX": {
+          "encoding": "100000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80004057",
+          "mask": "0xfc00707f"
+        },
+        "VSBC.VVM": {
+          "encoding": "0100100----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000057",
+          "mask": "0xfe00707f"
+        },
+        "VSBC.VXM": {
+          "encoding": "0100100----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48004057",
+          "mask": "0xfe00707f"
+        },
+        "VSE16.V": {
+          "encoding": "000000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E16.V": {
+          "encoding": "001000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E16.V": {
+          "encoding": "010000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E16.V": {
+          "encoding": "011000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E16.V": {
+          "encoding": "100000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E16.V": {
+          "encoding": "101000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E16.V": {
+          "encoding": "110000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E16.V": {
+          "encoding": "111000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSE32.V": {
+          "encoding": "000000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E32.V": {
+          "encoding": "001000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E32.V": {
+          "encoding": "010000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E32.V": {
+          "encoding": "011000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E32.V": {
+          "encoding": "100000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E32.V": {
+          "encoding": "101000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E32.V": {
+          "encoding": "110000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E32.V": {
+          "encoding": "111000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSE64.V": {
+          "encoding": "000000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E64.V": {
+          "encoding": "001000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E64.V": {
+          "encoding": "010000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E64.V": {
+          "encoding": "011000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E64.V": {
+          "encoding": "100000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E64.V": {
+          "encoding": "101000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E64.V": {
+          "encoding": "110000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E64.V": {
+          "encoding": "111000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSE8.V": {
+          "encoding": "000000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x27",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E8.V": {
+          "encoding": "001000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E8.V": {
+          "encoding": "010000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E8.V": {
+          "encoding": "011000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E8.V": {
+          "encoding": "100000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E8.V": {
+          "encoding": "101000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E8.V": {
+          "encoding": "110000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E8.V": {
+          "encoding": "111000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSETIVLI": {
+          "encoding": "11---------------111-----1010111",
+          "variable_fields": [
+            "zimm10",
+            "zimm5",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0007057",
+          "mask": "0xc000707f"
+        },
+        "VSETVL": {
+          "encoding": "1000000----------111-----1010111",
+          "variable_fields": [
+            "rs2",
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80007057",
+          "mask": "0xfe00707f"
+        },
+        "VSETVLI": {
+          "encoding": "0----------------111-----1010111",
+          "variable_fields": [
+            "zimm11",
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7057",
+          "mask": "0x8000707f"
+        },
+        "VSEXT.VF2": {
+          "encoding": "010010------00111010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4803a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSEXT.VF4": {
+          "encoding": "010010------00101010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4802a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSEXT.VF8": {
+          "encoding": "010010------00011010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4801a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSLIDE1DOWN.VX": {
+          "encoding": "001111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c006057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDE1UP.VX": {
+          "encoding": "001110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38006057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEDOWN.VI": {
+          "encoding": "001111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEDOWN.VX": {
+          "encoding": "001111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEUP.VI": {
+          "encoding": "001110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEUP.VX": {
+          "encoding": "001110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38004057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VI": {
+          "encoding": "100101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VV": {
+          "encoding": "100101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94000057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VX": {
+          "encoding": "100101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94004057",
+          "mask": "0xfc00707f"
+        },
+        "VSM.V": {
+          "encoding": "000000101011-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2b00027",
+          "mask": "0xfff0707f"
+        },
+        "VSMUL.VV": {
+          "encoding": "100111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c000057",
+          "mask": "0xfc00707f"
+        },
+        "VSMUL.VX": {
+          "encoding": "100111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI16.V": {
+          "encoding": "000011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI16.V": {
+          "encoding": "001011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI16.V": {
+          "encoding": "010011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI16.V": {
+          "encoding": "011011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI16.V": {
+          "encoding": "100011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI16.V": {
+          "encoding": "101011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI16.V": {
+          "encoding": "110011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI16.V": {
+          "encoding": "111011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI32.V": {
+          "encoding": "000011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI32.V": {
+          "encoding": "001011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI32.V": {
+          "encoding": "010011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI32.V": {
+          "encoding": "011011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI32.V": {
+          "encoding": "100011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI32.V": {
+          "encoding": "101011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI32.V": {
+          "encoding": "110011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI32.V": {
+          "encoding": "111011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI64.V": {
+          "encoding": "000011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI64.V": {
+          "encoding": "001011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI64.V": {
+          "encoding": "010011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI64.V": {
+          "encoding": "011011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI64.V": {
+          "encoding": "100011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI64.V": {
+          "encoding": "101011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI64.V": {
+          "encoding": "110011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI64.V": {
+          "encoding": "111011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI8.V": {
+          "encoding": "000011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI8.V": {
+          "encoding": "001011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI8.V": {
+          "encoding": "010011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI8.V": {
+          "encoding": "011011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI8.V": {
+          "encoding": "100011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI8.V": {
+          "encoding": "101011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI8.V": {
+          "encoding": "110011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI8.V": {
+          "encoding": "111011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec000027",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VI": {
+          "encoding": "101001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4003057",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VV": {
+          "encoding": "101001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000057",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VX": {
+          "encoding": "101001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4004057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VI": {
+          "encoding": "101000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0003057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VV": {
+          "encoding": "101000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VX": {
+          "encoding": "101000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSE16.V": {
+          "encoding": "000010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E16.V": {
+          "encoding": "001010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E16.V": {
+          "encoding": "010010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E16.V": {
+          "encoding": "011010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E16.V": {
+          "encoding": "100010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E16.V": {
+          "encoding": "101010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E16.V": {
+          "encoding": "110010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E16.V": {
+          "encoding": "111010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSE32.V": {
+          "encoding": "000010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E32.V": {
+          "encoding": "001010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E32.V": {
+          "encoding": "010010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E32.V": {
+          "encoding": "011010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E32.V": {
+          "encoding": "100010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E32.V": {
+          "encoding": "101010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E32.V": {
+          "encoding": "110010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E32.V": {
+          "encoding": "111010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSE64.V": {
+          "encoding": "000010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E64.V": {
+          "encoding": "001010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E64.V": {
+          "encoding": "010010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E64.V": {
+          "encoding": "011010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E64.V": {
+          "encoding": "100010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E64.V": {
+          "encoding": "101010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E64.V": {
+          "encoding": "110010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E64.V": {
+          "encoding": "111010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSE8.V": {
+          "encoding": "000010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E8.V": {
+          "encoding": "001010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E8.V": {
+          "encoding": "010010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E8.V": {
+          "encoding": "011010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E8.V": {
+          "encoding": "100010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E8.V": {
+          "encoding": "101010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E8.V": {
+          "encoding": "110010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E8.V": {
+          "encoding": "111010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VI": {
+          "encoding": "101011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac003057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VV": {
+          "encoding": "101011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VX": {
+          "encoding": "101011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VI": {
+          "encoding": "101010-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8003057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VV": {
+          "encoding": "101010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VX": {
+          "encoding": "101010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUB.VV": {
+          "encoding": "100011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUB.VX": {
+          "encoding": "100011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUBU.VV": {
+          "encoding": "100010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUBU.VX": {
+          "encoding": "100010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88004057",
+          "mask": "0xfc00707f"
+        },
+        "VSUB.VV": {
+          "encoding": "000010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000057",
+          "mask": "0xfc00707f"
+        },
+        "VSUB.VX": {
+          "encoding": "000010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8004057",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI16.V": {
+          "encoding": "000001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI16.V": {
+          "encoding": "001001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI16.V": {
+          "encoding": "010001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI16.V": {
+          "encoding": "011001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI16.V": {
+          "encoding": "100001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI16.V": {
+          "encoding": "101001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI16.V": {
+          "encoding": "110001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI16.V": {
+          "encoding": "111001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI32.V": {
+          "encoding": "000001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI32.V": {
+          "encoding": "001001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI32.V": {
+          "encoding": "010001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI32.V": {
+          "encoding": "011001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI32.V": {
+          "encoding": "100001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI32.V": {
+          "encoding": "101001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI32.V": {
+          "encoding": "110001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI32.V": {
+          "encoding": "111001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI64.V": {
+          "encoding": "000001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI64.V": {
+          "encoding": "001001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI64.V": {
+          "encoding": "010001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI64.V": {
+          "encoding": "011001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI64.V": {
+          "encoding": "100001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI64.V": {
+          "encoding": "101001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI64.V": {
+          "encoding": "110001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI64.V": {
+          "encoding": "111001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI8.V": {
+          "encoding": "000001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI8.V": {
+          "encoding": "001001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI8.V": {
+          "encoding": "010001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI8.V": {
+          "encoding": "011001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI8.V": {
+          "encoding": "100001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI8.V": {
+          "encoding": "101001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI8.V": {
+          "encoding": "110001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI8.V": {
+          "encoding": "111001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4000027",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.VV": {
+          "encoding": "110001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.VX": {
+          "encoding": "110001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.WV": {
+          "encoding": "110101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.WX": {
+          "encoding": "110101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.VV": {
+          "encoding": "110000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.VX": {
+          "encoding": "110000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.WV": {
+          "encoding": "110100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.WX": {
+          "encoding": "110100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACC.VV": {
+          "encoding": "111101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACC.VX": {
+          "encoding": "111101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCSU.VV": {
+          "encoding": "111111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xfc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCSU.VX": {
+          "encoding": "111111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xfc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCU.VV": {
+          "encoding": "111100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCU.VX": {
+          "encoding": "111100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCUS.VX": {
+          "encoding": "111110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMUL.VV": {
+          "encoding": "111011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMUL.VX": {
+          "encoding": "111011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULSU.VV": {
+          "encoding": "111010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULSU.VX": {
+          "encoding": "111010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULU.VV": {
+          "encoding": "111000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULU.VX": {
+          "encoding": "111000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWREDSUM.VS": {
+          "encoding": "110001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000057",
+          "mask": "0xfc00707f"
+        },
+        "VWREDSUMU.VS": {
+          "encoding": "110000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.VV": {
+          "encoding": "110011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.VX": {
+          "encoding": "110011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.WV": {
+          "encoding": "110111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xdc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.WX": {
+          "encoding": "110111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xdc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.VV": {
+          "encoding": "110010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.VX": {
+          "encoding": "110010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.WV": {
+          "encoding": "110110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.WX": {
+          "encoding": "110110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd8006057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VI": {
+          "encoding": "001011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c003057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VV": {
+          "encoding": "001011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VX": {
+          "encoding": "001011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c004057",
+          "mask": "0xfc00707f"
+        },
+        "VZEXT.VF2": {
+          "encoding": "010010------00110010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48032057",
+          "mask": "0xfc0ff07f"
+        },
+        "VZEXT.VF4": {
+          "encoding": "010010------00100010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48022057",
+          "mask": "0xfc0ff07f"
+        },
+        "VZEXT.VF8": {
+          "encoding": "010010------00010010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48012057",
+          "mask": "0xfc0ff07f"
+        }
+      },
       "state": "ratified",
       "ratification_date": "2021-11",
       "version": "1.0.0"
@@ -21002,7 +42163,8233 @@
       "desc": "Single-precision vector floating-point alongside 64-bit integer elements, for embedded cores that skip FP64.",
       "use": "FP32 + 64-bit int vectors",
       "url": "https://docs.riscv.org/reference/isa/unpriv/v-st-ext.html",
-      "instructions": {},
+      "instructions": {
+        "VAADD.VV": {
+          "encoding": "001001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24002057",
+          "mask": "0xfc00707f"
+        },
+        "VAADD.VX": {
+          "encoding": "001001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006057",
+          "mask": "0xfc00707f"
+        },
+        "VAADDU.VV": {
+          "encoding": "001000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20002057",
+          "mask": "0xfc00707f"
+        },
+        "VAADDU.VX": {
+          "encoding": "001000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006057",
+          "mask": "0xfc00707f"
+        },
+        "VADC.VIM": {
+          "encoding": "0100000----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40003057",
+          "mask": "0xfe00707f"
+        },
+        "VADC.VVM": {
+          "encoding": "0100000----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000057",
+          "mask": "0xfe00707f"
+        },
+        "VADC.VXM": {
+          "encoding": "0100000----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40004057",
+          "mask": "0xfe00707f"
+        },
+        "VADD.VI": {
+          "encoding": "000000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3057",
+          "mask": "0xfc00707f"
+        },
+        "VADD.VV": {
+          "encoding": "000000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x57",
+          "mask": "0xfc00707f"
+        },
+        "VADD.VX": {
+          "encoding": "000000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VI": {
+          "encoding": "001001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24003057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VV": {
+          "encoding": "001001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VX": {
+          "encoding": "001001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24004057",
+          "mask": "0xfc00707f"
+        },
+        "VASUB.VV": {
+          "encoding": "001011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c002057",
+          "mask": "0xfc00707f"
+        },
+        "VASUB.VX": {
+          "encoding": "001011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006057",
+          "mask": "0xfc00707f"
+        },
+        "VASUBU.VV": {
+          "encoding": "001010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28002057",
+          "mask": "0xfc00707f"
+        },
+        "VASUBU.VX": {
+          "encoding": "001010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006057",
+          "mask": "0xfc00707f"
+        },
+        "VCOMPRESS.VM": {
+          "encoding": "0101111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e002057",
+          "mask": "0xfe00707f"
+        },
+        "VCPOP.M": {
+          "encoding": "010000------10000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40082057",
+          "mask": "0xfc0ff07f"
+        },
+        "VDIV.VV": {
+          "encoding": "100001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84002057",
+          "mask": "0xfc00707f"
+        },
+        "VDIV.VX": {
+          "encoding": "100001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006057",
+          "mask": "0xfc00707f"
+        },
+        "VDIVU.VV": {
+          "encoding": "100000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80002057",
+          "mask": "0xfc00707f"
+        },
+        "VDIVU.VX": {
+          "encoding": "100000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006057",
+          "mask": "0xfc00707f"
+        },
+        "VFADD.VF": {
+          "encoding": "000000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5057",
+          "mask": "0xfc00707f"
+        },
+        "VFADD.VV": {
+          "encoding": "000000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1057",
+          "mask": "0xfc00707f"
+        },
+        "VFCLASS.V": {
+          "encoding": "010011------10000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c081057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.F.X.V": {
+          "encoding": "010010------00011001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48019057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.F.XU.V": {
+          "encoding": "010010------00010001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48011057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.RTZ.X.F.V": {
+          "encoding": "010010------00111001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48039057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.RTZ.XU.F.V": {
+          "encoding": "010010------00110001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48031057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.X.F.V": {
+          "encoding": "010010------00001001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48009057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.XU.F.V": {
+          "encoding": "010010------00000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48001057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFDIV.VF": {
+          "encoding": "100000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80005057",
+          "mask": "0xfc00707f"
+        },
+        "VFDIV.VV": {
+          "encoding": "100000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80001057",
+          "mask": "0xfc00707f"
+        },
+        "VFIRST.M": {
+          "encoding": "010000------10001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4008a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFMACC.VF": {
+          "encoding": "101100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMACC.VV": {
+          "encoding": "101100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMADD.VF": {
+          "encoding": "101000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMADD.VV": {
+          "encoding": "101000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMAX.VF": {
+          "encoding": "000110-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMAX.VV": {
+          "encoding": "000110-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMERGE.VFM": {
+          "encoding": "0101110----------101-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c005057",
+          "mask": "0xfe00707f"
+        },
+        "VFMIN.VF": {
+          "encoding": "000100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMIN.VV": {
+          "encoding": "000100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMSAC.VF": {
+          "encoding": "101110-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMSAC.VV": {
+          "encoding": "101110-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMSUB.VF": {
+          "encoding": "101010-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMSUB.VV": {
+          "encoding": "101010-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMUL.VF": {
+          "encoding": "100100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMUL.VV": {
+          "encoding": "100100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMV.F.S": {
+          "encoding": "0100001-----00000001-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42001057",
+          "mask": "0xfe0ff07f"
+        },
+        "VFMV.S.F": {
+          "encoding": "010000100000-----101-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42005057",
+          "mask": "0xfff0707f"
+        },
+        "VFMV.V.F": {
+          "encoding": "010111100000-----101-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e005057",
+          "mask": "0xfff0707f"
+        },
+        "VFNCVT.F.X.W": {
+          "encoding": "010010------10011001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48099057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.F.XU.W": {
+          "encoding": "010010------10010001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48091057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.RTZ.X.F.W": {
+          "encoding": "010010------10111001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x480b9057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.RTZ.XU.F.W": {
+          "encoding": "010010------10110001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x480b1057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.X.F.W": {
+          "encoding": "010010------10001001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48089057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.XU.F.W": {
+          "encoding": "010010------10000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48081057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNMACC.VF": {
+          "encoding": "101101-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4005057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMACC.VV": {
+          "encoding": "101101-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4001057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMADD.VF": {
+          "encoding": "101001-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4005057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMADD.VV": {
+          "encoding": "101001-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4001057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMSAC.VF": {
+          "encoding": "101111-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc005057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMSAC.VV": {
+          "encoding": "101111-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc001057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMSUB.VF": {
+          "encoding": "101011-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac005057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMSUB.VV": {
+          "encoding": "101011-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac001057",
+          "mask": "0xfc00707f"
+        },
+        "VFRDIV.VF": {
+          "encoding": "100001-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84005057",
+          "mask": "0xfc00707f"
+        },
+        "VFREC7.V": {
+          "encoding": "010011------00101001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c029057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFREDMAX.VS": {
+          "encoding": "000111-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c001057",
+          "mask": "0xfc00707f"
+        },
+        "VFREDMIN.VS": {
+          "encoding": "000101-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14001057",
+          "mask": "0xfc00707f"
+        },
+        "VFREDOSUM.VS": {
+          "encoding": "000011-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc001057",
+          "mask": "0xfc00707f"
+        },
+        "VFREDUSUM.VS": {
+          "encoding": "000001-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4001057",
+          "mask": "0xfc00707f"
+        },
+        "VFRSQRT7.V": {
+          "encoding": "010011------00100001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c021057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFRSUB.VF": {
+          "encoding": "100111-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJ.VF": {
+          "encoding": "001000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJ.VV": {
+          "encoding": "001000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20001057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJN.VF": {
+          "encoding": "001001-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJN.VV": {
+          "encoding": "001001-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24001057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJX.VF": {
+          "encoding": "001010-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJX.VV": {
+          "encoding": "001010-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28001057",
+          "mask": "0xfc00707f"
+        },
+        "VFSLIDE1DOWN.VF": {
+          "encoding": "001111-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSLIDE1UP.VF": {
+          "encoding": "001110-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSQRT.V": {
+          "encoding": "010011------00000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c001057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFSUB.VF": {
+          "encoding": "000010-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSUB.VV": {
+          "encoding": "000010-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8001057",
+          "mask": "0xfc00707f"
+        },
+        "VFWCVT.F.X.V": {
+          "encoding": "010010------01011001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48059057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFWCVT.F.XU.V": {
+          "encoding": "010010------01010001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48051057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFWCVT.RTZ.X.F.V": {
+          "encoding": "010010------01111001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48079057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFWCVT.RTZ.XU.F.V": {
+          "encoding": "010010------01110001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48071057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFWCVT.X.F.V": {
+          "encoding": "010010------01001001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48049057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFWCVT.XU.F.V": {
+          "encoding": "010010------01000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48041057",
+          "mask": "0xfc0ff07f"
+        },
+        "VID.V": {
+          "encoding": "010100-0000010001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5008a057",
+          "mask": "0xfdfff07f"
+        },
+        "VIOTA.M": {
+          "encoding": "010100------10000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x50082057",
+          "mask": "0xfc0ff07f"
+        },
+        "VL1RE16.V": {
+          "encoding": "000000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2805007",
+          "mask": "0xfff0707f"
+        },
+        "VL1RE32.V": {
+          "encoding": "000000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2806007",
+          "mask": "0xfff0707f"
+        },
+        "VL1RE64.V": {
+          "encoding": "000000101000-----111-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2807007",
+          "mask": "0xfff0707f"
+        },
+        "VL1RE8.V": {
+          "encoding": "000000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2800007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE16.V": {
+          "encoding": "001000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22805007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE32.V": {
+          "encoding": "001000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22806007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE64.V": {
+          "encoding": "001000101000-----111-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22807007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE8.V": {
+          "encoding": "001000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22800007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE16.V": {
+          "encoding": "011000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62805007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE32.V": {
+          "encoding": "011000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62806007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE64.V": {
+          "encoding": "011000101000-----111-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62807007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE8.V": {
+          "encoding": "011000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62800007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE16.V": {
+          "encoding": "111000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2805007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE32.V": {
+          "encoding": "111000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2806007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE64.V": {
+          "encoding": "111000101000-----111-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2807007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE8.V": {
+          "encoding": "111000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2800007",
+          "mask": "0xfff0707f"
+        },
+        "VLE16.V": {
+          "encoding": "000000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E16.V": {
+          "encoding": "001000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E16.V": {
+          "encoding": "010000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E16.V": {
+          "encoding": "011000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E16.V": {
+          "encoding": "100000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E16.V": {
+          "encoding": "101000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E16.V": {
+          "encoding": "110000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E16.V": {
+          "encoding": "111000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE16FF.V": {
+          "encoding": "000000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E16FF.V": {
+          "encoding": "001000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E16FF.V": {
+          "encoding": "010000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E16FF.V": {
+          "encoding": "011000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E16FF.V": {
+          "encoding": "100000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E16FF.V": {
+          "encoding": "101000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E16FF.V": {
+          "encoding": "110000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E16FF.V": {
+          "encoding": "111000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE32.V": {
+          "encoding": "000000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E32.V": {
+          "encoding": "001000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E32.V": {
+          "encoding": "010000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E32.V": {
+          "encoding": "011000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E32.V": {
+          "encoding": "100000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E32.V": {
+          "encoding": "101000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E32.V": {
+          "encoding": "110000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E32.V": {
+          "encoding": "111000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE32FF.V": {
+          "encoding": "000000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E32FF.V": {
+          "encoding": "001000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E32FF.V": {
+          "encoding": "010000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E32FF.V": {
+          "encoding": "011000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E32FF.V": {
+          "encoding": "100000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E32FF.V": {
+          "encoding": "101000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E32FF.V": {
+          "encoding": "110000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E32FF.V": {
+          "encoding": "111000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE64.V": {
+          "encoding": "000000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E64.V": {
+          "encoding": "001000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E64.V": {
+          "encoding": "010000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E64.V": {
+          "encoding": "011000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E64.V": {
+          "encoding": "100000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E64.V": {
+          "encoding": "101000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E64.V": {
+          "encoding": "110000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E64.V": {
+          "encoding": "111000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE64FF.V": {
+          "encoding": "000000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E64FF.V": {
+          "encoding": "001000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E64FF.V": {
+          "encoding": "010000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E64FF.V": {
+          "encoding": "011000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E64FF.V": {
+          "encoding": "100000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E64FF.V": {
+          "encoding": "101000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E64FF.V": {
+          "encoding": "110000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E64FF.V": {
+          "encoding": "111000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE8.V": {
+          "encoding": "000000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E8.V": {
+          "encoding": "001000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E8.V": {
+          "encoding": "010000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E8.V": {
+          "encoding": "011000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E8.V": {
+          "encoding": "100000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E8.V": {
+          "encoding": "101000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E8.V": {
+          "encoding": "110000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E8.V": {
+          "encoding": "111000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE8FF.V": {
+          "encoding": "000000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E8FF.V": {
+          "encoding": "001000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E8FF.V": {
+          "encoding": "010000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E8FF.V": {
+          "encoding": "011000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E8FF.V": {
+          "encoding": "100000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E8FF.V": {
+          "encoding": "101000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E8FF.V": {
+          "encoding": "110000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E8FF.V": {
+          "encoding": "111000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLM.V": {
+          "encoding": "000000101011-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2b00007",
+          "mask": "0xfff0707f"
+        },
+        "VLOXEI16.V": {
+          "encoding": "000011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI16.V": {
+          "encoding": "001011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI16.V": {
+          "encoding": "010011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI16.V": {
+          "encoding": "011011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI16.V": {
+          "encoding": "100011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI16.V": {
+          "encoding": "101011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI16.V": {
+          "encoding": "110011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI16.V": {
+          "encoding": "111011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXEI32.V": {
+          "encoding": "000011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI32.V": {
+          "encoding": "001011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI32.V": {
+          "encoding": "010011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI32.V": {
+          "encoding": "011011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI32.V": {
+          "encoding": "100011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI32.V": {
+          "encoding": "101011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI32.V": {
+          "encoding": "110011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI32.V": {
+          "encoding": "111011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXEI64.V": {
+          "encoding": "000011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI64.V": {
+          "encoding": "001011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI64.V": {
+          "encoding": "010011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI64.V": {
+          "encoding": "011011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI64.V": {
+          "encoding": "100011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI64.V": {
+          "encoding": "101011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI64.V": {
+          "encoding": "110011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI64.V": {
+          "encoding": "111011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXEI8.V": {
+          "encoding": "000011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI8.V": {
+          "encoding": "001011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI8.V": {
+          "encoding": "010011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI8.V": {
+          "encoding": "011011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI8.V": {
+          "encoding": "100011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI8.V": {
+          "encoding": "101011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI8.V": {
+          "encoding": "110011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI8.V": {
+          "encoding": "111011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE16.V": {
+          "encoding": "000010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E16.V": {
+          "encoding": "001010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E16.V": {
+          "encoding": "010010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E16.V": {
+          "encoding": "011010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E16.V": {
+          "encoding": "100010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E16.V": {
+          "encoding": "101010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E16.V": {
+          "encoding": "110010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E16.V": {
+          "encoding": "111010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE32.V": {
+          "encoding": "000010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E32.V": {
+          "encoding": "001010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E32.V": {
+          "encoding": "010010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E32.V": {
+          "encoding": "011010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E32.V": {
+          "encoding": "100010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E32.V": {
+          "encoding": "101010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E32.V": {
+          "encoding": "110010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E32.V": {
+          "encoding": "111010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE64.V": {
+          "encoding": "000010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E64.V": {
+          "encoding": "001010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E64.V": {
+          "encoding": "010010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E64.V": {
+          "encoding": "011010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E64.V": {
+          "encoding": "100010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E64.V": {
+          "encoding": "101010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E64.V": {
+          "encoding": "110010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E64.V": {
+          "encoding": "111010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE8.V": {
+          "encoding": "000010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E8.V": {
+          "encoding": "001010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E8.V": {
+          "encoding": "010010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E8.V": {
+          "encoding": "011010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E8.V": {
+          "encoding": "100010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E8.V": {
+          "encoding": "101010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E8.V": {
+          "encoding": "110010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E8.V": {
+          "encoding": "111010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI16.V": {
+          "encoding": "000001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI16.V": {
+          "encoding": "001001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI16.V": {
+          "encoding": "010001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI16.V": {
+          "encoding": "011001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI16.V": {
+          "encoding": "100001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI16.V": {
+          "encoding": "101001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI16.V": {
+          "encoding": "110001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI16.V": {
+          "encoding": "111001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI32.V": {
+          "encoding": "000001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI32.V": {
+          "encoding": "001001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI32.V": {
+          "encoding": "010001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI32.V": {
+          "encoding": "011001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI32.V": {
+          "encoding": "100001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI32.V": {
+          "encoding": "101001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI32.V": {
+          "encoding": "110001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI32.V": {
+          "encoding": "111001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI64.V": {
+          "encoding": "000001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI64.V": {
+          "encoding": "001001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI64.V": {
+          "encoding": "010001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI64.V": {
+          "encoding": "011001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI64.V": {
+          "encoding": "100001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI64.V": {
+          "encoding": "101001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI64.V": {
+          "encoding": "110001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI64.V": {
+          "encoding": "111001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI8.V": {
+          "encoding": "000001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI8.V": {
+          "encoding": "001001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI8.V": {
+          "encoding": "010001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI8.V": {
+          "encoding": "011001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI8.V": {
+          "encoding": "100001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI8.V": {
+          "encoding": "101001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI8.V": {
+          "encoding": "110001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI8.V": {
+          "encoding": "111001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4000007",
+          "mask": "0xfc00707f"
+        },
+        "VMACC.VV": {
+          "encoding": "101101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4002057",
+          "mask": "0xfc00707f"
+        },
+        "VMACC.VX": {
+          "encoding": "101101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4006057",
+          "mask": "0xfc00707f"
+        },
+        "VMADC.VI": {
+          "encoding": "0100011----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46003057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VIM": {
+          "encoding": "0100010----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44003057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VV": {
+          "encoding": "0100011----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46000057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VVM": {
+          "encoding": "0100010----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VX": {
+          "encoding": "0100011----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46004057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VXM": {
+          "encoding": "0100010----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44004057",
+          "mask": "0xfe00707f"
+        },
+        "VMADD.VV": {
+          "encoding": "101001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4002057",
+          "mask": "0xfc00707f"
+        },
+        "VMADD.VX": {
+          "encoding": "101001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006057",
+          "mask": "0xfc00707f"
+        },
+        "VMAND.MM": {
+          "encoding": "0110011----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x66002057",
+          "mask": "0xfe00707f"
+        },
+        "VMANDN.MM": {
+          "encoding": "0110001----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62002057",
+          "mask": "0xfe00707f"
+        },
+        "VMAX.VV": {
+          "encoding": "000111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c000057",
+          "mask": "0xfc00707f"
+        },
+        "VMAX.VX": {
+          "encoding": "000111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMAXU.VV": {
+          "encoding": "000110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18000057",
+          "mask": "0xfc00707f"
+        },
+        "VMAXU.VX": {
+          "encoding": "000110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18004057",
+          "mask": "0xfc00707f"
+        },
+        "VMERGE.VIM": {
+          "encoding": "0101110----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c003057",
+          "mask": "0xfe00707f"
+        },
+        "VMERGE.VVM": {
+          "encoding": "0101110----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c000057",
+          "mask": "0xfe00707f"
+        },
+        "VMERGE.VXM": {
+          "encoding": "0101110----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c004057",
+          "mask": "0xfe00707f"
+        },
+        "VMFEQ.VF": {
+          "encoding": "011000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFEQ.VV": {
+          "encoding": "011000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60001057",
+          "mask": "0xfc00707f"
+        },
+        "VMFGE.VF": {
+          "encoding": "011111-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7c005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFGT.VF": {
+          "encoding": "011101-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFLE.VF": {
+          "encoding": "011001-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFLE.VV": {
+          "encoding": "011001-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64001057",
+          "mask": "0xfc00707f"
+        },
+        "VMFLT.VF": {
+          "encoding": "011011-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFLT.VV": {
+          "encoding": "011011-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c001057",
+          "mask": "0xfc00707f"
+        },
+        "VMFNE.VF": {
+          "encoding": "011100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFNE.VV": {
+          "encoding": "011100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70001057",
+          "mask": "0xfc00707f"
+        },
+        "VMIN.VV": {
+          "encoding": "000101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14000057",
+          "mask": "0xfc00707f"
+        },
+        "VMIN.VX": {
+          "encoding": "000101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14004057",
+          "mask": "0xfc00707f"
+        },
+        "VMINU.VV": {
+          "encoding": "000100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10000057",
+          "mask": "0xfc00707f"
+        },
+        "VMINU.VX": {
+          "encoding": "000100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10004057",
+          "mask": "0xfc00707f"
+        },
+        "VMNAND.MM": {
+          "encoding": "0111011----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x76002057",
+          "mask": "0xfe00707f"
+        },
+        "VMNOR.MM": {
+          "encoding": "0111101----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7a002057",
+          "mask": "0xfe00707f"
+        },
+        "VMOR.MM": {
+          "encoding": "0110101----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6a002057",
+          "mask": "0xfe00707f"
+        },
+        "VMORN.MM": {
+          "encoding": "0111001----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x72002057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VV": {
+          "encoding": "0100111----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4e000057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VVM": {
+          "encoding": "0100110----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VX": {
+          "encoding": "0100111----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4e004057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VXM": {
+          "encoding": "0100110----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c004057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBF.M": {
+          "encoding": "010100------00001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5000a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMSEQ.VI": {
+          "encoding": "011000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSEQ.VV": {
+          "encoding": "011000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSEQ.VX": {
+          "encoding": "011000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGT.VI": {
+          "encoding": "011111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7c003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGT.VX": {
+          "encoding": "011111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGTU.VI": {
+          "encoding": "011110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x78003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGTU.VX": {
+          "encoding": "011110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x78004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSIF.M": {
+          "encoding": "010100------00011010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5001a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMSLE.VI": {
+          "encoding": "011101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLE.VV": {
+          "encoding": "011101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLE.VX": {
+          "encoding": "011101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VI": {
+          "encoding": "011100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VV": {
+          "encoding": "011100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VX": {
+          "encoding": "011100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLT.VV": {
+          "encoding": "011011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLT.VX": {
+          "encoding": "011011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLTU.VV": {
+          "encoding": "011010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLTU.VX": {
+          "encoding": "011010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VI": {
+          "encoding": "011001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VV": {
+          "encoding": "011001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VX": {
+          "encoding": "011001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSOF.M": {
+          "encoding": "010100------00010010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x50012057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMUL.VV": {
+          "encoding": "100101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94002057",
+          "mask": "0xfc00707f"
+        },
+        "VMUL.VX": {
+          "encoding": "100101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULH.VV": {
+          "encoding": "100111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULH.VX": {
+          "encoding": "100111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHSU.VV": {
+          "encoding": "100110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x98002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHSU.VX": {
+          "encoding": "100110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x98006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHU.VV": {
+          "encoding": "100100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHU.VX": {
+          "encoding": "100100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90006057",
+          "mask": "0xfc00707f"
+        },
+        "VMV1R.V": {
+          "encoding": "1001111-----00000011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e003057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV2R.V": {
+          "encoding": "1001111-----00001011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e00b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV4R.V": {
+          "encoding": "1001111-----00011011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e01b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV8R.V": {
+          "encoding": "1001111-----00111011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e03b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV.S.X": {
+          "encoding": "010000100000-----110-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42006057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.I": {
+          "encoding": "010111100000-----011-----1010111",
+          "variable_fields": [
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e003057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.V": {
+          "encoding": "010111100000-----000-----1010111",
+          "variable_fields": [
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e000057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.X": {
+          "encoding": "010111100000-----100-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e004057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.X.S": {
+          "encoding": "0100001-----00000010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42002057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMXNOR.MM": {
+          "encoding": "0111111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7e002057",
+          "mask": "0xfe00707f"
+        },
+        "VMXOR.MM": {
+          "encoding": "0110111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6e002057",
+          "mask": "0xfe00707f"
+        },
+        "VNCLIP.WI": {
+          "encoding": "101111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc003057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIP.WV": {
+          "encoding": "101111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc000057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIP.WX": {
+          "encoding": "101111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc004057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WI": {
+          "encoding": "101110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8003057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WV": {
+          "encoding": "101110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8000057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WX": {
+          "encoding": "101110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8004057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSAC.VV": {
+          "encoding": "101111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc002057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSAC.VX": {
+          "encoding": "101111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc006057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSUB.VV": {
+          "encoding": "101011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac002057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSUB.VX": {
+          "encoding": "101011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WI": {
+          "encoding": "101101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4003057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WV": {
+          "encoding": "101101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4000057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WX": {
+          "encoding": "101101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4004057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WI": {
+          "encoding": "101100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0003057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WV": {
+          "encoding": "101100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0000057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WX": {
+          "encoding": "101100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0004057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VI": {
+          "encoding": "001010-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28003057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VV": {
+          "encoding": "001010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VX": {
+          "encoding": "001010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28004057",
+          "mask": "0xfc00707f"
+        },
+        "VREDAND.VS": {
+          "encoding": "000001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMAX.VS": {
+          "encoding": "000111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMAXU.VS": {
+          "encoding": "000110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMIN.VS": {
+          "encoding": "000101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMINU.VS": {
+          "encoding": "000100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDOR.VS": {
+          "encoding": "000010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDSUM.VS": {
+          "encoding": "000000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2057",
+          "mask": "0xfc00707f"
+        },
+        "VREDXOR.VS": {
+          "encoding": "000011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc002057",
+          "mask": "0xfc00707f"
+        },
+        "VREM.VV": {
+          "encoding": "100011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c002057",
+          "mask": "0xfc00707f"
+        },
+        "VREM.VX": {
+          "encoding": "100011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006057",
+          "mask": "0xfc00707f"
+        },
+        "VREMU.VV": {
+          "encoding": "100010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88002057",
+          "mask": "0xfc00707f"
+        },
+        "VREMU.VX": {
+          "encoding": "100010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VI": {
+          "encoding": "001100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30003057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VV": {
+          "encoding": "001100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30000057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VX": {
+          "encoding": "001100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30004057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHEREI16.VV": {
+          "encoding": "001110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38000057",
+          "mask": "0xfc00707f"
+        },
+        "VRSUB.VI": {
+          "encoding": "000011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc003057",
+          "mask": "0xfc00707f"
+        },
+        "VRSUB.VX": {
+          "encoding": "000011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc004057",
+          "mask": "0xfc00707f"
+        },
+        "VS1R.V": {
+          "encoding": "000000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2800027",
+          "mask": "0xfff0707f"
+        },
+        "VS2R.V": {
+          "encoding": "001000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22800027",
+          "mask": "0xfff0707f"
+        },
+        "VS4R.V": {
+          "encoding": "011000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62800027",
+          "mask": "0xfff0707f"
+        },
+        "VS8R.V": {
+          "encoding": "111000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2800027",
+          "mask": "0xfff0707f"
+        },
+        "VSADD.VI": {
+          "encoding": "100001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84003057",
+          "mask": "0xfc00707f"
+        },
+        "VSADD.VV": {
+          "encoding": "100001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000057",
+          "mask": "0xfc00707f"
+        },
+        "VSADD.VX": {
+          "encoding": "100001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84004057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VI": {
+          "encoding": "100000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80003057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VV": {
+          "encoding": "100000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VX": {
+          "encoding": "100000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80004057",
+          "mask": "0xfc00707f"
+        },
+        "VSBC.VVM": {
+          "encoding": "0100100----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000057",
+          "mask": "0xfe00707f"
+        },
+        "VSBC.VXM": {
+          "encoding": "0100100----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48004057",
+          "mask": "0xfe00707f"
+        },
+        "VSE16.V": {
+          "encoding": "000000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E16.V": {
+          "encoding": "001000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E16.V": {
+          "encoding": "010000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E16.V": {
+          "encoding": "011000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E16.V": {
+          "encoding": "100000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E16.V": {
+          "encoding": "101000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E16.V": {
+          "encoding": "110000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E16.V": {
+          "encoding": "111000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSE32.V": {
+          "encoding": "000000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E32.V": {
+          "encoding": "001000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E32.V": {
+          "encoding": "010000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E32.V": {
+          "encoding": "011000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E32.V": {
+          "encoding": "100000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E32.V": {
+          "encoding": "101000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E32.V": {
+          "encoding": "110000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E32.V": {
+          "encoding": "111000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSE64.V": {
+          "encoding": "000000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E64.V": {
+          "encoding": "001000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E64.V": {
+          "encoding": "010000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E64.V": {
+          "encoding": "011000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E64.V": {
+          "encoding": "100000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E64.V": {
+          "encoding": "101000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E64.V": {
+          "encoding": "110000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E64.V": {
+          "encoding": "111000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSE8.V": {
+          "encoding": "000000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x27",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E8.V": {
+          "encoding": "001000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E8.V": {
+          "encoding": "010000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E8.V": {
+          "encoding": "011000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E8.V": {
+          "encoding": "100000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E8.V": {
+          "encoding": "101000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E8.V": {
+          "encoding": "110000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E8.V": {
+          "encoding": "111000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSETIVLI": {
+          "encoding": "11---------------111-----1010111",
+          "variable_fields": [
+            "zimm10",
+            "zimm5",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0007057",
+          "mask": "0xc000707f"
+        },
+        "VSETVL": {
+          "encoding": "1000000----------111-----1010111",
+          "variable_fields": [
+            "rs2",
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80007057",
+          "mask": "0xfe00707f"
+        },
+        "VSETVLI": {
+          "encoding": "0----------------111-----1010111",
+          "variable_fields": [
+            "zimm11",
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7057",
+          "mask": "0x8000707f"
+        },
+        "VSEXT.VF2": {
+          "encoding": "010010------00111010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4803a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSEXT.VF4": {
+          "encoding": "010010------00101010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4802a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSEXT.VF8": {
+          "encoding": "010010------00011010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4801a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSLIDE1DOWN.VX": {
+          "encoding": "001111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c006057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDE1UP.VX": {
+          "encoding": "001110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38006057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEDOWN.VI": {
+          "encoding": "001111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEDOWN.VX": {
+          "encoding": "001111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEUP.VI": {
+          "encoding": "001110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEUP.VX": {
+          "encoding": "001110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38004057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VI": {
+          "encoding": "100101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VV": {
+          "encoding": "100101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94000057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VX": {
+          "encoding": "100101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94004057",
+          "mask": "0xfc00707f"
+        },
+        "VSM.V": {
+          "encoding": "000000101011-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2b00027",
+          "mask": "0xfff0707f"
+        },
+        "VSMUL.VV": {
+          "encoding": "100111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c000057",
+          "mask": "0xfc00707f"
+        },
+        "VSMUL.VX": {
+          "encoding": "100111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI16.V": {
+          "encoding": "000011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI16.V": {
+          "encoding": "001011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI16.V": {
+          "encoding": "010011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI16.V": {
+          "encoding": "011011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI16.V": {
+          "encoding": "100011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI16.V": {
+          "encoding": "101011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI16.V": {
+          "encoding": "110011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI16.V": {
+          "encoding": "111011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI32.V": {
+          "encoding": "000011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI32.V": {
+          "encoding": "001011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI32.V": {
+          "encoding": "010011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI32.V": {
+          "encoding": "011011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI32.V": {
+          "encoding": "100011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI32.V": {
+          "encoding": "101011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI32.V": {
+          "encoding": "110011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI32.V": {
+          "encoding": "111011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI64.V": {
+          "encoding": "000011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI64.V": {
+          "encoding": "001011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI64.V": {
+          "encoding": "010011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI64.V": {
+          "encoding": "011011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI64.V": {
+          "encoding": "100011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI64.V": {
+          "encoding": "101011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI64.V": {
+          "encoding": "110011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI64.V": {
+          "encoding": "111011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI8.V": {
+          "encoding": "000011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI8.V": {
+          "encoding": "001011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI8.V": {
+          "encoding": "010011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI8.V": {
+          "encoding": "011011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI8.V": {
+          "encoding": "100011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI8.V": {
+          "encoding": "101011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI8.V": {
+          "encoding": "110011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI8.V": {
+          "encoding": "111011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec000027",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VI": {
+          "encoding": "101001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4003057",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VV": {
+          "encoding": "101001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000057",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VX": {
+          "encoding": "101001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4004057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VI": {
+          "encoding": "101000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0003057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VV": {
+          "encoding": "101000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VX": {
+          "encoding": "101000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSE16.V": {
+          "encoding": "000010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E16.V": {
+          "encoding": "001010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E16.V": {
+          "encoding": "010010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E16.V": {
+          "encoding": "011010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E16.V": {
+          "encoding": "100010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E16.V": {
+          "encoding": "101010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E16.V": {
+          "encoding": "110010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E16.V": {
+          "encoding": "111010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSE32.V": {
+          "encoding": "000010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E32.V": {
+          "encoding": "001010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E32.V": {
+          "encoding": "010010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E32.V": {
+          "encoding": "011010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E32.V": {
+          "encoding": "100010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E32.V": {
+          "encoding": "101010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E32.V": {
+          "encoding": "110010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E32.V": {
+          "encoding": "111010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSE64.V": {
+          "encoding": "000010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E64.V": {
+          "encoding": "001010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E64.V": {
+          "encoding": "010010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E64.V": {
+          "encoding": "011010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E64.V": {
+          "encoding": "100010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E64.V": {
+          "encoding": "101010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E64.V": {
+          "encoding": "110010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E64.V": {
+          "encoding": "111010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSE8.V": {
+          "encoding": "000010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E8.V": {
+          "encoding": "001010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E8.V": {
+          "encoding": "010010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E8.V": {
+          "encoding": "011010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E8.V": {
+          "encoding": "100010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E8.V": {
+          "encoding": "101010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E8.V": {
+          "encoding": "110010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E8.V": {
+          "encoding": "111010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VI": {
+          "encoding": "101011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac003057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VV": {
+          "encoding": "101011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VX": {
+          "encoding": "101011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VI": {
+          "encoding": "101010-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8003057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VV": {
+          "encoding": "101010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VX": {
+          "encoding": "101010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUB.VV": {
+          "encoding": "100011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUB.VX": {
+          "encoding": "100011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUBU.VV": {
+          "encoding": "100010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUBU.VX": {
+          "encoding": "100010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88004057",
+          "mask": "0xfc00707f"
+        },
+        "VSUB.VV": {
+          "encoding": "000010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000057",
+          "mask": "0xfc00707f"
+        },
+        "VSUB.VX": {
+          "encoding": "000010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8004057",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI16.V": {
+          "encoding": "000001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI16.V": {
+          "encoding": "001001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI16.V": {
+          "encoding": "010001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI16.V": {
+          "encoding": "011001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI16.V": {
+          "encoding": "100001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI16.V": {
+          "encoding": "101001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI16.V": {
+          "encoding": "110001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI16.V": {
+          "encoding": "111001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI32.V": {
+          "encoding": "000001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI32.V": {
+          "encoding": "001001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI32.V": {
+          "encoding": "010001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI32.V": {
+          "encoding": "011001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI32.V": {
+          "encoding": "100001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI32.V": {
+          "encoding": "101001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI32.V": {
+          "encoding": "110001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI32.V": {
+          "encoding": "111001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI64.V": {
+          "encoding": "000001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI64.V": {
+          "encoding": "001001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI64.V": {
+          "encoding": "010001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI64.V": {
+          "encoding": "011001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI64.V": {
+          "encoding": "100001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI64.V": {
+          "encoding": "101001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI64.V": {
+          "encoding": "110001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI64.V": {
+          "encoding": "111001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI8.V": {
+          "encoding": "000001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI8.V": {
+          "encoding": "001001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI8.V": {
+          "encoding": "010001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI8.V": {
+          "encoding": "011001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI8.V": {
+          "encoding": "100001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI8.V": {
+          "encoding": "101001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI8.V": {
+          "encoding": "110001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI8.V": {
+          "encoding": "111001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4000027",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.VV": {
+          "encoding": "110001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.VX": {
+          "encoding": "110001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.WV": {
+          "encoding": "110101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.WX": {
+          "encoding": "110101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.VV": {
+          "encoding": "110000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.VX": {
+          "encoding": "110000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.WV": {
+          "encoding": "110100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.WX": {
+          "encoding": "110100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACC.VV": {
+          "encoding": "111101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACC.VX": {
+          "encoding": "111101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCSU.VV": {
+          "encoding": "111111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xfc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCSU.VX": {
+          "encoding": "111111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xfc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCU.VV": {
+          "encoding": "111100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCU.VX": {
+          "encoding": "111100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCUS.VX": {
+          "encoding": "111110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMUL.VV": {
+          "encoding": "111011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMUL.VX": {
+          "encoding": "111011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULSU.VV": {
+          "encoding": "111010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULSU.VX": {
+          "encoding": "111010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULU.VV": {
+          "encoding": "111000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULU.VX": {
+          "encoding": "111000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWREDSUM.VS": {
+          "encoding": "110001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000057",
+          "mask": "0xfc00707f"
+        },
+        "VWREDSUMU.VS": {
+          "encoding": "110000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.VV": {
+          "encoding": "110011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.VX": {
+          "encoding": "110011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.WV": {
+          "encoding": "110111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xdc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.WX": {
+          "encoding": "110111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xdc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.VV": {
+          "encoding": "110010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.VX": {
+          "encoding": "110010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.WV": {
+          "encoding": "110110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.WX": {
+          "encoding": "110110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd8006057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VI": {
+          "encoding": "001011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c003057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VV": {
+          "encoding": "001011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VX": {
+          "encoding": "001011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c004057",
+          "mask": "0xfc00707f"
+        },
+        "VZEXT.VF2": {
+          "encoding": "010010------00110010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48032057",
+          "mask": "0xfc0ff07f"
+        },
+        "VZEXT.VF4": {
+          "encoding": "010010------00100010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48022057",
+          "mask": "0xfc0ff07f"
+        },
+        "VZEXT.VF8": {
+          "encoding": "010010------00010010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48012057",
+          "mask": "0xfc0ff07f"
+        }
+      },
       "state": "ratified",
       "ratification_date": "2021-11",
       "version": "1.0.0"
@@ -21015,7 +50402,8552 @@
       "desc": "Double-precision vector floating-point on top of Zve64f, completing embedded FP support at 64-bit element width.",
       "use": "Full FP64 embedded vectors",
       "url": "https://docs.riscv.org/reference/isa/unpriv/v-st-ext.html",
-      "instructions": {},
+      "instructions": {
+        "VAADD.VV": {
+          "encoding": "001001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24002057",
+          "mask": "0xfc00707f"
+        },
+        "VAADD.VX": {
+          "encoding": "001001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006057",
+          "mask": "0xfc00707f"
+        },
+        "VAADDU.VV": {
+          "encoding": "001000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20002057",
+          "mask": "0xfc00707f"
+        },
+        "VAADDU.VX": {
+          "encoding": "001000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006057",
+          "mask": "0xfc00707f"
+        },
+        "VADC.VIM": {
+          "encoding": "0100000----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40003057",
+          "mask": "0xfe00707f"
+        },
+        "VADC.VVM": {
+          "encoding": "0100000----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000057",
+          "mask": "0xfe00707f"
+        },
+        "VADC.VXM": {
+          "encoding": "0100000----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40004057",
+          "mask": "0xfe00707f"
+        },
+        "VADD.VI": {
+          "encoding": "000000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3057",
+          "mask": "0xfc00707f"
+        },
+        "VADD.VV": {
+          "encoding": "000000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x57",
+          "mask": "0xfc00707f"
+        },
+        "VADD.VX": {
+          "encoding": "000000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VI": {
+          "encoding": "001001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24003057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VV": {
+          "encoding": "001001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000057",
+          "mask": "0xfc00707f"
+        },
+        "VAND.VX": {
+          "encoding": "001001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24004057",
+          "mask": "0xfc00707f"
+        },
+        "VASUB.VV": {
+          "encoding": "001011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c002057",
+          "mask": "0xfc00707f"
+        },
+        "VASUB.VX": {
+          "encoding": "001011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006057",
+          "mask": "0xfc00707f"
+        },
+        "VASUBU.VV": {
+          "encoding": "001010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28002057",
+          "mask": "0xfc00707f"
+        },
+        "VASUBU.VX": {
+          "encoding": "001010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006057",
+          "mask": "0xfc00707f"
+        },
+        "VCOMPRESS.VM": {
+          "encoding": "0101111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e002057",
+          "mask": "0xfe00707f"
+        },
+        "VCPOP.M": {
+          "encoding": "010000------10000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40082057",
+          "mask": "0xfc0ff07f"
+        },
+        "VDIV.VV": {
+          "encoding": "100001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84002057",
+          "mask": "0xfc00707f"
+        },
+        "VDIV.VX": {
+          "encoding": "100001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006057",
+          "mask": "0xfc00707f"
+        },
+        "VDIVU.VV": {
+          "encoding": "100000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80002057",
+          "mask": "0xfc00707f"
+        },
+        "VDIVU.VX": {
+          "encoding": "100000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006057",
+          "mask": "0xfc00707f"
+        },
+        "VFADD.VF": {
+          "encoding": "000000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5057",
+          "mask": "0xfc00707f"
+        },
+        "VFADD.VV": {
+          "encoding": "000000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1057",
+          "mask": "0xfc00707f"
+        },
+        "VFCLASS.V": {
+          "encoding": "010011------10000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c081057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.F.X.V": {
+          "encoding": "010010------00011001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48019057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.F.XU.V": {
+          "encoding": "010010------00010001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48011057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.RTZ.X.F.V": {
+          "encoding": "010010------00111001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48039057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.RTZ.XU.F.V": {
+          "encoding": "010010------00110001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48031057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.X.F.V": {
+          "encoding": "010010------00001001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48009057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFCVT.XU.F.V": {
+          "encoding": "010010------00000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48001057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFDIV.VF": {
+          "encoding": "100000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80005057",
+          "mask": "0xfc00707f"
+        },
+        "VFDIV.VV": {
+          "encoding": "100000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80001057",
+          "mask": "0xfc00707f"
+        },
+        "VFIRST.M": {
+          "encoding": "010000------10001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4008a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFMACC.VF": {
+          "encoding": "101100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMACC.VV": {
+          "encoding": "101100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMADD.VF": {
+          "encoding": "101000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMADD.VV": {
+          "encoding": "101000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMAX.VF": {
+          "encoding": "000110-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMAX.VV": {
+          "encoding": "000110-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMERGE.VFM": {
+          "encoding": "0101110----------101-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c005057",
+          "mask": "0xfe00707f"
+        },
+        "VFMIN.VF": {
+          "encoding": "000100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMIN.VV": {
+          "encoding": "000100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMSAC.VF": {
+          "encoding": "101110-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMSAC.VV": {
+          "encoding": "101110-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMSUB.VF": {
+          "encoding": "101010-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMSUB.VV": {
+          "encoding": "101010-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMUL.VF": {
+          "encoding": "100100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90005057",
+          "mask": "0xfc00707f"
+        },
+        "VFMUL.VV": {
+          "encoding": "100100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90001057",
+          "mask": "0xfc00707f"
+        },
+        "VFMV.F.S": {
+          "encoding": "0100001-----00000001-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42001057",
+          "mask": "0xfe0ff07f"
+        },
+        "VFMV.S.F": {
+          "encoding": "010000100000-----101-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42005057",
+          "mask": "0xfff0707f"
+        },
+        "VFMV.V.F": {
+          "encoding": "010111100000-----101-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e005057",
+          "mask": "0xfff0707f"
+        },
+        "VFNCVT.F.F.W": {
+          "encoding": "010010------10100001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x480a1057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.F.X.W": {
+          "encoding": "010010------10011001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48099057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.F.XU.W": {
+          "encoding": "010010------10010001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48091057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.ROD.F.F.W": {
+          "encoding": "010010------10101001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x480a9057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.RTZ.X.F.W": {
+          "encoding": "010010------10111001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x480b9057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.RTZ.XU.F.W": {
+          "encoding": "010010------10110001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x480b1057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.X.F.W": {
+          "encoding": "010010------10001001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48089057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNCVT.XU.F.W": {
+          "encoding": "010010------10000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48081057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFNMACC.VF": {
+          "encoding": "101101-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4005057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMACC.VV": {
+          "encoding": "101101-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4001057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMADD.VF": {
+          "encoding": "101001-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4005057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMADD.VV": {
+          "encoding": "101001-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4001057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMSAC.VF": {
+          "encoding": "101111-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc005057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMSAC.VV": {
+          "encoding": "101111-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc001057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMSUB.VF": {
+          "encoding": "101011-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac005057",
+          "mask": "0xfc00707f"
+        },
+        "VFNMSUB.VV": {
+          "encoding": "101011-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac001057",
+          "mask": "0xfc00707f"
+        },
+        "VFRDIV.VF": {
+          "encoding": "100001-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84005057",
+          "mask": "0xfc00707f"
+        },
+        "VFREC7.V": {
+          "encoding": "010011------00101001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c029057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFREDMAX.VS": {
+          "encoding": "000111-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c001057",
+          "mask": "0xfc00707f"
+        },
+        "VFREDMIN.VS": {
+          "encoding": "000101-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14001057",
+          "mask": "0xfc00707f"
+        },
+        "VFREDOSUM.VS": {
+          "encoding": "000011-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc001057",
+          "mask": "0xfc00707f"
+        },
+        "VFREDUSUM.VS": {
+          "encoding": "000001-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4001057",
+          "mask": "0xfc00707f"
+        },
+        "VFRSQRT7.V": {
+          "encoding": "010011------00100001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c021057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFRSUB.VF": {
+          "encoding": "100111-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJ.VF": {
+          "encoding": "001000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJ.VV": {
+          "encoding": "001000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20001057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJN.VF": {
+          "encoding": "001001-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJN.VV": {
+          "encoding": "001001-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24001057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJX.VF": {
+          "encoding": "001010-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSGNJX.VV": {
+          "encoding": "001010-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28001057",
+          "mask": "0xfc00707f"
+        },
+        "VFSLIDE1DOWN.VF": {
+          "encoding": "001111-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSLIDE1UP.VF": {
+          "encoding": "001110-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSQRT.V": {
+          "encoding": "010011------00000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c001057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFSUB.VF": {
+          "encoding": "000010-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8005057",
+          "mask": "0xfc00707f"
+        },
+        "VFSUB.VV": {
+          "encoding": "000010-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8001057",
+          "mask": "0xfc00707f"
+        },
+        "VFWADD.VF": {
+          "encoding": "110000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0005057",
+          "mask": "0xfc00707f"
+        },
+        "VFWADD.VV": {
+          "encoding": "110000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0001057",
+          "mask": "0xfc00707f"
+        },
+        "VFWADD.WF": {
+          "encoding": "110100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd0005057",
+          "mask": "0xfc00707f"
+        },
+        "VFWADD.WV": {
+          "encoding": "110100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd0001057",
+          "mask": "0xfc00707f"
+        },
+        "VFWCVT.F.F.V": {
+          "encoding": "010010------01100001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48061057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFWCVT.F.X.V": {
+          "encoding": "010010------01011001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48059057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFWCVT.F.XU.V": {
+          "encoding": "010010------01010001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48051057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFWCVT.RTZ.X.F.V": {
+          "encoding": "010010------01111001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48079057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFWCVT.RTZ.XU.F.V": {
+          "encoding": "010010------01110001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48071057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFWCVT.X.F.V": {
+          "encoding": "010010------01001001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48049057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFWCVT.XU.F.V": {
+          "encoding": "010010------01000001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48041057",
+          "mask": "0xfc0ff07f"
+        },
+        "VFWMACC.VF": {
+          "encoding": "111100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf0005057",
+          "mask": "0xfc00707f"
+        },
+        "VFWMACC.VV": {
+          "encoding": "111100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf0001057",
+          "mask": "0xfc00707f"
+        },
+        "VFWMSAC.VF": {
+          "encoding": "111110-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf8005057",
+          "mask": "0xfc00707f"
+        },
+        "VFWMSAC.VV": {
+          "encoding": "111110-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf8001057",
+          "mask": "0xfc00707f"
+        },
+        "VFWMUL.VF": {
+          "encoding": "111000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0005057",
+          "mask": "0xfc00707f"
+        },
+        "VFWMUL.VV": {
+          "encoding": "111000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0001057",
+          "mask": "0xfc00707f"
+        },
+        "VFWNMACC.VF": {
+          "encoding": "111101-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf4005057",
+          "mask": "0xfc00707f"
+        },
+        "VFWNMACC.VV": {
+          "encoding": "111101-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf4001057",
+          "mask": "0xfc00707f"
+        },
+        "VFWNMSAC.VF": {
+          "encoding": "111111-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xfc005057",
+          "mask": "0xfc00707f"
+        },
+        "VFWNMSAC.VV": {
+          "encoding": "111111-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xfc001057",
+          "mask": "0xfc00707f"
+        },
+        "VFWREDOSUM.VS": {
+          "encoding": "110011-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc001057",
+          "mask": "0xfc00707f"
+        },
+        "VFWREDUSUM.VS": {
+          "encoding": "110001-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4001057",
+          "mask": "0xfc00707f"
+        },
+        "VFWSUB.VF": {
+          "encoding": "110010-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8005057",
+          "mask": "0xfc00707f"
+        },
+        "VFWSUB.VV": {
+          "encoding": "110010-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8001057",
+          "mask": "0xfc00707f"
+        },
+        "VFWSUB.WF": {
+          "encoding": "110110-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd8005057",
+          "mask": "0xfc00707f"
+        },
+        "VFWSUB.WV": {
+          "encoding": "110110-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd8001057",
+          "mask": "0xfc00707f"
+        },
+        "VID.V": {
+          "encoding": "010100-0000010001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5008a057",
+          "mask": "0xfdfff07f"
+        },
+        "VIOTA.M": {
+          "encoding": "010100------10000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x50082057",
+          "mask": "0xfc0ff07f"
+        },
+        "VL1RE16.V": {
+          "encoding": "000000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2805007",
+          "mask": "0xfff0707f"
+        },
+        "VL1RE32.V": {
+          "encoding": "000000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2806007",
+          "mask": "0xfff0707f"
+        },
+        "VL1RE64.V": {
+          "encoding": "000000101000-----111-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2807007",
+          "mask": "0xfff0707f"
+        },
+        "VL1RE8.V": {
+          "encoding": "000000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2800007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE16.V": {
+          "encoding": "001000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22805007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE32.V": {
+          "encoding": "001000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22806007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE64.V": {
+          "encoding": "001000101000-----111-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22807007",
+          "mask": "0xfff0707f"
+        },
+        "VL2RE8.V": {
+          "encoding": "001000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22800007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE16.V": {
+          "encoding": "011000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62805007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE32.V": {
+          "encoding": "011000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62806007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE64.V": {
+          "encoding": "011000101000-----111-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62807007",
+          "mask": "0xfff0707f"
+        },
+        "VL4RE8.V": {
+          "encoding": "011000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62800007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE16.V": {
+          "encoding": "111000101000-----101-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2805007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE32.V": {
+          "encoding": "111000101000-----110-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2806007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE64.V": {
+          "encoding": "111000101000-----111-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2807007",
+          "mask": "0xfff0707f"
+        },
+        "VL8RE8.V": {
+          "encoding": "111000101000-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2800007",
+          "mask": "0xfff0707f"
+        },
+        "VLE16.V": {
+          "encoding": "000000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E16.V": {
+          "encoding": "001000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E16.V": {
+          "encoding": "010000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E16.V": {
+          "encoding": "011000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E16.V": {
+          "encoding": "100000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E16.V": {
+          "encoding": "101000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E16.V": {
+          "encoding": "110000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E16.V": {
+          "encoding": "111000-00000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE16FF.V": {
+          "encoding": "000000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E16FF.V": {
+          "encoding": "001000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E16FF.V": {
+          "encoding": "010000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E16FF.V": {
+          "encoding": "011000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E16FF.V": {
+          "encoding": "100000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E16FF.V": {
+          "encoding": "101000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E16FF.V": {
+          "encoding": "110000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E16FF.V": {
+          "encoding": "111000-10000-----101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1005007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE32.V": {
+          "encoding": "000000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E32.V": {
+          "encoding": "001000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E32.V": {
+          "encoding": "010000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E32.V": {
+          "encoding": "011000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E32.V": {
+          "encoding": "100000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E32.V": {
+          "encoding": "101000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E32.V": {
+          "encoding": "110000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E32.V": {
+          "encoding": "111000-00000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE32FF.V": {
+          "encoding": "000000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E32FF.V": {
+          "encoding": "001000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E32FF.V": {
+          "encoding": "010000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E32FF.V": {
+          "encoding": "011000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E32FF.V": {
+          "encoding": "100000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E32FF.V": {
+          "encoding": "101000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E32FF.V": {
+          "encoding": "110000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E32FF.V": {
+          "encoding": "111000-10000-----110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1006007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE64.V": {
+          "encoding": "000000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E64.V": {
+          "encoding": "001000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E64.V": {
+          "encoding": "010000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E64.V": {
+          "encoding": "011000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E64.V": {
+          "encoding": "100000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E64.V": {
+          "encoding": "101000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E64.V": {
+          "encoding": "110000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E64.V": {
+          "encoding": "111000-00000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE64FF.V": {
+          "encoding": "000000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E64FF.V": {
+          "encoding": "001000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E64FF.V": {
+          "encoding": "010000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E64FF.V": {
+          "encoding": "011000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E64FF.V": {
+          "encoding": "100000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E64FF.V": {
+          "encoding": "101000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E64FF.V": {
+          "encoding": "110000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E64FF.V": {
+          "encoding": "111000-10000-----111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1007007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE8.V": {
+          "encoding": "000000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E8.V": {
+          "encoding": "001000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E8.V": {
+          "encoding": "010000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E8.V": {
+          "encoding": "011000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E8.V": {
+          "encoding": "100000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E8.V": {
+          "encoding": "101000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E8.V": {
+          "encoding": "110000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E8.V": {
+          "encoding": "111000-00000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLE8FF.V": {
+          "encoding": "000000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG2E8FF.V": {
+          "encoding": "001000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x21000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG3E8FF.V": {
+          "encoding": "010000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x41000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG4E8FF.V": {
+          "encoding": "011000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x61000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG5E8FF.V": {
+          "encoding": "100000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x81000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG6E8FF.V": {
+          "encoding": "101000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG7E8FF.V": {
+          "encoding": "110000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLSEG8E8FF.V": {
+          "encoding": "111000-10000-----000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe1000007",
+          "mask": "0xfdf0707f"
+        },
+        "VLM.V": {
+          "encoding": "000000101011-----000-----0000111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2b00007",
+          "mask": "0xfff0707f"
+        },
+        "VLOXEI16.V": {
+          "encoding": "000011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI16.V": {
+          "encoding": "001011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI16.V": {
+          "encoding": "010011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI16.V": {
+          "encoding": "011011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI16.V": {
+          "encoding": "100011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI16.V": {
+          "encoding": "101011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI16.V": {
+          "encoding": "110011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI16.V": {
+          "encoding": "111011-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec005007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXEI32.V": {
+          "encoding": "000011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI32.V": {
+          "encoding": "001011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI32.V": {
+          "encoding": "010011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI32.V": {
+          "encoding": "011011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI32.V": {
+          "encoding": "100011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI32.V": {
+          "encoding": "101011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI32.V": {
+          "encoding": "110011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI32.V": {
+          "encoding": "111011-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXEI64.V": {
+          "encoding": "000011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI64.V": {
+          "encoding": "001011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI64.V": {
+          "encoding": "010011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI64.V": {
+          "encoding": "011011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI64.V": {
+          "encoding": "100011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI64.V": {
+          "encoding": "101011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI64.V": {
+          "encoding": "110011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI64.V": {
+          "encoding": "111011-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec007007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXEI8.V": {
+          "encoding": "000011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG2EI8.V": {
+          "encoding": "001011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG3EI8.V": {
+          "encoding": "010011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG4EI8.V": {
+          "encoding": "011011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG5EI8.V": {
+          "encoding": "100011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG6EI8.V": {
+          "encoding": "101011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG7EI8.V": {
+          "encoding": "110011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc000007",
+          "mask": "0xfc00707f"
+        },
+        "VLOXSEG8EI8.V": {
+          "encoding": "111011-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE16.V": {
+          "encoding": "000010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E16.V": {
+          "encoding": "001010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E16.V": {
+          "encoding": "010010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E16.V": {
+          "encoding": "011010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E16.V": {
+          "encoding": "100010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E16.V": {
+          "encoding": "101010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E16.V": {
+          "encoding": "110010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E16.V": {
+          "encoding": "111010-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8005007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE32.V": {
+          "encoding": "000010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E32.V": {
+          "encoding": "001010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E32.V": {
+          "encoding": "010010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E32.V": {
+          "encoding": "011010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E32.V": {
+          "encoding": "100010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E32.V": {
+          "encoding": "101010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E32.V": {
+          "encoding": "110010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E32.V": {
+          "encoding": "111010-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE64.V": {
+          "encoding": "000010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E64.V": {
+          "encoding": "001010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E64.V": {
+          "encoding": "010010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E64.V": {
+          "encoding": "011010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E64.V": {
+          "encoding": "100010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E64.V": {
+          "encoding": "101010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E64.V": {
+          "encoding": "110010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E64.V": {
+          "encoding": "111010-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8007007",
+          "mask": "0xfc00707f"
+        },
+        "VLSE8.V": {
+          "encoding": "000010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG2E8.V": {
+          "encoding": "001010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG3E8.V": {
+          "encoding": "010010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG4E8.V": {
+          "encoding": "011010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG5E8.V": {
+          "encoding": "100010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG6E8.V": {
+          "encoding": "101010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG7E8.V": {
+          "encoding": "110010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLSSEG8E8.V": {
+          "encoding": "111010-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI16.V": {
+          "encoding": "000001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI16.V": {
+          "encoding": "001001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI16.V": {
+          "encoding": "010001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI16.V": {
+          "encoding": "011001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI16.V": {
+          "encoding": "100001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI16.V": {
+          "encoding": "101001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI16.V": {
+          "encoding": "110001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI16.V": {
+          "encoding": "111001-----------101-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4005007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI32.V": {
+          "encoding": "000001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI32.V": {
+          "encoding": "001001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI32.V": {
+          "encoding": "010001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI32.V": {
+          "encoding": "011001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI32.V": {
+          "encoding": "100001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI32.V": {
+          "encoding": "101001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI32.V": {
+          "encoding": "110001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI32.V": {
+          "encoding": "111001-----------110-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4006007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI64.V": {
+          "encoding": "000001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI64.V": {
+          "encoding": "001001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI64.V": {
+          "encoding": "010001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI64.V": {
+          "encoding": "011001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI64.V": {
+          "encoding": "100001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI64.V": {
+          "encoding": "101001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI64.V": {
+          "encoding": "110001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI64.V": {
+          "encoding": "111001-----------111-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4007007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXEI8.V": {
+          "encoding": "000001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG2EI8.V": {
+          "encoding": "001001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG3EI8.V": {
+          "encoding": "010001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG4EI8.V": {
+          "encoding": "011001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG5EI8.V": {
+          "encoding": "100001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG6EI8.V": {
+          "encoding": "101001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG7EI8.V": {
+          "encoding": "110001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000007",
+          "mask": "0xfc00707f"
+        },
+        "VLUXSEG8EI8.V": {
+          "encoding": "111001-----------000-----0000111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4000007",
+          "mask": "0xfc00707f"
+        },
+        "VMACC.VV": {
+          "encoding": "101101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4002057",
+          "mask": "0xfc00707f"
+        },
+        "VMACC.VX": {
+          "encoding": "101101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4006057",
+          "mask": "0xfc00707f"
+        },
+        "VMADC.VI": {
+          "encoding": "0100011----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46003057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VIM": {
+          "encoding": "0100010----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44003057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VV": {
+          "encoding": "0100011----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46000057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VVM": {
+          "encoding": "0100010----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VX": {
+          "encoding": "0100011----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x46004057",
+          "mask": "0xfe00707f"
+        },
+        "VMADC.VXM": {
+          "encoding": "0100010----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44004057",
+          "mask": "0xfe00707f"
+        },
+        "VMADD.VV": {
+          "encoding": "101001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4002057",
+          "mask": "0xfc00707f"
+        },
+        "VMADD.VX": {
+          "encoding": "101001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006057",
+          "mask": "0xfc00707f"
+        },
+        "VMAND.MM": {
+          "encoding": "0110011----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x66002057",
+          "mask": "0xfe00707f"
+        },
+        "VMANDN.MM": {
+          "encoding": "0110001----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62002057",
+          "mask": "0xfe00707f"
+        },
+        "VMAX.VV": {
+          "encoding": "000111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c000057",
+          "mask": "0xfc00707f"
+        },
+        "VMAX.VX": {
+          "encoding": "000111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMAXU.VV": {
+          "encoding": "000110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18000057",
+          "mask": "0xfc00707f"
+        },
+        "VMAXU.VX": {
+          "encoding": "000110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18004057",
+          "mask": "0xfc00707f"
+        },
+        "VMERGE.VIM": {
+          "encoding": "0101110----------011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c003057",
+          "mask": "0xfe00707f"
+        },
+        "VMERGE.VVM": {
+          "encoding": "0101110----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c000057",
+          "mask": "0xfe00707f"
+        },
+        "VMERGE.VXM": {
+          "encoding": "0101110----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5c004057",
+          "mask": "0xfe00707f"
+        },
+        "VMFEQ.VF": {
+          "encoding": "011000-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFEQ.VV": {
+          "encoding": "011000-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60001057",
+          "mask": "0xfc00707f"
+        },
+        "VMFGE.VF": {
+          "encoding": "011111-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7c005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFGT.VF": {
+          "encoding": "011101-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFLE.VF": {
+          "encoding": "011001-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFLE.VV": {
+          "encoding": "011001-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64001057",
+          "mask": "0xfc00707f"
+        },
+        "VMFLT.VF": {
+          "encoding": "011011-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFLT.VV": {
+          "encoding": "011011-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c001057",
+          "mask": "0xfc00707f"
+        },
+        "VMFNE.VF": {
+          "encoding": "011100-----------101-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70005057",
+          "mask": "0xfc00707f"
+        },
+        "VMFNE.VV": {
+          "encoding": "011100-----------001-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70001057",
+          "mask": "0xfc00707f"
+        },
+        "VMIN.VV": {
+          "encoding": "000101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14000057",
+          "mask": "0xfc00707f"
+        },
+        "VMIN.VX": {
+          "encoding": "000101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14004057",
+          "mask": "0xfc00707f"
+        },
+        "VMINU.VV": {
+          "encoding": "000100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10000057",
+          "mask": "0xfc00707f"
+        },
+        "VMINU.VX": {
+          "encoding": "000100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10004057",
+          "mask": "0xfc00707f"
+        },
+        "VMNAND.MM": {
+          "encoding": "0111011----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x76002057",
+          "mask": "0xfe00707f"
+        },
+        "VMNOR.MM": {
+          "encoding": "0111101----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7a002057",
+          "mask": "0xfe00707f"
+        },
+        "VMOR.MM": {
+          "encoding": "0110101----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6a002057",
+          "mask": "0xfe00707f"
+        },
+        "VMORN.MM": {
+          "encoding": "0111001----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x72002057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VV": {
+          "encoding": "0100111----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4e000057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VVM": {
+          "encoding": "0100110----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VX": {
+          "encoding": "0100111----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4e004057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBC.VXM": {
+          "encoding": "0100110----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c004057",
+          "mask": "0xfe00707f"
+        },
+        "VMSBF.M": {
+          "encoding": "010100------00001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5000a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMSEQ.VI": {
+          "encoding": "011000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSEQ.VV": {
+          "encoding": "011000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSEQ.VX": {
+          "encoding": "011000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGT.VI": {
+          "encoding": "011111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7c003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGT.VX": {
+          "encoding": "011111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGTU.VI": {
+          "encoding": "011110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x78003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSGTU.VX": {
+          "encoding": "011110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x78004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSIF.M": {
+          "encoding": "010100------00011010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5001a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMSLE.VI": {
+          "encoding": "011101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLE.VV": {
+          "encoding": "011101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLE.VX": {
+          "encoding": "011101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x74004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VI": {
+          "encoding": "011100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VV": {
+          "encoding": "011100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLEU.VX": {
+          "encoding": "011100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x70004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLT.VV": {
+          "encoding": "011011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLT.VX": {
+          "encoding": "011011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLTU.VV": {
+          "encoding": "011010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSLTU.VX": {
+          "encoding": "011010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VI": {
+          "encoding": "011001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64003057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VV": {
+          "encoding": "011001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000057",
+          "mask": "0xfc00707f"
+        },
+        "VMSNE.VX": {
+          "encoding": "011001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64004057",
+          "mask": "0xfc00707f"
+        },
+        "VMSOF.M": {
+          "encoding": "010100------00010010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x50012057",
+          "mask": "0xfc0ff07f"
+        },
+        "VMUL.VV": {
+          "encoding": "100101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94002057",
+          "mask": "0xfc00707f"
+        },
+        "VMUL.VX": {
+          "encoding": "100101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULH.VV": {
+          "encoding": "100111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULH.VX": {
+          "encoding": "100111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHSU.VV": {
+          "encoding": "100110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x98002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHSU.VX": {
+          "encoding": "100110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x98006057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHU.VV": {
+          "encoding": "100100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90002057",
+          "mask": "0xfc00707f"
+        },
+        "VMULHU.VX": {
+          "encoding": "100100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x90006057",
+          "mask": "0xfc00707f"
+        },
+        "VMV1R.V": {
+          "encoding": "1001111-----00000011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e003057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV2R.V": {
+          "encoding": "1001111-----00001011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e00b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV4R.V": {
+          "encoding": "1001111-----00011011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e01b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV8R.V": {
+          "encoding": "1001111-----00111011-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9e03b057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMV.S.X": {
+          "encoding": "010000100000-----110-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42006057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.I": {
+          "encoding": "010111100000-----011-----1010111",
+          "variable_fields": [
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e003057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.V": {
+          "encoding": "010111100000-----000-----1010111",
+          "variable_fields": [
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e000057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.V.X": {
+          "encoding": "010111100000-----100-----1010111",
+          "variable_fields": [
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5e004057",
+          "mask": "0xfff0707f"
+        },
+        "VMV.X.S": {
+          "encoding": "0100001-----00000010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x42002057",
+          "mask": "0xfe0ff07f"
+        },
+        "VMXNOR.MM": {
+          "encoding": "0111111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7e002057",
+          "mask": "0xfe00707f"
+        },
+        "VMXOR.MM": {
+          "encoding": "0110111----------010-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6e002057",
+          "mask": "0xfe00707f"
+        },
+        "VNCLIP.WI": {
+          "encoding": "101111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc003057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIP.WV": {
+          "encoding": "101111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc000057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIP.WX": {
+          "encoding": "101111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc004057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WI": {
+          "encoding": "101110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8003057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WV": {
+          "encoding": "101110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8000057",
+          "mask": "0xfc00707f"
+        },
+        "VNCLIPU.WX": {
+          "encoding": "101110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb8004057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSAC.VV": {
+          "encoding": "101111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc002057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSAC.VX": {
+          "encoding": "101111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xbc006057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSUB.VV": {
+          "encoding": "101011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac002057",
+          "mask": "0xfc00707f"
+        },
+        "VNMSUB.VX": {
+          "encoding": "101011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WI": {
+          "encoding": "101101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4003057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WV": {
+          "encoding": "101101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4000057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRA.WX": {
+          "encoding": "101101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb4004057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WI": {
+          "encoding": "101100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0003057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WV": {
+          "encoding": "101100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0000057",
+          "mask": "0xfc00707f"
+        },
+        "VNSRL.WX": {
+          "encoding": "101100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xb0004057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VI": {
+          "encoding": "001010-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28003057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VV": {
+          "encoding": "001010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000057",
+          "mask": "0xfc00707f"
+        },
+        "VOR.VX": {
+          "encoding": "001010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28004057",
+          "mask": "0xfc00707f"
+        },
+        "VREDAND.VS": {
+          "encoding": "000001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMAX.VS": {
+          "encoding": "000111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x1c002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMAXU.VS": {
+          "encoding": "000110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x18002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMIN.VS": {
+          "encoding": "000101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x14002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDMINU.VS": {
+          "encoding": "000100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x10002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDOR.VS": {
+          "encoding": "000010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8002057",
+          "mask": "0xfc00707f"
+        },
+        "VREDSUM.VS": {
+          "encoding": "000000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2057",
+          "mask": "0xfc00707f"
+        },
+        "VREDXOR.VS": {
+          "encoding": "000011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc002057",
+          "mask": "0xfc00707f"
+        },
+        "VREM.VV": {
+          "encoding": "100011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c002057",
+          "mask": "0xfc00707f"
+        },
+        "VREM.VX": {
+          "encoding": "100011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006057",
+          "mask": "0xfc00707f"
+        },
+        "VREMU.VV": {
+          "encoding": "100010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88002057",
+          "mask": "0xfc00707f"
+        },
+        "VREMU.VX": {
+          "encoding": "100010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VI": {
+          "encoding": "001100-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30003057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VV": {
+          "encoding": "001100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30000057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHER.VX": {
+          "encoding": "001100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x30004057",
+          "mask": "0xfc00707f"
+        },
+        "VRGATHEREI16.VV": {
+          "encoding": "001110-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38000057",
+          "mask": "0xfc00707f"
+        },
+        "VRSUB.VI": {
+          "encoding": "000011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc003057",
+          "mask": "0xfc00707f"
+        },
+        "VRSUB.VX": {
+          "encoding": "000011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc004057",
+          "mask": "0xfc00707f"
+        },
+        "VS1R.V": {
+          "encoding": "000000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2800027",
+          "mask": "0xfff0707f"
+        },
+        "VS2R.V": {
+          "encoding": "001000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x22800027",
+          "mask": "0xfff0707f"
+        },
+        "VS4R.V": {
+          "encoding": "011000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x62800027",
+          "mask": "0xfff0707f"
+        },
+        "VS8R.V": {
+          "encoding": "111000101000-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe2800027",
+          "mask": "0xfff0707f"
+        },
+        "VSADD.VI": {
+          "encoding": "100001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84003057",
+          "mask": "0xfc00707f"
+        },
+        "VSADD.VV": {
+          "encoding": "100001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000057",
+          "mask": "0xfc00707f"
+        },
+        "VSADD.VX": {
+          "encoding": "100001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84004057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VI": {
+          "encoding": "100000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80003057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VV": {
+          "encoding": "100000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000057",
+          "mask": "0xfc00707f"
+        },
+        "VSADDU.VX": {
+          "encoding": "100000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80004057",
+          "mask": "0xfc00707f"
+        },
+        "VSBC.VVM": {
+          "encoding": "0100100----------000-----1010111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000057",
+          "mask": "0xfe00707f"
+        },
+        "VSBC.VXM": {
+          "encoding": "0100100----------100-----1010111",
+          "variable_fields": [
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48004057",
+          "mask": "0xfe00707f"
+        },
+        "VSE16.V": {
+          "encoding": "000000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x5027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E16.V": {
+          "encoding": "001000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E16.V": {
+          "encoding": "010000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E16.V": {
+          "encoding": "011000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E16.V": {
+          "encoding": "100000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E16.V": {
+          "encoding": "101000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E16.V": {
+          "encoding": "110000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E16.V": {
+          "encoding": "111000-00000-----101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0005027",
+          "mask": "0xfdf0707f"
+        },
+        "VSE32.V": {
+          "encoding": "000000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E32.V": {
+          "encoding": "001000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E32.V": {
+          "encoding": "010000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E32.V": {
+          "encoding": "011000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E32.V": {
+          "encoding": "100000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E32.V": {
+          "encoding": "101000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E32.V": {
+          "encoding": "110000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E32.V": {
+          "encoding": "111000-00000-----110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006027",
+          "mask": "0xfdf0707f"
+        },
+        "VSE64.V": {
+          "encoding": "000000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E64.V": {
+          "encoding": "001000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E64.V": {
+          "encoding": "010000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E64.V": {
+          "encoding": "011000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E64.V": {
+          "encoding": "100000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E64.V": {
+          "encoding": "101000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E64.V": {
+          "encoding": "110000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E64.V": {
+          "encoding": "111000-00000-----111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0007027",
+          "mask": "0xfdf0707f"
+        },
+        "VSE8.V": {
+          "encoding": "000000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x27",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG2E8.V": {
+          "encoding": "001000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x20000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG3E8.V": {
+          "encoding": "010000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x40000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG4E8.V": {
+          "encoding": "011000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x60000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG5E8.V": {
+          "encoding": "100000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG6E8.V": {
+          "encoding": "101000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG7E8.V": {
+          "encoding": "110000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSSEG8E8.V": {
+          "encoding": "111000-00000-----000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0000027",
+          "mask": "0xfdf0707f"
+        },
+        "VSETIVLI": {
+          "encoding": "11---------------111-----1010111",
+          "variable_fields": [
+            "zimm10",
+            "zimm5",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0007057",
+          "mask": "0xc000707f"
+        },
+        "VSETVL": {
+          "encoding": "1000000----------111-----1010111",
+          "variable_fields": [
+            "rs2",
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x80007057",
+          "mask": "0xfe00707f"
+        },
+        "VSETVLI": {
+          "encoding": "0----------------111-----1010111",
+          "variable_fields": [
+            "zimm11",
+            "rs1",
+            "rd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x7057",
+          "mask": "0x8000707f"
+        },
+        "VSEXT.VF2": {
+          "encoding": "010010------00111010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4803a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSEXT.VF4": {
+          "encoding": "010010------00101010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4802a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSEXT.VF8": {
+          "encoding": "010010------00011010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4801a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VSLIDE1DOWN.VX": {
+          "encoding": "001111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c006057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDE1UP.VX": {
+          "encoding": "001110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38006057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEDOWN.VI": {
+          "encoding": "001111-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEDOWN.VX": {
+          "encoding": "001111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x3c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEUP.VI": {
+          "encoding": "001110-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLIDEUP.VX": {
+          "encoding": "001110-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x38004057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VI": {
+          "encoding": "100101-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94003057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VV": {
+          "encoding": "100101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94000057",
+          "mask": "0xfc00707f"
+        },
+        "VSLL.VX": {
+          "encoding": "100101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x94004057",
+          "mask": "0xfc00707f"
+        },
+        "VSM.V": {
+          "encoding": "000000101011-----000-----0100111",
+          "variable_fields": [
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2b00027",
+          "mask": "0xfff0707f"
+        },
+        "VSMUL.VV": {
+          "encoding": "100111-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c000057",
+          "mask": "0xfc00707f"
+        },
+        "VSMUL.VX": {
+          "encoding": "100111-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x9c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI16.V": {
+          "encoding": "000011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI16.V": {
+          "encoding": "001011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI16.V": {
+          "encoding": "010011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI16.V": {
+          "encoding": "011011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI16.V": {
+          "encoding": "100011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI16.V": {
+          "encoding": "101011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI16.V": {
+          "encoding": "110011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI16.V": {
+          "encoding": "111011-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec005027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI32.V": {
+          "encoding": "000011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI32.V": {
+          "encoding": "001011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI32.V": {
+          "encoding": "010011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI32.V": {
+          "encoding": "011011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI32.V": {
+          "encoding": "100011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI32.V": {
+          "encoding": "101011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI32.V": {
+          "encoding": "110011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI32.V": {
+          "encoding": "111011-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI64.V": {
+          "encoding": "000011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI64.V": {
+          "encoding": "001011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI64.V": {
+          "encoding": "010011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI64.V": {
+          "encoding": "011011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI64.V": {
+          "encoding": "100011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI64.V": {
+          "encoding": "101011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI64.V": {
+          "encoding": "110011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI64.V": {
+          "encoding": "111011-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec007027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXEI8.V": {
+          "encoding": "000011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG2EI8.V": {
+          "encoding": "001011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG3EI8.V": {
+          "encoding": "010011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG4EI8.V": {
+          "encoding": "011011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x6c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG5EI8.V": {
+          "encoding": "100011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG6EI8.V": {
+          "encoding": "101011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG7EI8.V": {
+          "encoding": "110011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc000027",
+          "mask": "0xfc00707f"
+        },
+        "VSOXSEG8EI8.V": {
+          "encoding": "111011-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec000027",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VI": {
+          "encoding": "101001-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4003057",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VV": {
+          "encoding": "101001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000057",
+          "mask": "0xfc00707f"
+        },
+        "VSRA.VX": {
+          "encoding": "101001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4004057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VI": {
+          "encoding": "101000-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0003057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VV": {
+          "encoding": "101000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0000057",
+          "mask": "0xfc00707f"
+        },
+        "VSRL.VX": {
+          "encoding": "101000-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa0004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSE16.V": {
+          "encoding": "000010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E16.V": {
+          "encoding": "001010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E16.V": {
+          "encoding": "010010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E16.V": {
+          "encoding": "011010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E16.V": {
+          "encoding": "100010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E16.V": {
+          "encoding": "101010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E16.V": {
+          "encoding": "110010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E16.V": {
+          "encoding": "111010-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8005027",
+          "mask": "0xfc00707f"
+        },
+        "VSSE32.V": {
+          "encoding": "000010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E32.V": {
+          "encoding": "001010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E32.V": {
+          "encoding": "010010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E32.V": {
+          "encoding": "011010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E32.V": {
+          "encoding": "100010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E32.V": {
+          "encoding": "101010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E32.V": {
+          "encoding": "110010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E32.V": {
+          "encoding": "111010-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006027",
+          "mask": "0xfc00707f"
+        },
+        "VSSE64.V": {
+          "encoding": "000010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E64.V": {
+          "encoding": "001010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E64.V": {
+          "encoding": "010010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E64.V": {
+          "encoding": "011010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E64.V": {
+          "encoding": "100010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E64.V": {
+          "encoding": "101010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E64.V": {
+          "encoding": "110010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E64.V": {
+          "encoding": "111010-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8007027",
+          "mask": "0xfc00707f"
+        },
+        "VSSE8.V": {
+          "encoding": "000010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG2E8.V": {
+          "encoding": "001010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x28000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG3E8.V": {
+          "encoding": "010010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG4E8.V": {
+          "encoding": "011010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x68000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG5E8.V": {
+          "encoding": "100010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG6E8.V": {
+          "encoding": "101010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG7E8.V": {
+          "encoding": "110010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSSEG8E8.V": {
+          "encoding": "111010-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "rs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8000027",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VI": {
+          "encoding": "101011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac003057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VV": {
+          "encoding": "101011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRA.VX": {
+          "encoding": "101011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xac004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VI": {
+          "encoding": "101010-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8003057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VV": {
+          "encoding": "101010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSRL.VX": {
+          "encoding": "101010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa8004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUB.VV": {
+          "encoding": "100011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUB.VX": {
+          "encoding": "100011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8c004057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUBU.VV": {
+          "encoding": "100010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88000057",
+          "mask": "0xfc00707f"
+        },
+        "VSSUBU.VX": {
+          "encoding": "100010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x88004057",
+          "mask": "0xfc00707f"
+        },
+        "VSUB.VV": {
+          "encoding": "000010-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8000057",
+          "mask": "0xfc00707f"
+        },
+        "VSUB.VX": {
+          "encoding": "000010-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x8004057",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI16.V": {
+          "encoding": "000001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI16.V": {
+          "encoding": "001001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI16.V": {
+          "encoding": "010001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI16.V": {
+          "encoding": "011001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI16.V": {
+          "encoding": "100001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI16.V": {
+          "encoding": "101001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI16.V": {
+          "encoding": "110001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI16.V": {
+          "encoding": "111001-----------101-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4005027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI32.V": {
+          "encoding": "000001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI32.V": {
+          "encoding": "001001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI32.V": {
+          "encoding": "010001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI32.V": {
+          "encoding": "011001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI32.V": {
+          "encoding": "100001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI32.V": {
+          "encoding": "101001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI32.V": {
+          "encoding": "110001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI32.V": {
+          "encoding": "111001-----------110-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4006027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI64.V": {
+          "encoding": "000001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI64.V": {
+          "encoding": "001001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI64.V": {
+          "encoding": "010001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI64.V": {
+          "encoding": "011001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI64.V": {
+          "encoding": "100001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI64.V": {
+          "encoding": "101001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI64.V": {
+          "encoding": "110001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI64.V": {
+          "encoding": "111001-----------111-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4007027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXEI8.V": {
+          "encoding": "000001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG2EI8.V": {
+          "encoding": "001001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x24000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG3EI8.V": {
+          "encoding": "010001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x44000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG4EI8.V": {
+          "encoding": "011001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x64000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG5EI8.V": {
+          "encoding": "100001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x84000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG6EI8.V": {
+          "encoding": "101001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xa4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG7EI8.V": {
+          "encoding": "110001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000027",
+          "mask": "0xfc00707f"
+        },
+        "VSUXSEG8EI8.V": {
+          "encoding": "111001-----------000-----0100111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vs3"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe4000027",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.VV": {
+          "encoding": "110001-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.VX": {
+          "encoding": "110001-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.WV": {
+          "encoding": "110101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADD.WX": {
+          "encoding": "110101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.VV": {
+          "encoding": "110000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.VX": {
+          "encoding": "110000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.WV": {
+          "encoding": "110100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWADDU.WX": {
+          "encoding": "110100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACC.VV": {
+          "encoding": "111101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf4002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACC.VX": {
+          "encoding": "111101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf4006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCSU.VV": {
+          "encoding": "111111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xfc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCSU.VX": {
+          "encoding": "111111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xfc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCU.VV": {
+          "encoding": "111100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCU.VX": {
+          "encoding": "111100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMACCUS.VX": {
+          "encoding": "111110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xf8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMUL.VV": {
+          "encoding": "111011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMUL.VX": {
+          "encoding": "111011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xec006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULSU.VV": {
+          "encoding": "111010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULSU.VX": {
+          "encoding": "111010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULU.VV": {
+          "encoding": "111000-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0002057",
+          "mask": "0xfc00707f"
+        },
+        "VWMULU.VX": {
+          "encoding": "111000-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xe0006057",
+          "mask": "0xfc00707f"
+        },
+        "VWREDSUM.VS": {
+          "encoding": "110001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc4000057",
+          "mask": "0xfc00707f"
+        },
+        "VWREDSUMU.VS": {
+          "encoding": "110000-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc0000057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.VV": {
+          "encoding": "110011-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.VX": {
+          "encoding": "110011-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xcc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.WV": {
+          "encoding": "110111-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xdc002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUB.WX": {
+          "encoding": "110111-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xdc006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.VV": {
+          "encoding": "110010-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.VX": {
+          "encoding": "110010-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xc8006057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.WV": {
+          "encoding": "110110-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd8002057",
+          "mask": "0xfc00707f"
+        },
+        "VWSUBU.WX": {
+          "encoding": "110110-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0xd8006057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VI": {
+          "encoding": "001011-----------011-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "simm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c003057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VV": {
+          "encoding": "001011-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c000057",
+          "mask": "0xfc00707f"
+        },
+        "VXOR.VX": {
+          "encoding": "001011-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x2c004057",
+          "mask": "0xfc00707f"
+        },
+        "VZEXT.VF2": {
+          "encoding": "010010------00110010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48032057",
+          "mask": "0xfc0ff07f"
+        },
+        "VZEXT.VF4": {
+          "encoding": "010010------00100010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48022057",
+          "mask": "0xfc0ff07f"
+        },
+        "VZEXT.VF8": {
+          "encoding": "010010------00010010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_v"
+          ],
+          "match": "0x48012057",
+          "mask": "0xfc0ff07f"
+        }
+      },
       "state": "ratified",
       "ratification_date": "2021-11",
       "version": "1.0.0"
@@ -26178,7 +64110,151 @@
       "desc": "Vector rotations, byte reversal, and and-not operations that underpin cipher and hash kernels.",
       "use": "Vector crypto bit ops",
       "url": "https://docs.riscv.org/reference/isa/unpriv/vector-crypto.html",
-      "instructions": {},
+      "instructions": {
+        "VANDN.VV": {
+          "encoding": "000001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4000057",
+          "mask": "0xfc00707f"
+        },
+        "VANDN.VX": {
+          "encoding": "000001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4004057",
+          "mask": "0xfc00707f"
+        },
+        "VBREV8.V": {
+          "encoding": "010010------01000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x48042057",
+          "mask": "0xfc0ff07f"
+        },
+        "VREV8.V": {
+          "encoding": "010010------01001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4804a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VROL.VV": {
+          "encoding": "010101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54000057",
+          "mask": "0xfc00707f"
+        },
+        "VROL.VX": {
+          "encoding": "010101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54004057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VI": {
+          "encoding": "01010------------011-----1010111",
+          "variable_fields": [
+            "zimm6hi",
+            "vm",
+            "vs2",
+            "zimm6lo",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50003057",
+          "mask": "0xf800707f"
+        },
+        "VROR.VV": {
+          "encoding": "010100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50000057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VX": {
+          "encoding": "010100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50004057",
+          "mask": "0xfc00707f"
+        }
+      },
       "state": "ratified",
       "ratification_date": "2023-09",
       "version": "1.0.0"
@@ -26588,10 +64664,404 @@
       "name": "Zvknc",
       "short": "Vector NIST + CLMUL",
       "tags": [],
+      "members": [
+        "Zvkn",
+        "Zvbc"
+      ],
       "desc": "Vector NIST algorithm suite bundled with carry-less multiply for Galois-field arithmetic.",
       "use": "NIST suite plus carry-less multiply",
       "url": "https://docs.riscv.org/reference/isa/unpriv/vector-crypto.html",
-      "instructions": {},
+      "instructions": {
+        "VAESDF.VS": {
+          "encoding": "1010011-----00001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa600a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDF.VV": {
+          "encoding": "1010001-----00001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa200a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDM.VS": {
+          "encoding": "1010011-----00000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa6002077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDM.VV": {
+          "encoding": "1010001-----00000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa2002077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEF.VS": {
+          "encoding": "1010011-----00011010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa601a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEF.VV": {
+          "encoding": "1010001-----00011010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa201a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEM.VS": {
+          "encoding": "1010011-----00010010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa6012077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEM.VV": {
+          "encoding": "1010001-----00010010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa2012077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESKF1.VI": {
+          "encoding": "1000101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0x8a002077",
+          "mask": "0xfe00707f"
+        },
+        "VAESKF2.VI": {
+          "encoding": "1010101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xaa002077",
+          "mask": "0xfe00707f"
+        },
+        "VAESZ.VS": {
+          "encoding": "1010011-----00111010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa603a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VANDN.VV": {
+          "encoding": "000001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4000057",
+          "mask": "0xfc00707f"
+        },
+        "VANDN.VX": {
+          "encoding": "000001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4004057",
+          "mask": "0xfc00707f"
+        },
+        "VBREV8.V": {
+          "encoding": "010010------01000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x48042057",
+          "mask": "0xfc0ff07f"
+        },
+        "VREV8.V": {
+          "encoding": "010010------01001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4804a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VROL.VV": {
+          "encoding": "010101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54000057",
+          "mask": "0xfc00707f"
+        },
+        "VROL.VX": {
+          "encoding": "010101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54004057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VI": {
+          "encoding": "01010------------011-----1010111",
+          "variable_fields": [
+            "zimm6hi",
+            "vm",
+            "vs2",
+            "zimm6lo",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50003057",
+          "mask": "0xf800707f"
+        },
+        "VROR.VV": {
+          "encoding": "010100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50000057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VX": {
+          "encoding": "010100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50004057",
+          "mask": "0xfc00707f"
+        },
+        "VSHA2CH.VV": {
+          "encoding": "1011101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xba002077",
+          "mask": "0xfe00707f"
+        },
+        "VSHA2CL.VV": {
+          "encoding": "1011111----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xbe002077",
+          "mask": "0xfe00707f"
+        },
+        "VSHA2MS.VV": {
+          "encoding": "1011011----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xb6002077",
+          "mask": "0xfe00707f"
+        },
+        "VCLMUL.VV": {
+          "encoding": "001100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x30002057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMUL.VX": {
+          "encoding": "001100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x30006057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMULH.VV": {
+          "encoding": "001101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x34002057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMULH.VX": {
+          "encoding": "001101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x34006057",
+          "mask": "0xfc00707f"
+        }
+      },
       "state": "ratified",
       "ratification_date": "2023-09",
       "version": "1.0.0"
@@ -26772,10 +65242,373 @@
       "name": "Zvkng",
       "short": "Vector NIST + GCM",
       "tags": [],
+      "members": [
+        "Zvkn",
+        "Zvkg"
+      ],
       "desc": "Vector NIST algorithm suite bundled with the GHASH instructions for complete AES-GCM coverage.",
       "use": "NIST suite plus GCM authentication",
       "url": "https://docs.riscv.org/reference/isa/unpriv/vector-crypto.html",
-      "instructions": {},
+      "instructions": {
+        "VAESDF.VS": {
+          "encoding": "1010011-----00001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa600a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDF.VV": {
+          "encoding": "1010001-----00001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa200a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDM.VS": {
+          "encoding": "1010011-----00000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa6002077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESDM.VV": {
+          "encoding": "1010001-----00000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa2002077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEF.VS": {
+          "encoding": "1010011-----00011010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa601a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEF.VV": {
+          "encoding": "1010001-----00011010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa201a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEM.VS": {
+          "encoding": "1010011-----00010010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa6012077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESEM.VV": {
+          "encoding": "1010001-----00010010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa2012077",
+          "mask": "0xfe0ff07f"
+        },
+        "VAESKF1.VI": {
+          "encoding": "1000101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0x8a002077",
+          "mask": "0xfe00707f"
+        },
+        "VAESKF2.VI": {
+          "encoding": "1010101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xaa002077",
+          "mask": "0xfe00707f"
+        },
+        "VAESZ.VS": {
+          "encoding": "1010011-----00111010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkned",
+            "rv_zvkn"
+          ],
+          "match": "0xa603a077",
+          "mask": "0xfe0ff07f"
+        },
+        "VANDN.VV": {
+          "encoding": "000001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4000057",
+          "mask": "0xfc00707f"
+        },
+        "VANDN.VX": {
+          "encoding": "000001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4004057",
+          "mask": "0xfc00707f"
+        },
+        "VBREV8.V": {
+          "encoding": "010010------01000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x48042057",
+          "mask": "0xfc0ff07f"
+        },
+        "VREV8.V": {
+          "encoding": "010010------01001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4804a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VROL.VV": {
+          "encoding": "010101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54000057",
+          "mask": "0xfc00707f"
+        },
+        "VROL.VX": {
+          "encoding": "010101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54004057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VI": {
+          "encoding": "01010------------011-----1010111",
+          "variable_fields": [
+            "zimm6hi",
+            "vm",
+            "vs2",
+            "zimm6lo",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50003057",
+          "mask": "0xf800707f"
+        },
+        "VROR.VV": {
+          "encoding": "010100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50000057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VX": {
+          "encoding": "010100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50004057",
+          "mask": "0xfc00707f"
+        },
+        "VSHA2CH.VV": {
+          "encoding": "1011101----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xba002077",
+          "mask": "0xfe00707f"
+        },
+        "VSHA2CL.VV": {
+          "encoding": "1011111----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xbe002077",
+          "mask": "0xfe00707f"
+        },
+        "VSHA2MS.VV": {
+          "encoding": "1011011----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvknha",
+            "rv_zvknhb",
+            "rv_zvkn"
+          ],
+          "match": "0xb6002077",
+          "mask": "0xfe00707f"
+        },
+        "VGHSH.VV": {
+          "encoding": "1011001----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkg"
+          ],
+          "match": "0xb2002077",
+          "mask": "0xfe00707f"
+        },
+        "VGMUL.VV": {
+          "encoding": "1010001-----10001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkg"
+          ],
+          "match": "0xa208a077",
+          "mask": "0xfe0ff07f"
+        }
+      },
       "state": "ratified",
       "ratification_date": "2023-09",
       "version": "1.0.0"
@@ -27134,10 +65967,282 @@
       "name": "Zvksc",
       "short": "Vector ShangMi + CLMUL",
       "tags": [],
+      "members": [
+        "Zvks",
+        "Zvbc"
+      ],
       "desc": "Vector ShangMi algorithm suite bundled with carry-less multiply for Galois-field arithmetic.",
       "use": "ShangMi suite plus carry-less multiply",
       "url": "https://docs.riscv.org/reference/isa/unpriv/vector-crypto.html",
-      "instructions": {},
+      "instructions": {
+        "VANDN.VV": {
+          "encoding": "000001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4000057",
+          "mask": "0xfc00707f"
+        },
+        "VANDN.VX": {
+          "encoding": "000001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4004057",
+          "mask": "0xfc00707f"
+        },
+        "VBREV8.V": {
+          "encoding": "010010------01000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x48042057",
+          "mask": "0xfc0ff07f"
+        },
+        "VREV8.V": {
+          "encoding": "010010------01001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4804a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VROL.VV": {
+          "encoding": "010101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54000057",
+          "mask": "0xfc00707f"
+        },
+        "VROL.VX": {
+          "encoding": "010101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54004057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VI": {
+          "encoding": "01010------------011-----1010111",
+          "variable_fields": [
+            "zimm6hi",
+            "vm",
+            "vs2",
+            "zimm6lo",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50003057",
+          "mask": "0xf800707f"
+        },
+        "VROR.VV": {
+          "encoding": "010100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50000057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VX": {
+          "encoding": "010100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50004057",
+          "mask": "0xfc00707f"
+        },
+        "VSM3C.VI": {
+          "encoding": "1010111----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksh",
+            "rv_zvks"
+          ],
+          "match": "0xae002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM3ME.VV": {
+          "encoding": "1000001----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksh",
+            "rv_zvks"
+          ],
+          "match": "0x82002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM4K.VI": {
+          "encoding": "1000011----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0x86002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM4R.VS": {
+          "encoding": "1010011-----10000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0xa6082077",
+          "mask": "0xfe0ff07f"
+        },
+        "VSM4R.VV": {
+          "encoding": "1010001-----10000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0xa2082077",
+          "mask": "0xfe0ff07f"
+        },
+        "VCLMUL.VV": {
+          "encoding": "001100-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x30002057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMUL.VX": {
+          "encoding": "001100-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x30006057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMULH.VV": {
+          "encoding": "001101-----------010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x34002057",
+          "mask": "0xfc00707f"
+        },
+        "VCLMULH.VX": {
+          "encoding": "001101-----------110-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbc"
+          ],
+          "match": "0x34006057",
+          "mask": "0xfc00707f"
+        }
+      },
       "state": "ratified",
       "ratification_date": "2023-09",
       "version": "1.0.0"
@@ -27203,10 +66308,251 @@
       "name": "Zvksg",
       "short": "Vector ShangMi + GCM",
       "tags": [],
+      "members": [
+        "Zvks",
+        "Zvkg"
+      ],
       "desc": "Vector ShangMi algorithm suite bundled with the GHASH instructions for GCM authentication.",
       "use": "ShangMi + GCM vectors",
       "url": "https://docs.riscv.org/reference/isa/unpriv/vector-crypto.html",
-      "instructions": {},
+      "instructions": {
+        "VANDN.VV": {
+          "encoding": "000001-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4000057",
+          "mask": "0xfc00707f"
+        },
+        "VANDN.VX": {
+          "encoding": "000001-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4004057",
+          "mask": "0xfc00707f"
+        },
+        "VBREV8.V": {
+          "encoding": "010010------01000010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x48042057",
+          "mask": "0xfc0ff07f"
+        },
+        "VREV8.V": {
+          "encoding": "010010------01001010-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x4804a057",
+          "mask": "0xfc0ff07f"
+        },
+        "VROL.VV": {
+          "encoding": "010101-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54000057",
+          "mask": "0xfc00707f"
+        },
+        "VROL.VX": {
+          "encoding": "010101-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x54004057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VI": {
+          "encoding": "01010------------011-----1010111",
+          "variable_fields": [
+            "zimm6hi",
+            "vm",
+            "vs2",
+            "zimm6lo",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50003057",
+          "mask": "0xf800707f"
+        },
+        "VROR.VV": {
+          "encoding": "010100-----------000-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50000057",
+          "mask": "0xfc00707f"
+        },
+        "VROR.VX": {
+          "encoding": "010100-----------100-----1010111",
+          "variable_fields": [
+            "vm",
+            "vs2",
+            "rs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvbb",
+            "rv_zvks",
+            "rv_zvkn"
+          ],
+          "match": "0x50004057",
+          "mask": "0xfc00707f"
+        },
+        "VSM3C.VI": {
+          "encoding": "1010111----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksh",
+            "rv_zvks"
+          ],
+          "match": "0xae002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM3ME.VV": {
+          "encoding": "1000001----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksh",
+            "rv_zvks"
+          ],
+          "match": "0x82002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM4K.VI": {
+          "encoding": "1000011----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "zimm5",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0x86002077",
+          "mask": "0xfe00707f"
+        },
+        "VSM4R.VS": {
+          "encoding": "1010011-----10000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0xa6082077",
+          "mask": "0xfe0ff07f"
+        },
+        "VSM4R.VV": {
+          "encoding": "1010001-----10000010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvksed",
+            "rv_zvks"
+          ],
+          "match": "0xa2082077",
+          "mask": "0xfe0ff07f"
+        },
+        "VGHSH.VV": {
+          "encoding": "1011001----------010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vs1",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkg"
+          ],
+          "match": "0xb2002077",
+          "mask": "0xfe00707f"
+        },
+        "VGMUL.VV": {
+          "encoding": "1010001-----10001010-----1110111",
+          "variable_fields": [
+            "vs2",
+            "vd"
+          ],
+          "extension": [
+            "rv_zvkg"
+          ],
+          "match": "0xa208a077",
+          "mask": "0xfe0ff07f"
+        }
+      },
       "state": "ratified",
       "ratification_date": "2023-09",
       "version": "1.0.0"
@@ -29234,6 +68580,73 @@
       "state": "frozen",
       "behavior": "The Smpmpmt extension provides a mechanism analogous to Svpbmt but associated\nwith the PMP registers rather than page-table entries.\nA new WARL field, MT (Memory Type), is added in the unallocated bits 6--5 in\neach PMP configuration register.\nThe MT field of the lowest-numbered PMP register that an",
       "version": "0.6"
+    },
+    {
+      "id": "Sspmp",
+      "name": "Sspmp",
+      "short": "S-level PMP",
+      "tags": [],
+      "desc": "Supervisor-mode physical memory protection: per-hart entries that grant or revoke read, write and execute on physical regions without paging.",
+      "use": "Task isolation on MCU-class cores that have no MMU",
+      "url": "https://docs.riscv.org/reference/isa/extensions/sspmp/_attachments/riscv-spmp.pdf",
+      "long_name": "S-level Physical Memory Protection",
+      "type": "privileged",
+      "state": "ratified",
+      "ratification_date": "2026-08",
+      "version": "1.0.0",
+      "instructions": {}
+    },
+    {
+      "id": "Sspmpen",
+      "name": "Sspmpen",
+      "short": "SPMP Entry Enable",
+      "tags": [],
+      "desc": "A bitmask CSR that activates SPMP entries individually, so a context switch is one register write instead of reprogramming up to 128 registers.",
+      "use": "Cutting SPMP context-switch cost on RTOS workloads",
+      "url": "https://docs.riscv.org/reference/isa/extensions/sspmp/_attachments/riscv-spmp.pdf",
+      "long_name": "Extension for Optimizing Context Switching of SPMP Entries",
+      "type": "privileged",
+      "state": "ratified",
+      "ratification_date": "2026-08",
+      "csrs": {
+        "spmpen": {
+          "address": "0x183",
+          "priv_mode": "S",
+          "length": 64,
+          "desc": "SPMP entry enable"
+        },
+        "spmpenh": {
+          "address": "0x193",
+          "priv_mode": "S",
+          "length": 32,
+          "desc": "Upper 32 bits of SPMP entry enable (RV32 only)"
+        }
+      },
+      "version": "1.0.0",
+      "instructions": {}
+    },
+    {
+      "id": "Smpmpdeleg",
+      "name": "Smpmpdeleg",
+      "short": "PMP/SPMP Sharing",
+      "tags": [],
+      "desc": "Delegates a contiguous range of M-mode PMP entries to supervisor mode, where they become SPMP entries, so one block of hardware serves both.",
+      "use": "Reusing PMP hardware instead of duplicating it for SPMP",
+      "url": "https://docs.riscv.org/reference/isa/extensions/sspmp/_attachments/riscv-spmp.pdf",
+      "long_name": "Extension for Sharing Hardware Resources between PMP and SPMP",
+      "type": "privileged",
+      "state": "ratified",
+      "ratification_date": "2026-08",
+      "csrs": {
+        "mpmpdeleg": {
+          "address": "0x316",
+          "priv_mode": "M",
+          "length": 64,
+          "desc": "PMP-to-SPMP delegation control"
+        }
+      },
+      "version": "1.0.0",
+      "instructions": {}
     }
   ],
   "s_interrupt": [

--- a/tests/catalog-coverage.test.mjs
+++ b/tests/catalog-coverage.test.mjs
@@ -21,6 +21,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { PROFILES } from '../src/profiles.js';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const catalog = JSON.parse(
@@ -449,11 +450,16 @@ test('optional and mandatory sets do not overlap', () => {
   const optional = JSON.parse(
     fs.readFileSync(path.join(here, '..', 'src', 'profile-optional.json'), 'utf8'),
   );
-  const profiles = fs.readFileSync(path.join(here, '..', 'src', 'profiles.js'), 'utf8');
+  /*
+   * Read the table, do not re-parse the source. The regex this replaces
+   * assumed every profile was written as a multi-line array: a one-line entry
+   * (`RVI20U32: ['RV32I'],`) has no `\n  ]` to stop at, so the match ran on
+   * into the NEXT profile's block and the test silently compared RVI20U32's
+   * options against RVA20's mandatory set.
+   */
   for (const [profile, list] of Object.entries(optional)) {
-    const block = profiles.match(new RegExp(`\\n  ${profile}: \\[([\\s\\S]*?)\\n  \\]`));
-    if (!block) continue;
-    const mandatory = new Set([...block[1].matchAll(/'([^']+)'/g)].map((m) => m[1]));
+    const mandatory = new Set(PROFILES[profile] ?? []);
+    if (mandatory.size === 0) continue;
     const both = list.filter((id) => mandatory.has(id));
     assert.deepEqual(
       both,

--- a/tests/completeness.test.mjs
+++ b/tests/completeness.test.mjs
@@ -160,6 +160,55 @@ test('ownership decides the bucket: right encoding, wrong extension is an attrib
   assert.equal(result.attributedDifferently[0].localExtension, 'Zalasr');
 });
 
+test('the two coverage questions are answered separately', () => {
+  /*
+   * The bug this guards: "is the encoding in the catalogue anywhere" reads
+   * 100% while an extension lists nothing at all. That is not hypothetical —
+   * it is exactly how Zve32x, Zve32f, Zve64x, Zve64f and Zvkb shipped empty
+   * past every check, their instructions all present under V and Zvbb.
+   *
+   * One instruction, attributed by upstream to an extension that does not list
+   * it locally, must count as covered globally and uncovered per-extension.
+   */
+  const zalasr = rowFor('Zalasr', 'LB.AQ');
+  const result = compareAgainstUpstream(catalogue, {
+    extensions: [],
+    instructions: [
+      { mnemonic: 'LB.AQ', match: zalasr.match, mask: zalasr.mask, definedBy: ['Zicsr'] },
+    ],
+  });
+
+  assert.equal(result.coverage.considered, 1);
+  assert.deepEqual(result.coverage.global, { covered: 1, uncovered: 0, percent: 100 });
+  assert.equal(result.coverage.perExtension.covered, 0);
+  assert.equal(result.coverage.perExtension.filedElsewhere, 1);
+  assert.equal(result.coverage.perExtension.percent, 0);
+
+  // `complete` is global coverage, and now says so rather than implying it.
+  assert.equal(result.complete, true, 'nothing is absent, so the gate passes');
+});
+
+test('coverage buckets account for every instruction considered', () => {
+  // considered = covered here + filed elsewhere + encoding disagrees + absent.
+  // If they ever stop adding up, a bucket is being double-counted.
+  const zalasr = rowFor('Zalasr', 'LB.AQ');
+  const result = compareAgainstUpstream(catalogue, {
+    extensions: [],
+    instructions: [
+      { mnemonic: 'LB.AQ', match: zalasr.match, mask: zalasr.mask, definedBy: ['Zalasr'] },
+      { mnemonic: 'LB.AQ', match: zalasr.match, mask: zalasr.mask, definedBy: ['Zicsr'] },
+      { mnemonic: 'NOSUCH.INSN', match: '0xdeadbeef', mask: '0xffffffff', definedBy: ['Zicsr'] },
+    ],
+  });
+  const { considered, perExtension: pe } = result.coverage;
+  assert.equal(considered, 3);
+  assert.equal(pe.covered + pe.filedElsewhere + pe.encodingDisagrees + pe.uncovered, considered);
+  assert.equal(pe.covered, 1);
+  assert.equal(pe.filedElsewhere, 1);
+  assert.equal(pe.uncovered, 1);
+  assert.equal(result.complete, false, 'a genuinely absent encoding still fails the gate');
+});
+
 // ── the ordering variants, against real data ───────────────────────────────
 
 test('all four orderings of a real AMO are covered by the one catalogue row', () => {

--- a/tests/isa-graph.test.mjs
+++ b/tests/isa-graph.test.mjs
@@ -19,6 +19,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {
   DEPENDENCY_GRAPH,
+  EDGE_SOURCES,
   SMART_DEPENDENCIES,
   INCOMPATIBLE_WITH,
   validateGraph,
@@ -88,7 +89,9 @@ test('every edge cites a source', () => {
   for (const [id, node] of Object.entries(DEPENDENCY_GRAPH.nodes)) {
     for (const edge of node.requires ?? []) {
       assert.ok(edge.ref?.trim(), `${id} -> ${edge.ext} has no citation`);
-      assert.ok(['udb', 'isa-manual', 'clang'].includes(edge.src), `${id} -> ${edge.ext} has src "${edge.src}"`);
+      // Read the permitted set from the module rather than restating it, so
+      // adding a source in one place cannot leave the other behind.
+      assert.ok(EDGE_SOURCES.has(edge.src), `${id} -> ${edge.ext} has src "${edge.src}"`);
     }
   }
 });

--- a/tests/profiles.test.mjs
+++ b/tests/profiles.test.mjs
@@ -85,3 +85,35 @@ test('satp translation modes are excluded from -march', () => {
     assert.ok(!NON_MARCH_IDS.has(real), `${real} is a valid -march extension and should be emitted`);
   }
 });
+
+test('RVI20 mandates its base ISA and nothing else', () => {
+  /*
+   * The whole character of RVI20 is that everything is optional: §4.1.1.2 and
+   * §4.1.2.2 of the profiles document each read "There are no mandatory
+   * extensions." Adding M or C here — as every other profile in this table
+   * does — would silently promote an option into a requirement and make the
+   * generated -march wrong for the one profile whose point is minimalism.
+   */
+  assert.deepEqual(PROFILES.RVI20U32, ['RV32I']);
+  assert.deepEqual(PROFILES.RVI20U64, ['RV64I']);
+});
+
+test('RVI20 offers its options, and only ones that fit its XLEN', () => {
+  const optional = JSON.parse(
+    fs.readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'src', 'profile-optional.json'),
+      'utf8',
+    ),
+  );
+  for (const name of ['RVI20U32', 'RVI20U64']) {
+    for (const id of ['M', 'A', 'F', 'D', 'C', 'Zifencei', 'Zicntr', 'Zihpm']) {
+      assert.ok(optional[name]?.includes(id), `${name} should offer ${id}`);
+    }
+  }
+  // Zcf is the compressed single-precision pair, defined for RV32 only. UDB's
+  // RVI20U64 inherits RVI20U32 wholesale and so lists it; offering it on a
+  // 64-bit profile would put an unbuildable chip in front of the reader.
+  assert.ok(optional.RVI20U32.includes('Zcf'), 'RV32 gets Zcf');
+  assert.ok(!optional.RVI20U64.includes('Zcf'), 'RV64 must not');
+  assert.ok(optional.RVI20U64.includes('Zcd'), 'Zcd is defined for both XLENs');
+});

--- a/tests/sync-tooling.test.mjs
+++ b/tests/sync-tooling.test.mjs
@@ -139,6 +139,34 @@ test('--dry-run leaves the UDB sync catalogue alone', () => {
   assert.equal(hashCatalog(), before);
 });
 
+test('extensions UDB does not carry stay on the watchlist', (t) => {
+  /*
+   * The report's watchlist is derived — an entry carrying a long_name is taken
+   * to be already synced and dropped from it. That rule assumes UDB is always
+   * ahead of us. SPMP is where it is not: ratified in its own specification,
+   * absent from UDB entirely, and described here from that PDF, which is
+   * exactly what would remove it from the list.
+   *
+   * So the one part of the catalogue UDB is behind on would be the one part the
+   * weekly report never mentions. ALWAYS_WATCH holds them there.
+   */
+  const udb = path.resolve(root, '..', 'riscv-unified-db');
+  if (!fs.existsSync(path.join(udb, 'spec', 'std', 'isa', 'ext'))) {
+    t.skip('no riscv-unified-db checkout beside this repo');
+    return;
+  }
+
+  const { status, stdout } = run('sync_udb_extensions.cjs', [udb, '--dry-run']);
+  assert.equal(status, 0, stdout);
+  for (const id of ['Sspmp', 'Sspmpen', 'Smpmpdeleg']) {
+    assert.match(
+      stdout,
+      new RegExp(`^\\s+- ${id}$`, 'm'),
+      `${id} should be reported as still missing from UDB:\n${stdout}`,
+    );
+  }
+});
+
 test('the graph seeder fails loudly when pointed somewhere wrong', () => {
   const { status } = run('seed-dependency-graph.mjs', ['--check', '--udb', '/nonexistent-udb-path']);
   assert.equal(status, 1, 'a missing UDB checkout must be a failure');

--- a/tests/udb-parser.test.mjs
+++ b/tests/udb-parser.test.mjs
@@ -8,6 +8,8 @@ import {
   parseVariables,
   applyNotConstraints,
   parseEncodings,
+  parseDefinedBy,
+  predicateXlen,
   EXTENSION_ALIASES,
 } from '../scripts/check-udb-completeness.mjs';
 
@@ -260,4 +262,96 @@ encoding:
   const RM = 0x7n << 12n;
   assert.equal(encs[0].mask & RM, RM, 'RV32 pins tt via not:');
   assert.equal(encs[1].mask & RM, 0n, 'RV64 leaves it free');
+});
+
+// ── definedBy as a predicate, not a flat owner list ────────────────────────
+
+/*
+ * Reading only the `name:` values answers "which extensions" and discards
+ * "under what conditions". 132 instruction files in unified-db carry an
+ * `xlen:` inside definedBy, so MULW's "RV64 AND (M OR Zmmul)" collapsed to
+ * "[M, Zmmul]" and the RV64 half was simply gone. That condition is the only
+ * thing distinguishing an RV32-only pairing from its RV64 namesake.
+ *
+ * Every shape below is taken from a real file in the corpus.
+ */
+
+test('the simple shape: one extension, no condition', () => {
+  const { owners, predicate } = parseDefinedBy(`  extension:
+    name: I`);
+  assert.deepEqual(owners, ['I']);
+  assert.deepEqual(predicate, { extension: { name: 'I' } });
+  assert.equal(predicateXlen(predicate), null, 'applies to both XLENs');
+});
+
+test('an alternation keeps its shape', () => {
+  const { owners, predicate } = parseDefinedBy(`  extension:
+    anyOf:
+      - name: Smctr
+      - name: Ssctr`);
+  assert.deepEqual(owners, ['Smctr', 'Ssctr']);
+  assert.deepEqual(predicate, {
+    extension: { anyOf: [{ name: 'Smctr' }, { name: 'Ssctr' }] },
+  });
+});
+
+test('an xlen condition survives, nested or not', () => {
+  // Zaamo/amoor.d.rl.yaml — extension first, then the width.
+  const flat = parseDefinedBy(`  allOf:
+    - extension:
+        name: Zaamo
+    - xlen: 64`);
+  assert.deepEqual(flat.owners, ['Zaamo']);
+  assert.equal(predicateXlen(flat.predicate), 64);
+
+  // M/mulw.yaml — the width guards an alternation.
+  const nested = parseDefinedBy(`  allOf:
+    - xlen: 64
+    - extension:
+        anyOf:
+          - name: M
+          - name: Zmmul`);
+  assert.deepEqual(nested.owners, ['M', 'Zmmul']);
+  assert.equal(predicateXlen(nested.predicate), 64);
+  assert.deepEqual(nested.predicate, {
+    allOf: [{ xlen: 64 }, { extension: { anyOf: [{ name: 'M' }, { name: 'Zmmul' }] } }],
+  });
+});
+
+test('a negation is not mistaken for a requirement', () => {
+  // Zbb/zext.h.yaml: Zbb AND NOT Zbkb. The flat reading gave [Zbb, Zbkb],
+  // which states the opposite of what the file says about Zbkb.
+  const { owners, predicate } = parseDefinedBy(`  extension:
+    allOf:
+      - name: Zbb
+      - not:
+          name: Zbkb`);
+  assert.deepEqual(owners, ['Zbb', 'Zbkb'], 'the flat list still names both');
+  assert.deepEqual(predicate, {
+    extension: { allOf: [{ name: 'Zbb' }, { not: { name: 'Zbkb' } }] },
+  });
+});
+
+test('an xlen inside an alternation does not pin the instruction', () => {
+  // Only allOf propagates unconditionally: one alternative naming RV64 does
+  // not make the instruction RV64-only.
+  const { predicate } = parseDefinedBy(`  anyOf:
+    - xlen: 64
+    - extension:
+        name: Zbb`);
+  assert.equal(predicateXlen(predicate), null);
+});
+
+test('comments inside the block are ignored', () => {
+  const { owners } = parseDefinedBy(`  # zext.h is an alias of pack under Zbkb
+  extension:
+    name: Zbb`);
+  assert.deepEqual(owners, ['Zbb']);
+});
+
+test('an unrecognised shape yields no predicate rather than a wrong one', () => {
+  const { owners, predicate } = parseDefinedBy(`  extension:
+    ????`);
+  assert.equal(predicate, null, 'degrade to the flat list rather than invent a condition');
+  assert.deepEqual(owners, []);
 });

--- a/tests/zve-subsets.test.mjs
+++ b/tests/zve-subsets.test.mjs
@@ -1,0 +1,246 @@
+/**
+ * The embedded vector subsets, and the other extensions that had no upstream
+ * instruction source.
+ *
+ * Zve32x, Zve32f, Zve64x, Zve64f and Zve64d shipped with empty instruction
+ * maps. Every check the project runs passed anyway, and that is the point of
+ * this file: riscv-opcodes has no `rv_zve*` tag, unified-db attributes all 627
+ * vector instructions to one owner (Zvl32b), and the completeness gate only
+ * ever asked whether an encoding was in the catalogue *somewhere* — which it
+ * was, under V. Nothing upstream can catch a mistake in the derivation, so the
+ * rules are pinned here instead.
+ *
+ * The counts are deliberately exact. A rule change that moves one instruction
+ * should have to say so.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const catalogue = JSON.parse(
+  fs.readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'src', 'riscv_extensions.json'),
+    'utf8',
+  ),
+);
+
+const byId = new Map();
+for (const group of Object.values(catalogue)) {
+  if (Array.isArray(group)) for (const entry of group) byId.set(entry.id, entry);
+}
+const mnemonics = (id) => new Set(Object.keys(byId.get(id)?.instructions ?? {}));
+const count = (id) => mnemonics(id).size;
+
+// ---------------------------------------------------------------------------
+// Zve*
+// ---------------------------------------------------------------------------
+
+test('every Zve* subset carries instructions', () => {
+  for (const id of ['Zve32x', 'Zve32f', 'Zve64x', 'Zve64f', 'Zve64d']) {
+    assert.ok(count(id) > 0, `${id} is empty — the derivation did not run`);
+  }
+});
+
+test('the subsets nest the way the spec orders them', () => {
+  // §30.1.18.2: Zve32f and Zve64x depend on Zve32x, Zve64f on both, Zve64d on
+  // Zve64f. The chain forks: neither Zve32f nor Zve64x contains the other.
+  const subsetOf = (sub, sup) => {
+    const [a, b] = [mnemonics(sub), mnemonics(sup)];
+    const escaped = [...a].filter((m) => !b.has(m));
+    assert.deepEqual(escaped, [], `${sub} should be a subset of ${sup}`);
+  };
+  subsetOf('Zve32x', 'Zve32f');
+  subsetOf('Zve32x', 'Zve64x');
+  subsetOf('Zve32f', 'Zve64f');
+  subsetOf('Zve64x', 'Zve64f');
+  subsetOf('Zve64f', 'Zve64d');
+
+  const f32 = mnemonics('Zve32f');
+  const x64 = mnemonics('Zve64x');
+  assert.ok([...f32].some((m) => !x64.has(m)), 'Zve32f should hold FP that Zve64x lacks');
+  assert.ok([...x64].some((m) => !f32.has(m)), 'Zve64x should hold EEW=64 that Zve32f lacks');
+});
+
+test('Zve64d is V, because V is Zve64d plus a wider VLEN', () => {
+  // V depends on Zve64d and Zvl128b; the extra requirement is minimum VLEN,
+  // not instructions. Anything else here means the derivation dropped one.
+  assert.deepEqual([...mnemonics('Zve64d')].sort(), [...mnemonics('V')].sort());
+});
+
+test('the x-variants exclude floating point and nothing else', () => {
+  const v = mnemonics('V');
+  const isFP = (m) => (/^VF/.test(m) && m !== 'VFIRST.M') || /^VMF/.test(m);
+  const expected = [...v].filter((m) => !isFP(m)).sort();
+  assert.deepEqual([...mnemonics('Zve64x')].sort(), expected);
+
+  // The mnemonics that read as floating point and are not.
+  assert.ok(mnemonics('Zve32x').has('VFIRST.M'), 'VFIRST.M is a mask instruction');
+  for (const m of ['VSEXT.VF2', 'VZEXT.VF4', 'VSEXT.VF8']) {
+    assert.ok(mnemonics('Zve32x').has(m), `${m} is integer — the VF is a widening factor`);
+  }
+  // ...and the FP compares, which are spelled VMF rather than VF.
+  for (const m of ['VMFEQ.VV', 'VMFLT.VF']) {
+    assert.ok(!mnemonics('Zve64x').has(m), `${m} is a floating-point compare`);
+  }
+});
+
+test('Zve32* stop at EEW=32, so the EEW=64 encodings are absent', () => {
+  const z32 = mnemonics('Zve32x');
+  for (const m of ['VLE64.V', 'VSE64.V', 'VL4RE64.V', 'VLSEG8E64.V', 'VLE64FF.V']) {
+    assert.ok(!z32.has(m), `${m} names EEW=64`);
+  }
+  for (const m of ['VLOXEI64.V', 'VSUXSEG3EI64.V']) {
+    assert.ok(!z32.has(m), `${m} is a 64-bit indexed form`);
+  }
+  // The Zve64* pair carries all of them.
+  for (const m of ['VLE64.V', 'VLOXEI64.V']) {
+    assert.ok(mnemonics('Zve64x').has(m), `${m} should be in Zve64x`);
+  }
+  // Nothing else is dropped: EEW 8/16/32 stay.
+  for (const m of ['VLE8.V', 'VLE16.V', 'VLE32.V', 'VADD.VV', 'VMULH.VV', 'VSMUL.VV']) {
+    assert.ok(z32.has(m), `${m} is within EEW=32`);
+  }
+});
+
+test('the f-variants take FP32 but not the work that needs FP64', () => {
+  for (const id of ['Zve32f', 'Zve64f']) {
+    const set = mnemonics(id);
+    for (const m of ['VFADD.VV', 'VFMUL.VF', 'VFSQRT.V', 'VFREDUSUM.VS', 'VFMV.F.S']) {
+      assert.ok(set.has(m), `${id} should carry ${m} at EEW=32`);
+    }
+    // Widening FP arithmetic produces a 2×SEW float, which is FP64 here.
+    for (const m of ['VFWADD.VV', 'VFWMUL.VF', 'VFWMACC.VV', 'VFWNMSAC.VF']) {
+      assert.ok(!set.has(m), `${id} cannot widen to FP64 (${m})`);
+    }
+    // §30.1.18.2 lists widening FP reductions for Zve64d only.
+    for (const m of ['VFWREDUSUM.VS', 'VFWREDOSUM.VS']) {
+      assert.ok(!set.has(m), `${id} has no widening FP reduction (${m})`);
+    }
+    // Float-to-float conversions need two float widths.
+    for (const m of ['VFWCVT.F.F.V', 'VFNCVT.F.F.W', 'VFNCVT.ROD.F.F.W']) {
+      assert.ok(!set.has(m), `${id} has only one float width (${m})`);
+    }
+  }
+  assert.ok(mnemonics('Zve64d').has('VFWADD.VV'), 'Zve64d has FP64 and so widens');
+});
+
+test('an FP/integer conversion turns on the integer width, not the float', () => {
+  /*
+   * These are the ones that separate Zve32f from Zve64f, and the reason the
+   * carve-out cannot be a single flat list. Both extensions offer FP32 and no
+   * FP64; they differ in whether an integer may be 64 bits wide.
+   */
+  const f32 = mnemonics('Zve32f');
+  const f64 = mnemonics('Zve64f');
+
+  for (const m of ['VFWCVT.X.F.V', 'VFWCVT.RTZ.XU.F.V', 'VFNCVT.F.X.W', 'VFNCVT.F.XU.W']) {
+    assert.ok(!f32.has(m), `${m} needs a 64-bit integer, which Zve32f lacks`);
+    assert.ok(f64.has(m), `${m} is available in Zve64f, which has EEW=64 integers`);
+  }
+  // Their mirror images stay in both: int16 → FP32 and FP32 → int16.
+  for (const m of ['VFWCVT.F.X.V', 'VFWCVT.F.XU.V', 'VFNCVT.X.F.W', 'VFNCVT.RTZ.XU.F.W']) {
+    assert.ok(f32.has(m), `${m} stays within EEW=32`);
+    assert.ok(f64.has(m), `${m} stays within EEW=32`);
+  }
+});
+
+test('the derived sets have not silently moved', () => {
+  assert.deepEqual(
+    {
+      Zve32x: count('Zve32x'),
+      Zve32f: count('Zve32f'),
+      Zve64x: count('Zve64x'),
+      Zve64f: count('Zve64f'),
+      Zve64d: count('Zve64d'),
+    },
+    { Zve32x: 450, Zve32f: 522, Zve64x: 526, Zve64f: 604, Zve64d: 627 },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The other extensions that were present in name only
+// ---------------------------------------------------------------------------
+
+test('Zvkb carries the nine forms the crypto extensions share', () => {
+  // riscv-opcodes has no rv_zvkb tag; the nine appear there with three
+  // memberships (rv_zvbb, rv_zvkn, rv_zvks), so tag routing left Zvkb empty.
+  assert.deepEqual([...mnemonics('Zvkb')].sort(), [
+    'VANDN.VV',
+    'VANDN.VX',
+    'VBREV8.V',
+    'VREV8.V',
+    'VROL.VV',
+    'VROL.VX',
+    'VROR.VI',
+    'VROR.VV',
+    'VROR.VX',
+  ]);
+  // They are exactly the intersection of the two bundles that share them.
+  const shared = [...mnemonics('Zvkn')].filter((m) => mnemonics('Zvks').has(m)).sort();
+  assert.deepEqual([...mnemonics('Zvkb')].sort(), shared);
+});
+
+test('Zilsd and Zclsd carry their RV32 register-pair encodings', () => {
+  assert.deepEqual([...mnemonics('Zilsd')].sort(), ['LD.RV32', 'SD.RV32']);
+  assert.deepEqual([...mnemonics('Zclsd')].sort(), [
+    'C.LD.RV32',
+    'C.LDSP.RV32',
+    'C.SD.RV32',
+    'C.SDSP.RV32',
+  ]);
+
+  /*
+   * The whole point is that these are NOT the RV64 rows. Each pins one extra
+   * bit — the even-register constraint that makes the operand a pair — so the
+   * mask must differ from the RV64 instruction of the same name.
+   */
+  const rv64 = byId.get('RV64I').instructions;
+  const zilsd = byId.get('Zilsd').instructions;
+  assert.equal(zilsd['LD.RV32'].match, rv64.LD.match, 'same opcode as the RV64 load');
+  assert.notEqual(zilsd['LD.RV32'].mask, rv64.LD.mask, 'but a narrower mask');
+  assert.ok(
+    zilsd['LD.RV32'].variable_fields.includes('rd_e'),
+    'the destination is an even register pair',
+  );
+  assert.ok(
+    zilsd['SD.RV32'].variable_fields.includes('rs2_e'),
+    'the source is an even register pair',
+  );
+});
+
+test('the bundles resolve to the union of their members', () => {
+  // Modelled with `members`, the same umbrella mechanism B and Zk use. The
+  // dependency graph always had the relation, so a resolved selection was
+  // right; the entries' own maps were empty, which is what compare reads.
+  const union = (...ids) => new Set(ids.flatMap((id) => [...mnemonics(id)]));
+  const same = (id, ...members) =>
+    assert.deepEqual([...mnemonics(id)].sort(), [...union(...members)].sort(), id);
+
+  same('Zvknc', 'Zvkn', 'Zvbc');
+  same('Zvkng', 'Zvkn', 'Zvkg');
+  same('Zvksc', 'Zvks', 'Zvbc');
+  same('Zvksg', 'Zvks', 'Zvkg');
+  // Zce omits Zcf: that member is conditional on RV32+F, and an umbrella
+  // carries no conditionals.
+  same('Zce', 'Zca', 'Zcb', 'Zcmp', 'Zcmt');
+});
+
+// ---------------------------------------------------------------------------
+// SPMP
+// ---------------------------------------------------------------------------
+
+test('the SPMP family is catalogued', () => {
+  for (const id of ['Sspmp', 'Sspmpen', 'Smpmpdeleg']) {
+    const entry = byId.get(id);
+    assert.ok(entry, `${id} missing from the catalogue`);
+    assert.equal(entry.state, 'ratified');
+    assert.equal(entry.ratification_date, '2026-08');
+    // CSR-only extensions. An empty instruction map is correct here, unlike
+    // the Zve* case above.
+    assert.equal(count(id), 0, `${id} defines no instructions`);
+  }
+  assert.equal(byId.get('Sspmpen').csrs.spmpen.address, '0x183');
+  assert.equal(byId.get('Smpmpdeleg').csrs.mpmpdeleg.address, '0x316');
+});


### PR DESCRIPTION
## What this changes

`npm run udb:check` now reports two coverage numbers instead of one, and says
which of them gates the build. The five extensions the old number was hiding —
`Zve32x`, `Zve32f`, `Zve64x`, `Zve64f` and `Zvkb` — get their instructions, the
ratified SPMP family is added, and `Zilsd`, `Zclsd` and the `RVI20` profiles are
filled in.

```
coverage over 1237 upstream encodings:
    global (present anywhere in the catalogue)          1237/1237  100%
    per-extension (listed by an owner upstream names)    602/1237  48.7%
```

Only global coverage gates. Attribution differences are frequently legitimate —
unified-db files `AMOCAS.B` under Zabha, this catalogue under Zacas — so the
second number is one to watch move, not a threshold to pass.

## Why

Fixes #312.

The gate only ever asked whether an upstream encoding was in the catalogue
*somewhere*, and for every one of these it was — filed under `V`, `Zvbb` or
`RV64I`. Each gap showed up only as one more `attributedDifferently` row among
635, and `complete` never read that bucket.

## What is in it

- **SPMP** — `Sspmp`, `Sspmpen`, `Smpmpdeleg`, ratified 8/2026 in a
  specification unified-db does not model. Every dependency edge is quoted from
  that document and cites a new `spec` provenance source, the graph having
  assumed each extension lives in UDB or the ISA manual.
- **Zve\*** — derived from `V` by the EEW and FP table in unpriv §30.1.18.2:
  450, 522, 526, 604 and 627 instructions. **This is the part a reviewer cannot
  check against upstream**, because no upstream carries it (no `rv_zve*` tag in
  riscv-opcodes; unified-db attributes all 627 vector instructions to `Zvl32b`).
  `tests/zve-subsets.test.mjs` pins the rules and the exact counts instead.
- **Zilsd / Zclsd** — six RV32 register-pair encodings built from
  riscv-opcodes' `rv32_zilsd` and `rv32_zclsd`. Every line upstream is a
  `$pseudo_op`, which the drift checker excludes by design, which is why they
  were never picked up.
- **Zvkb** — the nine forms upstream expresses as triple tag membership.
- **Zvknc / Zvkng / Zvksc / Zvksg / Zce** — modelled as `members` umbrellas, the
  mechanism `B` and `Zk` already use.
- **RVI20U32 / RVI20U64** — the base ISA alone (§4.1.1.2: *"There are no
  mandatory extensions"*), plus their optional sets with `Zcf` dropped from the
  64-bit one.
- **`definedBy` is parsed as a predicate tree**, so the 126 instructions whose
  ownership is guarded by an `xlen` keep that condition.
- **`ALWAYS_WATCH`** holds SPMP on the sync report's watchlist: that list is
  derived, and giving an extension a `long_name` is what drops it off. We are
  ahead of unified-db here, and the report should keep saying so.

Two pre-existing bugs surfaced on the way. `catalog-coverage` regex-parsed
`profiles.js` assuming multi-line arrays, so a one-line entry compared against
the next profile's block; `isa-graph` restated the permitted edge sources
instead of reading `EDGE_SOURCES`. Both now read the module.

## How it was verified

- `npm test` — 374 tests, 373 pass, 1 pre-existing skip
- `npm run lint`, `npm run build` — clean
- `npm run sync:check`, `npm run opcodes:check`, `npm run profiles:check` — in sync
- `npm run graph:check` against unified-db `main` — *no drift, 223 nodes match*
- Browser, light theme at 1568px: `Zve32x` shows **450 instructions** with no
  `VLE64`/`VF*`; `Sspmp` shows RATIFIED 2026-08; `RVI20U64` highlights `RV64I`
  alone and reports `Sspmp` as "Not required in RVI20U64"

- [x] `npm test` passes
- [x] `npm run build` succeeds

## If this touches ISA data

- [x] Cited the source: specification section, `riscv-unified-db` file, or `riscv-opcodes` entry
- [x] Regenerated rather than hand-edited, where a generator exists
      (`npm run sync`, `npm run sync:udb`, `scripts/seed-dependency-graph.mjs`)

`src/riscv_extensions.json` and `src/profile-optional.json` are generator
output. The graph nodes were added to match what `seed-dependency-graph.mjs`
emits from `LOCAL_EDGES` — confirmed by `graph:check` reporting no drift — rather
than by re-seeding, which would have rewritten the recorded UDB commit.

## Sign-off

- [x] Every commit is signed off (`git commit -s`), per the [DCO](../DCO)
