### PR TITLE
ci: sign the commits the automated workflows create

### DIFF
--- a/.github/workflows/audit-deps.yml
+++ b/.github/workflows/audit-deps.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           commit-message: 'chore(deps): apply npm audit fixes'
           # Same reasoning as sync-udb-extensions.yml: the DCO gate matches the
@@ -129,6 +129,16 @@ jobs:
           # the sign-off valid.
           author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
           committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          # sign-commits, because `main` carries a required_signatures rule and
+          # this action does NOT sign by default (`sign-commits` defaults to
+          # false, and v6 had no such input at all — it was added in v7). Every
+          # automated PR was therefore opened with an unsigned commit and could
+          # not be merged, while the DCO check stayed green and made it look
+          # fine. Sign-off and signature are different things: `signoff` writes a
+          # Signed-off-by trailer, which is plain text; required_signatures wants
+          # a cryptographic one. With sign-commits the action commits through the
+          # GitHub API and GitHub signs with its own key.
+          sign-commits: true
           signoff: true
           branch: chore/audit-deps
           delete-branch: true

--- a/.github/workflows/sync-udb-extensions.yml
+++ b/.github/workflows/sync-udb-extensions.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           commit-message: 'feat: sync extension data from riscv-unified-db'
           # The DCO gate matches the Signed-off-by trailer against the commit
@@ -106,6 +106,16 @@ jobs:
           # being attributed to whoever happened to click "Run workflow".
           author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
           committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          # sign-commits, because `main` carries a required_signatures rule and
+          # this action does NOT sign by default (`sign-commits` defaults to
+          # false, and v6 had no such input at all — it was added in v7). Every
+          # automated PR was therefore opened with an unsigned commit and could
+          # not be merged, while the DCO check stayed green and made it look
+          # fine. Sign-off and signature are different things: `signoff` writes a
+          # Signed-off-by trailer, which is plain text; required_signatures wants
+          # a cryptographic one. With sign-commits the action commits through the
+          # GitHub API and GitHub signs with its own key.
+          sign-commits: true
           signoff: true
           title: 'feat: sync extension data from UDB'
           body: |


### PR DESCRIPTION
## What this changes

Both workflows that open automated PRs now sign their commits.

## Why

Every automated PR has been unmergeable, and the reason was well disguised. #319 is the live example: 7/7 checks green, DCO green, approved, no conflicts, branch up to date — and still `BLOCKED`.

`main` carries a `required_signatures` rule, so a commit needs a cryptographic signature. `peter-evans/create-pull-request` does not produce one by default: `sign-commits` defaults to `false`, and the pinned v6.1.0 had no such input at all — it arrived in v7.

What hid it:

- Both workflows already say `signoff: true`, and the ruleset enforcing signatures is named **"Enforce DCO Compliance."** A DCO sign-off is a `Signed-off-by` line — plain text certifying origin. A signature is a key. Different things, similar words.
- GitHub reports only `mergeStateStatus: BLOCKED` with no reason attached.
- The rule lives in a repository **ruleset**, not classic branch protection, so `repos/.../branches/main/protection` shows only `build-and-test` and `strict: true`. You have to look at `repos/.../rules/branches/main` to see `required_signatures`.

Confirmed on the commit itself:

```
commit 25d86ec62c20  (PR #319)
author   github-actions[bot]
verified false
reason   unsigned
```

For contrast, `3f2de4c` on `main` — a human merge — is `verified: true`.

## The change

`sync-udb-extensions.yml` and `audit-deps.yml` both move from v6.1.0 to v8 (pinned by digest with a `# v8` comment, matching the convention here) and set `sign-commits: true`. The action then commits through the GitHub API, and GitHub signs with its own key.

The existing `author`/`committer` pinning is deliberately left alone. The DCO gate matches the `Signed-off-by` trailer against the commit **author**; this action writes the trailer from the **committer**; and `sign-commits` forces the committer to the token identity — `github-actions[bot]`, which is exactly what both are already pinned to. They coincide, so the trailer still matches.

## How it was verified

- The pinned digest `5f6978f` is confirmed to be a **commit** object, not an annotated-tag object — the `git/ref/tags/v8` response reports `type: commit`, and it resolves to a real commit in the action's history. Pinning the tag object instead would break the workflow.
- `sign-commits` confirmed absent from v6.1.0's `action.yml` and present from v7.0.0 onward, so this genuinely could not be enabled without the bump.
- Both files still parse as YAML with their job structure intact.
- `npm test` 419 (418 pass, 1 pre-existing skip), `npm run lint` clean, `npm run build` compiles.

**What this does not do:** it does not unblock #319. That PR's commit is already written and unsigned. The next scheduled sync supersedes it.

The real test is the next scheduled run — no local check can prove the action signs correctly at runtime. If the DCO trailer and author drift apart under `sign-commits`, the DCO check will say so on that PR.

- [x] `npm test` passes
- [x] `npm run build` succeeds

## Sign-off

- [x] Every commit is signed off (`git commit -s`), per the [DCO](../DCO)
