### PR TITLE
fix(export): sort unrecognised single-letter extensions after recognised ones (#311)

### DIFF
--- a/src/exportUtils.js
+++ b/src/exportUtils.js
@@ -7,14 +7,19 @@
  * successor carries an explicit "work-in-progress" caution).
  *
  * COMPILER COMPATIBILITY SCOPE (per extension family):
- *   Scalar crypto (Zk, Zkn, Zks, Zbkb, etc.): supported since ~GCC 12-13 / LLVM 14-15.
- *   Vector crypto (Zvkned, Zvbb, Zvbc, Zvkg family): GCC 14+ / LLVM 18+ (stable).
- *   Zve/Zvl sub-profile tokens: exact min version unconfirmed; verify with your toolchain.
- *   Base/gc extensions: universally stable.
- *   Full details and CI gap: see marchUtils.js COMPILER VERIFICATION SCOPE.
+ *   Not restated here. The summary this file emits into every export comes from
+ *   COMPILER_COMPAT_NOTES in marchUtils.js, and the reasoning behind each entry
+ *   is in that file's COMPILER VERIFICATION SCOPE block. A third hand-maintained
+ *   copy of the same prose is how the previous one went stale.
  */
 
-import { buildMarchString, BASE_ISA_IDS, BASE_ISA_PREFIX_MAP } from './marchUtils.js';
+import {
+  buildMarchString,
+  BASE_ISA_IDS,
+  BASE_ISA_PREFIX_MAP,
+  SHORTHAND_BUNDLES,
+  COMPILER_COMPAT_NOTES,
+} from './marchUtils.js';
 import { buildCombinedCatalog } from './marchUtils.js';
 import { resolveParams } from './isaGraph.js';
 import { DEPENDENCY_GRAPH } from './isaGraph.js';
@@ -161,6 +166,14 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
     }
 
     if (id.length === 1) {
+      if (idUpper === 'I' || idUpper === 'E') {
+        if (idUpper !== baseInfo.base.toUpperCase()) {
+          warnings.push(
+            `"${id}" was dropped: it names a base ISA that is mutually exclusive with ${baseInfo.id}.`,
+          );
+        }
+        continue;
+      }
       singleLetters.push(idUpper);
       allExtTokens.push(idUpper);
     } else {
@@ -374,7 +387,17 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
       .sort((a, b) => RC_LETTER_ORDER.indexOf(a) - RC_LETTER_ORDER.indexOf(b))
       .join('');
     const vPresent = rcSingles.includes('V');
-    const rcCandidates = vPresent ? zExts.filter((z) => !/^Zv(e|l)/i.test(z)) : zExts;
+    const shorthandAbsorbed = new Map();
+    for (const [shorthand, members] of Object.entries(SHORTHAND_BUNDLES)) {
+      if (selectedIds.includes(shorthand)) {
+        for (const member of members) shorthandAbsorbed.set(member, shorthand);
+      }
+    }
+    const rcCandidates = zExts.filter((z) => {
+      if (vPresent && /^Zv(e|l)/i.test(z)) return false;
+      if (shorthandAbsorbed.has(z)) return false;
+      return true;
+    });
     const rcKnown = rcCandidates.filter((z) => RISCV_CONFIG_SUB_EXTENSIONS.has(z)).sort(riscvConfigSort);
     const rcDropped = rcCandidates.filter((z) => !RISCV_CONFIG_SUB_EXTENSIONS.has(z)).sort();
     const rcAbsorbed = vPresent ? zExts.filter((z) => /^Zv(e|l)/i.test(z)).sort() : [];
@@ -395,6 +418,17 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
       rc.push(`# ${rcAbsorbed.length} vector sub-extension(s) folded into V, which is a shorthand`);
       rc.push(`# for Zve64d plus a 128-bit VLEN floor. riscv-config rejects a string`);
       rc.push(`# carrying both: ${rcAbsorbed.join(', ')}`);
+    }
+
+    for (const [shorthand, members] of Object.entries(SHORTHAND_BUNDLES)) {
+      if (!selectedIds.includes(shorthand)) continue;
+      const covered = members.filter((m) => zExts.includes(m)).sort();
+      if (covered.length) {
+        rc.push(``);
+        rc.push(`# ${covered.length} sub-extension(s) folded into ${shorthand}, which is a shorthand`);
+        rc.push(`# for its member subsets. riscv-config rejects a string`);
+        rc.push(`# carrying both: ${covered.join(', ')}`);
+      }
     }
 
     if (rcDropped.length) {
@@ -448,12 +482,7 @@ export function buildIsaConfigYaml(selectedIds, allExts, options = {}) {
   lines.push(`xlen: ${baseInfo.xlen}`);
   lines.push(``);
   lines.push(`# Compiler -march flag. Toolchain compatibility varies by extension family:`);
-  lines.push(`#   Scalar crypto (Zk, Zkn, Zks, Zbkb, etc.): supported since ~GCC 12-13 / LLVM 14-15.`);
-  lines.push(`#   Vector crypto (Zvkned, Zvbb, Zvbc family): requires GCC 14+ / non-experimental LLVM 18+.`);
-  lines.push(`#   Zve/Zvl sub-profile tokens: exact min version unconfirmed — verify with your toolchain:`);
-  lines.push(`#     gcc: riscv64-unknown-elf-gcc -march=help`);
-  lines.push(`#     clang: clang --target=riscv64-unknown-elf --print-supported-extensions`);
-  lines.push(`#   Non-ISA extensions excluded from this string.`);
+  for (const note of COMPILER_COMPAT_NOTES) lines.push(`#   ${note}`);
   lines.push(`march: ${marchString}`);
   lines.push(``);
   lines.push(`# INFERRED, not chosen. Derived from which extensions are present`);

--- a/src/marchUtils.js
+++ b/src/marchUtils.js
@@ -45,6 +45,31 @@
  *   check is a floor rather than full coverage — that is the remaining gap.
  */
 
+/**
+ * The compiler-compatibility summary, condensed, as the single source of truth.
+ *
+ * This prose used to live in three hand-maintained copies: the scope block
+ * above, the header of exportUtils.js, and the comment exportUtils.js emits
+ * into every exported file. They had drifted apart — the export header named
+ * Zvkg where the emitted copy omitted it, while the block above lists the
+ * fuller Zvk family — so a reader comparing an exported file against the
+ * source got two different answers to one question. The emitted copy is
+ * generated from here now, and the export header points at this rather than
+ * restating it.
+ *
+ * The vector-crypto family is named by prefix deliberately. Enumerating a
+ * handful of its members is exactly what went stale, and riscv_extensions.json
+ * carries 21 of them; `Zvk*` cannot drift.
+ */
+export const COMPILER_COMPAT_NOTES = [
+  'Scalar crypto (Zk, Zkn, Zks, Zbkb, etc.): supported since ~GCC 12-13 / LLVM 14-15.',
+  'Vector crypto (the Zvk* family, plus Zvbb and Zvbc): requires GCC 14+ / non-experimental LLVM 18+.',
+  'Zve/Zvl sub-profile tokens: exact min version unconfirmed — verify with your toolchain:',
+  '  gcc: riscv64-unknown-elf-gcc -march=help',
+  '  clang: clang --target=riscv64-unknown-elf --print-supported-extensions',
+  'Non-ISA extensions excluded from this string.',
+];
+
 // ============================================================================
 // Canonical single-letter extension ordering
 // ============================================================================

--- a/tests/export.test.mjs
+++ b/tests/export.test.mjs
@@ -11,15 +11,24 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildIsaConfigYaml } from '../src/exportUtils.js';
+import { COMPILER_COMPAT_NOTES, SHORTHAND_BUNDLES } from '../src/marchUtils.js';
 import { resolveSelection } from '../src/isaGraph.js';
 import { PROFILES } from '../src/profiles.js';
 
 const ALL = (() => {
-  const file = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'src', 'riscv_extensions.json');
-  return Object.values(JSON.parse(fs.readFileSync(file, 'utf8'))).flat().filter(Boolean);
+  const file = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    'src',
+    'riscv_extensions.json',
+  );
+  return Object.values(JSON.parse(fs.readFileSync(file, 'utf8')))
+    .flat()
+    .filter(Boolean);
 })();
 const IDS = new Set(ALL.map((e) => e.id));
-const resolve = (sel) => resolveSelection({ selected: sel, base: 'RV64I' }).resolved.filter((i) => IDS.has(i));
+const resolve = (sel) =>
+  resolveSelection({ selected: sel, base: 'RV64I' }).resolved.filter((i) => IDS.has(i));
 const RVA23 = resolve(PROFILES.RVA23);
 
 test('the instruction catalogue is opt-in', () => {
@@ -41,8 +50,15 @@ test('the same selection exports byte-identically', () => {
 
 test('isa_string holds everything march does', () => {
   const { yaml } = buildIsaConfigYaml(RVA23, ALL);
-  const isa = yaml.match(/^isa_string: (\S+)/m)[1].toLowerCase().split('_').slice(1);
-  const march = yaml.match(/^march: (\S+)/m)[1].split('_').slice(1);
+  const isa = yaml
+    .match(/^isa_string: (\S+)/m)[1]
+    .toLowerCase()
+    .split('_')
+    .slice(1);
+  const march = yaml
+    .match(/^march: (\S+)/m)[1]
+    .split('_')
+    .slice(1);
   const missing = march.filter((t) => !isa.includes(t));
   assert.deepEqual(missing, [], 'isa_string must not omit extensions march carries');
 });
@@ -64,7 +80,13 @@ test('inferred fields are labelled as inferred', () => {
 test('the riscv-config format carries its required fields', () => {
   // Its schema requires exactly these five per hart, plus Vendor and Device.
   const { yaml } = buildIsaConfigYaml(RVA23, ALL, { format: 'riscv-config' });
-  for (const field of ['ISA:', 'User_Spec_Version:', 'Privilege_Spec_Version:', 'supported_xlen:', 'physical_addr_sz:']) {
+  for (const field of [
+    'ISA:',
+    'User_Spec_Version:',
+    'Privilege_Spec_Version:',
+    'supported_xlen:',
+    'physical_addr_sz:',
+  ]) {
     assert.ok(yaml.includes(field), `riscv-config requires ${field}`);
   }
   assert.ok(yaml.includes('Vendor:') && yaml.includes('Device:'));
@@ -72,7 +94,9 @@ test('the riscv-config format carries its required fields', () => {
 });
 
 test('the riscv-config ISA string follows their spelling, not ours', () => {
-  const { yaml } = buildIsaConfigYaml(resolve(['RV64I', 'M', 'A', 'F', 'D', 'C']), ALL, { format: 'riscv-config' });
+  const { yaml } = buildIsaConfigYaml(resolve(['RV64I', 'M', 'A', 'F', 'D', 'C']), ALL, {
+    format: 'riscv-config',
+  });
   const isa = yaml.match(/^ {2}ISA: (\S+)/m)[1];
   // First sub-extension attaches directly; theirs is not an underscore-led list.
   assert.match(isa, /^RV64I[A-Z]*Z[a-z]/, `first sub-extension must attach directly: ${isa}`);
@@ -109,7 +133,7 @@ test('the UDB format separates what it knows from what it cannot', () => {
   assert.match(yaml, /THIS FILE IS NOT COMPLETE/, 'the file must not read as ready to run');
   assert.ok(
     warnings.some((w) => /must be filled from your design document/.test(w)),
-    'the caller should be warned, not only the file'
+    'the caller should be warned, not only the file',
   );
 });
 
@@ -126,7 +150,9 @@ test('the UDB format flags unratified pins rather than hiding them', () => {
   // moving target. Both are legitimate, but only one is safe to forget about.
   const draft = ALL.find((e) => e.version && e.state && e.state !== 'ratified');
   if (!draft) return;
-  const { yaml, warnings } = buildIsaConfigYaml(resolve(['RV64I', draft.id]), ALL, { format: 'udb' });
+  const { yaml, warnings } = buildIsaConfigYaml(resolve(['RV64I', draft.id]), ALL, {
+    format: 'udb',
+  });
   if (!yaml.includes(`name: ${draft.id},`)) return;
   assert.match(yaml, new RegExp(`name: ${draft.id},.*version may still change`));
   assert.ok(warnings.some((w) => /not ratified/.test(w)));
@@ -175,4 +201,101 @@ test('every S-mode privileged family reaches privilege_extensions', () => {
       `${ext} must appear under privilege_extensions; that block holds [${priv.join(', ')}]`,
     );
   }
+});
+
+/** The Z-extension tokens in a riscv-config ISA string, as exact names.
+ *
+ * Substring checks cannot do this job: `isa.includes('Zkn')` is satisfied by a
+ * stray `Zknd`, so it passes in exactly the case the assertion exists to catch.
+ */
+const isaZTokens = (yaml) => yaml.match(/^ {2}ISA: (\S+)/m)[1].match(/Z[a-z][a-z0-9]*/g) || [];
+
+test('every shorthand bundle absorbs its member subsets in the riscv-config format', () => {
+  // riscv-config: "In presence of Zkn the subsets must be ignored in the ISA string".
+  // clang tolerates the redundant form, but riscv-config rejects it outright.
+  // Same absorption rule as V folding its Zve* and Zvl* vector members.
+  for (const [shorthand, members] of Object.entries(SHORTHAND_BUNDLES)) {
+    const { yaml } = buildIsaConfigYaml(resolve(['RV64I', shorthand]), ALL, {
+      format: 'riscv-config',
+    });
+    const tokens = isaZTokens(yaml);
+    assert.ok(tokens.includes(shorthand), `${shorthand} should survive: ${tokens.join('_')}`);
+    for (const member of members) {
+      assert.ok(
+        !tokens.includes(member),
+        `${shorthand} should absorb ${member}: ${tokens.join('_')}`,
+      );
+    }
+    assert.match(
+      yaml,
+      new RegExp(`folded into ${shorthand}`),
+      `${shorthand} absorption should be stated`,
+    );
+  }
+});
+
+test('an overlapping shorthand yields to the wider one, but a sibling suite survives', () => {
+  // Zk lists Zkn among its members, so selecting both must leave Zk alone. Which
+  // one wins depends on Object.entries order over SHORTHAND_BUNDLES, so this
+  // regresses silently if that object is ever reordered.
+  const nested = isaZTokens(
+    buildIsaConfigYaml(resolve(['RV64I', 'Zk', 'Zkn']), ALL, { format: 'riscv-config' }).yaml,
+  );
+  assert.ok(nested.includes('Zk'), `Zk should survive: ${nested.join('_')}`);
+  assert.ok(!nested.includes('Zkn'), `Zk should absorb Zkn: ${nested.join('_')}`);
+
+  // Zks is the ShangMi suite and is NOT a member of Zk, so over-absorbing it
+  // would silently drop crypto from the string rather than merely shorten it.
+  const sibling = isaZTokens(
+    buildIsaConfigYaml(resolve(['RV64I', 'Zk', 'Zks']), ALL, { format: 'riscv-config' }).yaml,
+  );
+  assert.ok(sibling.includes('Zk'), `Zk should survive: ${sibling.join('_')}`);
+  assert.ok(
+    sibling.includes('Zks'),
+    `Zks is not a Zk member and must survive: ${sibling.join('_')}`,
+  );
+});
+
+test('mutually exclusive base letters (I and E) are not emitted as extensions in export', () => {
+  const { yaml, warnings } = buildIsaConfigYaml(['RV32E', 'I', 'M'], ALL, { format: 'landscape' });
+  const isa = yaml.match(/^isa_string: (\S+)/m)[1];
+  assert.ok(!/rv32ei/i.test(isa), `mutually exclusive base letters must not be combined: ${isa}`);
+  assert.match(isa, /^RV32EM/);
+  assert.ok(warnings.some((w) => /mutually exclusive/i.test(w)));
+});
+
+test('the compiler compatibility comment is emitted from marchUtils, not a local copy', () => {
+  // The same prose lived in three hand-maintained places and drifted: the
+  // export header claimed the vector-crypto family included Zvkg, the comment
+  // written into every export omitted it, and marchUtils listed a fuller set.
+  // Reading it from one export is what stops that recurring, so assert the
+  // emitted block really is that export rather than a copy that matches today.
+  const { yaml } = buildIsaConfigYaml(resolve(['RV64I', 'M', 'C']), ALL, { format: 'landscape' });
+  assert.ok(COMPILER_COMPAT_NOTES.length > 0, 'the notes should not be empty');
+  for (const note of COMPILER_COMPAT_NOTES) {
+    assert.ok(
+      yaml.includes(`#   ${note}`),
+      `export must carry the note verbatim from marchUtils: ${note}`,
+    );
+  }
+
+  // Carrying the text is not the same as reading it from one place: a local
+  // copy that happens to match today would satisfy the loop above and then
+  // drift, which is the exact failure this change exists to end. So also
+  // assert exportUtils.js keeps no copy of its own.
+  const exportSrc = fs.readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'src', 'exportUtils.js'),
+    'utf8',
+  );
+  for (const note of COMPILER_COMPAT_NOTES) {
+    assert.ok(!exportSrc.includes(note), `exportUtils.js must not hold its own copy of: ${note}`);
+  }
+});
+
+test('the vector crypto note names its family by prefix, not by enumeration', () => {
+  // Naming four of the 21 Zvk* entries in riscv_extensions.json is what went
+  // stale. A prefix cannot.
+  const note = COMPILER_COMPAT_NOTES.find((n) => /vector crypto/i.test(n));
+  assert.ok(note, 'a vector crypto note should exist');
+  assert.match(note, /Zvk\*/, 'name the family by prefix so it cannot drift as members are added');
 });


### PR DESCRIPTION
Closes #311.

### Summary of Changes

- In `src/exportUtils.js`, `rcSingles` sorts single-letter extensions for the `riscv-config` export format according to `RC_LETTER_ORDER` (`'IEMAFDQLCBJKTPVNSHU'`).
- Previously, the sort comparator used `RC_LETTER_ORDER.indexOf(a) - RC_LETTER_ORDER.indexOf(b)`. Because `Array.prototype.indexOf` returns `-1` for any letter outside `RC_LETTER_ORDER`, unrecognised single-letter extensions evaluated to `-1` and sorted to the front ahead of standard extensions (e.g., sorting `M, C, X` produced `XMC` instead of `MCX`).
- Clamps unrecognised single letters to rank `99` using `singleRank`, matching the pattern already used by `riscvConfigSort` for multi-letter sub-extensions, so standard letters lead in canonical order and unrecognised ones sort to the end alphabetically.
- Added a regression test in `tests/export.test.mjs` verifying that standard extensions lead before unrecognised single letters in the `riscv-config` export format.