### PR TITLE
feat: show the instruction count on each extension tile

### DIFF
--- a/src/ExtensionTile.jsx
+++ b/src/ExtensionTile.jsx
@@ -46,6 +46,9 @@ function ExtensionTile({
   const highlighted = isHighlighted(data.id) || matchesSearch || isSelected;
   const dimmed = isDimmed(data.id) && !matchesSearch && !isSelected;
   const inWorkspace = workspaceIds.has(data.id);
+  // Derived from `data` rather than passed in, so tilePropsAreEqual needs no
+  // new comparison: it already returns false when `data` changes identity.
+  const instructionCount = Object.keys(data.instructions || {}).length;
   const inCompare = compareIds.has(data.id);
 
   return (
@@ -236,12 +239,39 @@ function ExtensionTile({
       {/* The short label, not `desc`. The tile is 190px wide - about 32
           characters a line, 65 in the two-line clamp - so a full description
           truncates into a fragment here. `desc` is shown in the details panel
-          when a tile is selected, where there is room for it. */}
-      <div
-        className="text-[11px] leading-snug line-clamp-2"
-        style={{ color: 'var(--riscv-text-2)' }}
-      >
-        {data.short || data.desc}
+          when a tile is selected, where there is room for it.
+
+          The instruction count shares this row rather than the name row above:
+          the corner controls are absolutely positioned over the name row's
+          right edge, so a count there would sit under the compare and "+"
+          buttons. */}
+      <div className="flex items-end justify-between gap-2">
+        <div
+          className="text-[11px] leading-snug line-clamp-2"
+          style={{ color: 'var(--riscv-text-2)' }}
+        >
+          {data.short || data.desc}
+        </div>
+        {/* Shown only when there are instructions to count. 122 of the 223
+            catalogue entries define none — Ziccamoa is a PMA rule, Sspmp is
+            CSR-only — and for those an empty list is the correct answer, not a
+            missing one. Printing "0" across more than half the grid would read
+            as absent data. Absence of the figure carries the same meaning
+            without the false alarm.
+
+            The number is this entry's OWN map, so the `members` bundles report
+            their union: Zvknc reads 27, Zce 54. */}
+        {instructionCount > 0 && (
+          <span
+            className="font-mono text-[10px] leading-none shrink-0"
+            style={{ color: 'var(--riscv-text-2)' }}
+            // A bare numeral means nothing read aloud, and nothing on hover.
+            aria-label={`${instructionCount} instructions`}
+            title={`${instructionCount} instructions`}
+          >
+            {instructionCount}
+          </span>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What this changes

Each extension tile now shows how many instructions it carries.

```
┌────────────────────────┐     ┌────────────────────────┐
│ Zbb              [⇄][+]│     │ Ziccamoa         [⇄][+]│
│ Basic Bitmanip     25  │     │ Atomics PMA            │
└────────────────────────┘     └────────────────────────┘
```

The count sits on the short-label row, not beside the name: the corner controls
are absolutely positioned over the name row's right edge, so a figure there
would sit under the compare and `+` buttons. It shares that row as a `shrink-0`
flex item, so a narrowing tile takes width from the label and never from the
number, and the label keeps its two-line clamp.

## Why

Closes #314.

The grid is where extensions get compared, and it said nothing about how much
was in any of them — that took selecting a tile and reading the details panel,
one at a time.

**The count is deliberately absent on 122 of 223 tiles.** Those entries define
no instructions and an empty list is the correct answer, not a missing one:
`Ziccamoa` is a PMA rule, `Sspmp` is CSR-only, `Zve` and `Zvl32b` are
naming-prefix and VLEN entries. Printing `0` across more than half the grid
would read as absent data — the misreading #312 was about, and the one
`AGENTS.md` now warns against outright. Showing nothing says the same thing
without the false alarm.

## Notes for review

- The figure is the entry's **own** map, so the `members` bundles report their
  union: `Zvknc` reads 27, `Zce` 54. Both were empty until #313.
- Derived from `data` rather than passed as a prop, so `tilePropsAreEqual` needs
  no new comparison — it already returns false when `data` changes identity, and
  the 227-tile remount that file exists to prevent stays prevented.
- A bare numeral is meaningless to a screen reader, so it carries a matching
  `aria-label` and `title` ("25 instructions").

## How it was verified

`npm test` (374, 373 pass, 1 pre-existing skip), `npm run lint`, `npm run build`
— all clean. Per `AGENTS.md` the suite does not render the UI, so the rest is a
browser check at 1910px in **both themes**:

| check | result |
|---|---|
| Count elements rendered | 101 — exactly the non-empty extensions |
| Label/count collisions | 0 across all 101 |
| Distinct tile heights | 56 / 71px — unchanged, the count adds no height |
| Contrast, light (worst: `Zca`) | 5.61:1 — passes AA |
| Contrast, dark (worst: `Ssctr`) | 6.65:1 — passes AA |

One gap worth stating: `resize_window` reported success but the window was
maximized, so I could not test a genuinely narrow viewport. The layout reasoning
holds — `shrink-0` on the count, label is the flexible element, collision audit
run at the real ~190px tile width — but I have not seen it at mobile width. The
dark figure is also approximate, computed against a semi-transparent tile
background.

- [x] `npm test` passes
- [x] `npm run build` succeeds

## Sign-off

- [x] Every commit is signed off (`git commit -s`), per the [DCO](../DCO)
